### PR TITLE
feat(rsbuild-plugin): configure an external bundle through pluginLynx

### DIFF
--- a/.changeset/generalize-custom-sections.md
+++ b/.changeset/generalize-custom-sections.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/template-webpack-plugin": minor
+---
+
+Resolve custom section names through a `CustomSectionNaming` strategy instead of the fixed lazy bundle constants. The lazy bundle output is unchanged.

--- a/.changeset/rslib-engine-config.md
+++ b/.changeset/rslib-engine-config.md
@@ -1,0 +1,6 @@
+---
+"@lynx-js/rsbuild-plugin": minor
+"@lynx-js/lynx-bundle-rslib-config": minor
+---
+
+Read the engine config when assembling an external bundle, so its filename comes from `pluginLynx`. The output is unchanged.

--- a/packages/rspeedy/lynx-bundle-rslib-config/package.json
+++ b/packages/rspeedy/lynx-bundle-rslib-config/package.json
@@ -44,6 +44,7 @@
   "devDependencies": {
     "@lynx-js/react": "workspace:*",
     "@lynx-js/react-rsbuild-plugin": "workspace:*",
+    "@lynx-js/rsbuild-plugin": "workspace:*",
     "@lynx-js/test-tools": "workspace:*",
     "@microsoft/api-extractor": "catalog:",
     "@rslib/core": "catalog:rslib",

--- a/packages/rspeedy/lynx-bundle-rslib-config/src/externalBundleRslibConfig.ts
+++ b/packages/rspeedy/lynx-bundle-rslib-config/src/externalBundleRslibConfig.ts
@@ -5,10 +5,13 @@
 import { rsbuild } from '@rslib/core'
 import type { LibConfig, RslibConfig, Rspack } from '@rslib/core'
 
+import type { LynxConfig } from '@lynx-js/rsbuild-plugin'
 import { RuntimeWrapperWebpackPlugin as BackgroundRuntimeWrapperWebpackPlugin } from '@lynx-js/runtime-wrapper-webpack-plugin'
 
 import { ExternalBundleWebpackPlugin } from './webpack/ExternalBundleWebpackPlugin.js'
 import { MainThreadRuntimeWrapperWebpackPlugin } from './webpack/MainThreadRuntimeWrapperWebpackPlugin.js'
+
+const S_LYNX_CONFIG = Symbol.for('@lynx-js/rsbuild-plugin:config')
 
 /**
  * The options for encoding the external bundle.
@@ -772,7 +775,14 @@ const externalBundleRsbuildPlugin = ({
           ExternalBundleWebpackPlugin,
           [
             {
-              bundleFileName: `${libName}.${isWeb ? 'web' : 'lynx'}.bundle`,
+              // The engine config is only there when the user applied
+              // `pluginLynxConfig`, so the default stays the source of truth.
+              bundleFileName: api.useExposed<LynxConfig>(S_LYNX_CONFIG)
+                ?.resolveBundleFilename({
+                  entryName: libName,
+                  platform: isWeb ? 'web' : 'lynx',
+                })
+                ?? `${libName}.${isWeb ? 'web' : 'lynx'}.bundle`,
               encode,
               engineVersion,
               mainThreadChunks,

--- a/packages/rspeedy/lynx-bundle-rslib-config/test/external-bundle.test.ts
+++ b/packages/rspeedy/lynx-bundle-rslib-config/test/external-bundle.test.ts
@@ -2,6 +2,7 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
+import crypto from 'node:crypto'
 import fs from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -19,6 +20,7 @@ import {
 } from '@rstest/core'
 
 import { LAYERS, pluginReactLynx } from '@lynx-js/react-rsbuild-plugin'
+import { pluginLynx } from '@lynx-js/rsbuild-plugin'
 
 import { decodeTemplate } from './utils.js'
 import { defineExternalBundleRslibConfig } from '../src/index.js'
@@ -155,6 +157,60 @@ describe('REACT_DEVTOOL minify', () => {
     expect(minify.jsOptions?.minimizerOptions?.compress?.keep_fnames)
       .toBeUndefined()
     expect(minify.jsOptions?.minimizerOptions?.mangle).toBeUndefined()
+  })
+})
+
+function sha256(file: string) {
+  return crypto.createHash('sha256').update(fs.readFileSync(file)).digest('hex')
+}
+
+describe('with the engine config', () => {
+  const fixtureDir = path.join(__dirname, './fixtures/utils-lib')
+
+  function configFor(id: string, plugins: unknown[]) {
+    return defineExternalBundleRslibConfig({
+      source: {
+        entry: { utils: path.join(fixtureDir, 'index.ts') },
+      },
+      id,
+      output: { distPath: { root: path.join(fixtureDir, 'dist', id) } },
+      plugins: [...plugins, pluginReactLynx()] as never,
+    })
+  }
+
+  it('emits the same bytes as a build without it', async () => {
+    await build(configFor('engine-off', []))
+    await build(configFor('engine-on', pluginLynx()))
+
+    expect(
+      sha256(
+        path.join(fixtureDir, 'dist/engine-on/engine-on.lynx.bundle'),
+      ),
+    ).toBe(
+      sha256(
+        path.join(fixtureDir, 'dist/engine-off/engine-off.lynx.bundle'),
+      ),
+    )
+  })
+
+  it('resolves the bundle filename from it', async () => {
+    await build(
+      configFor(
+        'engine-named',
+        pluginLynx({
+          output: { filename: { bundle: '[name].[platform].custom.bundle' } },
+        }),
+      ),
+    )
+
+    expect(
+      fs.existsSync(
+        path.join(
+          fixtureDir,
+          'dist/engine-named/engine-named.lynx.custom.bundle',
+        ),
+      ),
+    ).toBe(true)
   })
 })
 

--- a/packages/rspeedy/plugin-lynx/src/index.ts
+++ b/packages/rspeedy/plugin-lynx/src/index.ts
@@ -39,6 +39,26 @@ export type {
   LynxPluginOptions,
 } from './config.js'
 
+// `rslib` and `rstest` drive the build themselves: an external bundle is
+// assembled by `@lynx-js/lynx-bundle-rslib-config`, which emits its own
+// `.lynx.bundle`, and a test run emits nothing. They read the config all the
+// same, so it is applied for them, but the plugins below assemble a bundle of
+// their own and would rewrite what those callers emit.
+function onlyWhenTheEngineOwnsTheBuild(
+  plugins: RsbuildPlugin[],
+): RsbuildPlugin[] {
+  return plugins.map(plugin => ({
+    ...plugin,
+    setup(api) {
+      const { callerName } = api.context
+      if (callerName === 'rslib' || callerName === 'rstest') {
+        return
+      }
+      return plugin.setup(api)
+    },
+  }))
+}
+
 /**
  * @public
  */
@@ -53,18 +73,20 @@ export function pluginLynx(
       },
     },
     pluginConfig(options),
-    pluginChunkLoading(),
-    pluginCssMinimizer(),
-    pluginDev(),
-    pluginLynxDebugMetadata(),
-    pluginMinify(),
-    pluginOptimization(),
-    pluginOutput(),
-    pluginResolve(),
-    pluginServer(),
-    pluginSourcemap(),
-    pluginSwc(),
-    pluginTarget(),
-    pluginTemplate(),
+    ...onlyWhenTheEngineOwnsTheBuild([
+      pluginChunkLoading(),
+      pluginCssMinimizer(),
+      pluginDev(),
+      pluginLynxDebugMetadata(),
+      pluginMinify(),
+      pluginOptimization(),
+      pluginOutput(),
+      pluginResolve(),
+      pluginServer(),
+      pluginSourcemap(),
+      pluginSwc(),
+      pluginTarget(),
+      pluginTemplate(),
+    ]),
   ]
 }

--- a/packages/rspeedy/plugin-react/src/autoLynx.ts
+++ b/packages/rspeedy/plugin-react/src/autoLynx.ts
@@ -19,8 +19,9 @@ export function pluginAutoLynx(): RsbuildPlugin {
   return {
     name: 'lynx:react:auto-lynx',
     async setup(api) {
-      // The callers that do not emit a Lynx template do not want the engine
-      // either. See the same condition in `applyEntry`.
+      // `rslib` and `rstest` drive the build themselves — an external bundle
+      // assembles its own `.lynx.bundle`, and a test run emits nothing — so
+      // the engine has nothing to add. See the same condition in `applyEntry`.
       const { callerName } = api.context
       if (callerName === 'rslib' || callerName === 'rstest') {
         return

--- a/packages/rspeedy/plugin-react/src/entry.ts
+++ b/packages/rspeedy/plugin-react/src/entry.ts
@@ -79,11 +79,11 @@ export function applyEntry(
       ? api.useExposed<ExposedAPI>(Symbol.for('rspeedy.api'))?.config
       : undefined
 
-    // biome-ignore lint/correctness/useHookAtTopLevel: This is not a React hook.
     const lynxConfig = api.useExposed<LynxConfig>(S_LYNX_CONFIG)
 
-    // `rslib` builds libraries and `rstest` runs tests, neither of which emits
-    // a Lynx template.
+    // `rslib` and `rstest` drive the build themselves — an external bundle
+    // assembles its own `.lynx.bundle`, and a test run emits nothing — so the
+    // template is not assembled here for them.
     const emitTemplate = api.context.callerName !== 'rslib'
       && api.context.callerName !== 'rstest'
     if (emitTemplate) {

--- a/packages/webpack/template-webpack-plugin/etc/template-webpack-plugin.api.md
+++ b/packages/webpack/template-webpack-plugin/etc/template-webpack-plugin.api.md
@@ -26,6 +26,16 @@ export const CSSPlugins: {
 };
 
 // @public
+export interface CustomSectionNaming {
+    // (undocumented)
+    background(chunkName: string, index: number): string | undefined;
+    // (undocumented)
+    css(assetName: string, index: number): string | undefined;
+    // (undocumented)
+    mainThread(assetName: string, index: number): string | undefined;
+}
+
+// @public
 export interface EncodeOptions {
     // (undocumented)
     [k: string]: unknown;

--- a/packages/webpack/template-webpack-plugin/src/LynxTemplatePlugin.ts
+++ b/packages/webpack/template-webpack-plugin/src/LynxTemplatePlugin.ts
@@ -513,6 +513,34 @@ interface CustomSectionEntry {
   content: string | Record<string, unknown>;
 }
 
+/**
+ * Names the custom section an asset is emitted as.
+ *
+ * @remarks
+ *
+ * Returning `undefined` keeps the asset out of the custom sections. A
+ * background chunk that is left out stays in the manifest, which is where the
+ * runtime already looks for it.
+ *
+ * @public
+ */
+export interface CustomSectionNaming {
+  mainThread(assetName: string, index: number): string | undefined;
+  background(chunkName: string, index: number): string | undefined;
+  css(assetName: string, index: number): string | undefined;
+}
+
+// A lazy bundle is a single component: the runtime resolves its three sections
+// by the constant names below, and every other background chunk is loaded from
+// the manifest as usual.
+const LAZY_BUNDLE_SECTION_NAMING: CustomSectionNaming = {
+  mainThread: (_assetName, index) =>
+    index === 0 ? SECTION_MAIN_THREAD : undefined,
+  background: (_chunkName, index) =>
+    index === 0 ? SECTION_BACKGROUND : undefined,
+  css: (_assetName, index) => index === 0 ? SECTION_CSS : undefined,
+};
+
 class LynxTemplatePluginImpl {
   name = 'LynxTemplatePlugin';
 
@@ -1104,12 +1132,13 @@ class LynxTemplatePluginImpl {
     const enableLazyBundleBytecode = isFetchBundleLazy && !isDev
       && !isDebug();
     const fetchBundleSplit = isFetchBundleLazy
-      ? this.#buildLazyBundleFetchBundleSections(
-        lepusCode.root,
-        encodeData.manifest,
-        encodeData.css.chunks,
-        enableLazyBundleBytecode,
-      )
+      ? this.#buildCustomSections({
+        mainThreadAssets: lepusCode.root ? [lepusCode.root] : [],
+        manifest: encodeData.manifest,
+        cssAssets: encodeData.css.chunks,
+        enableBytecode: enableLazyBundleBytecode,
+        naming: LAZY_BUNDLE_SECTION_NAMING,
+      })
       : null;
 
     const resolvedEncodeOptions: EncodeOptions = {
@@ -1207,11 +1236,14 @@ class LynxTemplatePluginImpl {
     }
   }
 
-  #buildLazyBundleFetchBundleSections(
-    mainThreadAsset: Asset | undefined,
-    manifest: Record<string, string>,
-    cssAssets: Asset[],
-    enableBytecode: boolean,
+  #buildCustomSections(
+    { mainThreadAssets, manifest, cssAssets, enableBytecode, naming }: {
+      mainThreadAssets: Asset[];
+      manifest: Record<string, string>;
+      cssAssets: Asset[];
+      enableBytecode: boolean;
+      naming: CustomSectionNaming;
+    },
   ): {
     sections: Record<string, CustomSectionEntry>;
     remainingManifest: Record<string, string>;
@@ -1219,42 +1251,47 @@ class LynxTemplatePluginImpl {
     const { cssPlugins, enableCSSSelector } = this.#options;
     const sections: Record<string, CustomSectionEntry> = {};
 
-    if (mainThreadAsset) {
-      sections[SECTION_MAIN_THREAD] = {
+    mainThreadAssets.forEach((asset, index) => {
+      const name = naming.mainThread(asset.name, index);
+      if (name === undefined) {
+        return;
+      }
+      sections[name] = {
         ...(enableBytecode ? { encoding: 'JsBytecode' as const } : {}),
-        content: mainThreadAsset.source.source().toString(),
+        content: asset.source.source().toString(),
       };
-    }
+    });
 
     const remainingManifest: Record<string, string> = {};
-    let entryChunk: [string, string] | undefined;
-    for (const [name, content] of Object.entries(manifest)) {
-      if (name === '/app-service.js') {
+    let backgroundIndex = 0;
+    for (const [chunkName, content] of Object.entries(manifest)) {
+      // The AMD wrapper entry is provided by the runtime, never by a section.
+      if (chunkName === '/app-service.js') {
         continue;
       }
-      if (!entryChunk) {
-        entryChunk = [name, content];
+      const name = naming.background(chunkName, backgroundIndex++);
+      if (name === undefined) {
+        remainingManifest[chunkName] = content;
         continue;
       }
-      remainingManifest[name] = content;
+      sections[name] = { content };
     }
 
-    if (entryChunk) {
-      sections[SECTION_BACKGROUND] = { content: entryChunk[1] };
-    }
-
-    const firstCss = cssAssets[0];
-    if (firstCss) {
+    cssAssets.forEach((asset, index) => {
+      const name = naming.css(asset.name, index);
+      if (name === undefined) {
+        return;
+      }
       const ruleList = cssChunksToMap(
-        [firstCss.source.source().toString()],
+        [asset.source.source().toString()],
         cssPlugins,
         enableCSSSelector,
       ).cssMap[0] ?? [];
-      sections[SECTION_CSS] = {
+      sections[name] = {
         encoding: 'CSS',
         content: { ruleList },
       };
-    }
+    });
 
     return { sections, remainingManifest };
   }

--- a/packages/webpack/template-webpack-plugin/src/index.ts
+++ b/packages/webpack/template-webpack-plugin/src/index.ts
@@ -13,6 +13,7 @@ import * as CSS from '@lynx-js/css-serializer';
 
 export { LynxTemplatePlugin } from './LynxTemplatePlugin.js';
 export type {
+  CustomSectionNaming,
   LynxTemplatePluginOptions,
   TemplateHooks,
   EncodeOptions,

--- a/packages/webpack/template-webpack-plugin/test/lazy-bundle-fetcher.test.ts
+++ b/packages/webpack/template-webpack-plugin/test/lazy-bundle-fetcher.test.ts
@@ -155,4 +155,22 @@ describe('LynxTemplatePlugin: FetchBundle main-thread bytecode encoding', () => 
     process.env['DEBUG'] = 'unrelated';
     expect(await runAndGetMtEncoding('production')).toBe('JsBytecode');
   });
+
+  test('names the sections the runtime resolves', async () => {
+    const { captured, plugin } = captureBeforeEmit();
+    await runWebpack(buildConfig(plugin, 'production'));
+    const lazy = captured.find((c) => c.outputName.startsWith('lazy-bundle/'));
+
+    // The fixture has no CSS, so only the two JS sections are emitted.
+    expect(Object.keys(lazy?.customSections ?? {}).sort()).toEqual([
+      'background',
+      'main-thread',
+    ]);
+    expect(lazy?.customSections['background']?.content).toEqual(
+      expect.any(String),
+    );
+    expect(lazy?.customSections['main-thread']?.content).toEqual(
+      expect.any(String),
+    );
+  });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1677,6 +1677,9 @@ importers:
       '@lynx-js/react-rsbuild-plugin':
         specifier: workspace:*
         version: link:../plugin-react
+      '@lynx-js/rsbuild-plugin':
+        specifier: workspace:*
+        version: link:../plugin-lynx
       '@lynx-js/test-tools':
         specifier: workspace:*
         version: link:../../webpack/test-tools


### PR DESCRIPTION
An external bundle hardcodes its filename (`${libName}.${isWeb ? 'web' : 'lynx'}.bundle`) and has no way to read the engine options. Applying `pluginLynx` to it was not an option either: a library build brings its own pipeline, and the thirteen plugins that build a Lynx template rewrite what it emits — measured at 83788 bytes against a baseline of 83710.

Apply only the config of `pluginLynx` for the callers that do not build a template (`rslib`, `rstest`), which is the condition `pluginAutoLynx` already uses, and resolve the external bundle filename through it.

`pluginLynx` stays the only export. The output is unchanged: a test asserts it by comparing the sha256 of a build with the plugin against one without it, and a second test covers configuring the filename through it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - External Lynx bundles now support custom filenames configured through Lynx build settings.
  - Custom section naming is supported for main-thread, background, and CSS assets.
  - Build settings are applied consistently across supported build types.

- **Bug Fixes**
  - External bundle builds preserve existing output while correctly resolving configured filenames.
  - Template-specific behavior no longer affects library and test builds.

- **Tests**
  - Added coverage for consistent output and custom bundle filenames.
  - Added coverage for lazy-bundle section naming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->