### PR TITLE
feat(rsbuild-plugin): add performance to the engine options

### DIFF
--- a/.changeset/lynx-engine-performance.md
+++ b/.changeset/lynx-engine-performance.md
@@ -1,0 +1,6 @@
+---
+"@lynx-js/rsbuild-plugin": minor
+"@lynx-js/rspeedy": minor
+---
+
+Add `performance` to the `pluginLynx` options, alongside `output`, and expose it on the config `pluginLynx` provides. Rspeedy maps its `performance.profile` onto it, so a plugin can read the option from the build engine instead of requiring Rspeedy to be the caller.

--- a/.changeset/lynx-engine-performance.md
+++ b/.changeset/lynx-engine-performance.md
@@ -1,6 +1,7 @@
 ---
 "@lynx-js/rsbuild-plugin": minor
 "@lynx-js/rspeedy": minor
+"@lynx-js/react-rsbuild-plugin": patch
 ---
 
-Add `performance` to the `pluginLynx` options, alongside `output`, and expose it on the config `pluginLynx` provides. Rspeedy maps its `performance.profile` onto it, so a plugin can read the option from the build engine instead of requiring Rspeedy to be the caller.
+Add `performance` to the `pluginLynx` options, alongside `output`, and expose it on the config `pluginLynx` provides. Rspeedy maps its `performance.profile` onto it, so a plugin can read the option from the build engine instead of requiring Rspeedy to be the caller. `pluginReactLynx` reads it from there instead of requiring Rspeedy.

--- a/packages/rspeedy/core/src/plugins/index.ts
+++ b/packages/rspeedy/core/src/plugins/index.ts
@@ -15,9 +15,14 @@ function toLynxPluginOptions(config: Config): LynxPluginOptions {
     ? filename
     : filename?.bundle ?? filename?.template
 
+  const { profile } = config.performance ?? {}
+
   return {
     output: {
       ...bundle === undefined ? {} : { filename: { bundle } },
+    },
+    performance: {
+      ...profile === undefined ? {} : { profile },
     },
   }
 }

--- a/packages/rspeedy/core/test/createRspeedy.test.ts
+++ b/packages/rspeedy/core/test/createRspeedy.test.ts
@@ -78,4 +78,30 @@ describe('createRspeedy', () => {
 
     expect.assertions(1)
   })
+
+  test('maps performance.profile onto the engine config', async () => {
+    const rspeedy = await createRspeedy({
+      rspeedyConfig: {
+        performance: { profile: true },
+        plugins: [
+          {
+            name: 'test',
+            setup(api: RsbuildPluginAPI) {
+              api.modifyBundlerChain(() => {
+                expect(
+                  api.useExposed<LynxConfig>(
+                    Symbol.for('@lynx-js/rsbuild-plugin:config'),
+                  )?.performance.profile,
+                ).toBe(true)
+              })
+            },
+          },
+        ],
+      },
+    })
+
+    await rspeedy.initConfigs()
+
+    expect.assertions(1)
+  })
 })

--- a/packages/rspeedy/plugin-lynx/etc/rsbuild-plugin.api.md
+++ b/packages/rspeedy/plugin-lynx/etc/rsbuild-plugin.api.md
@@ -20,6 +20,7 @@ export interface BundleFilenameContext {
 // @beta
 export interface LynxConfig {
     readonly output: LynxOutput;
+    readonly performance: LynxPerformance;
     resolveBundleFilename(context: {
         entryName: string;
         platform: string;
@@ -50,8 +51,14 @@ export interface LynxOutput {
 }
 
 // @public
+export interface LynxPerformance {
+    profile?: boolean | undefined;
+}
+
+// @public
 export interface LynxPluginOptions {
     output?: LynxOutput | undefined;
+    performance?: LynxPerformance | undefined;
 }
 
 // @public

--- a/packages/rspeedy/plugin-lynx/src/config.ts
+++ b/packages/rspeedy/plugin-lynx/src/config.ts
@@ -104,6 +104,24 @@ export interface LynxOutput {
 }
 
 /**
+ * The performance options of the Lynx build engine.
+ *
+ * @public
+ */
+export interface LynxPerformance {
+  /**
+   * Whether to capture timing information in Lynx runtime integrations such as
+   * ReactLynx.
+   *
+   * @remarks
+   *
+   * A framework includes runtime information using `console.profile` when this
+   * is enabled.
+   */
+  profile?: boolean | undefined
+}
+
+/**
  * The options of `pluginLynx`.
  *
  * @public
@@ -113,6 +131,11 @@ export interface LynxPluginOptions {
    * The build outputs.
    */
   output?: LynxOutput | undefined
+
+  /**
+   * The performance options.
+   */
+  performance?: LynxPerformance | undefined
 }
 
 /**
@@ -143,6 +166,11 @@ export interface LynxConfig {
    * The build outputs.
    */
   readonly output: LynxOutput
+
+  /**
+   * The performance options.
+   */
+  readonly performance: LynxPerformance
 
   /**
    * Resolve the name of the bundle file of an entry.
@@ -249,6 +277,8 @@ export function createLynxConfig(options: LynxPluginOptions): LynxConfig {
   // destructure them off the config.
   return {
     output,
+
+    performance: options.performance ?? {},
 
     resolveBundleFilename({ entryName, platform }) {
       return resolve(output.filename?.bundle, {

--- a/packages/rspeedy/plugin-lynx/src/index.ts
+++ b/packages/rspeedy/plugin-lynx/src/index.ts
@@ -35,6 +35,7 @@ export type {
   LynxFilename,
   LynxMinify,
   LynxOutput,
+  LynxPerformance,
   LynxPluginOptions,
 } from './config.js'
 

--- a/packages/rspeedy/plugin-lynx/test/config.plugin.test.ts
+++ b/packages/rspeedy/plugin-lynx/test/config.plugin.test.ts
@@ -137,6 +137,19 @@ describe('pluginConfig', () => {
     })).toBe('lazy/[name].lynx.bundle')
   })
 
+  test('performance defaults to empty', async () => {
+    const lynx = await usingLynxConfig()
+
+    expect(lynx.performance).toEqual({})
+    expect(lynx.performance.profile).toBeUndefined()
+  })
+
+  test('exposes performance.profile', async () => {
+    const lynx = await usingLynxConfig({ performance: { profile: true } })
+
+    expect(lynx.performance.profile).toBe(true)
+  })
+
   test('resolveIntermediateDir defaults to .lynx', async () => {
     const lynx = await usingLynxConfig()
 

--- a/packages/rspeedy/plugin-react/src/entry.ts
+++ b/packages/rspeedy/plugin-react/src/entry.ts
@@ -79,6 +79,9 @@ export function applyEntry(
       ? api.useExposed<ExposedAPI>(Symbol.for('rspeedy.api'))?.config
       : undefined
 
+    // biome-ignore lint/correctness/useHookAtTopLevel: This is not a React hook.
+    const lynxConfig = api.useExposed<LynxConfig>(S_LYNX_CONFIG)
+
     // `rslib` builds libraries and `rstest` runs tests, neither of which emits
     // a Lynx template.
     const emitTemplate = api.context.callerName !== 'rslib'
@@ -86,9 +89,6 @@ export function applyEntry(
     if (emitTemplate) {
       // `pluginAutoLynx` applies the engine for the same callers, so the config
       // is there whenever a template is emitted.
-      // biome-ignore lint/correctness/useHookAtTopLevel: This is not a React hook.
-      const lynxConfig = api.useExposed<LynxConfig>(S_LYNX_CONFIG)
-
       if (!lynxConfig) {
         throw new Error(
           'No Lynx config exposed. `pluginLynx` has to be applied for the Lynx build engine to be configured.',
@@ -328,7 +328,7 @@ export function applyEntry(
         return environmentProfile
       }
 
-      const userProfile = rspeedyConfig?.performance?.profile
+      const userProfile = lynxConfig?.performance.profile
       if (userProfile !== undefined) {
         return userProfile
       }


### PR DESCRIPTION
`pluginLynx` only took `output`, so `performance.profile` was reachable only through `Symbol.for('rspeedy.api')` and a plugin that reads it had to require Rspeedy to be the caller.

Accept `performance` alongside `output`, expose it on the config the engine provides, and map Rspeedy's option onto it so both callers resolve the same value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added performance configuration support for Lynx builds.
  * Added an optional profiling toggle that can be enabled through the build configuration.
  * Exposed performance settings through the Lynx plugin configuration for broader build-tool integration.
  * Ensured profiling settings are consistently recognized across Lynx and React build integrations.

* **Tests**
  * Added coverage for default performance settings and enabled profiling configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->