### PR TITLE
feat(rsbuild-plugin): drive the template hooks for an external bundle

### DIFF
--- a/.changeset/rslib-template-hooks.md
+++ b/.changeset/rslib-template-hooks.md
@@ -1,0 +1,7 @@
+---
+"@lynx-js/rsbuild-plugin": minor
+"@lynx-js/lynx-bundle-rslib-config": minor
+"@lynx-js/debug-metadata-rsbuild-plugin": patch
+---
+
+Drive the template lifecycle hooks for an external bundle, so `pluginLynxDebugMetadata` covers it: it now ships source maps and a release key.

--- a/examples/react-externals/package.json
+++ b/examples/react-externals/package.json
@@ -21,6 +21,7 @@
     "@lynx-js/preact-devtools": "5.0.1-20260721114100-d7da994",
     "@lynx-js/qrcode-rsbuild-plugin": "workspace:*",
     "@lynx-js/react-rsbuild-plugin": "workspace:*",
+    "@lynx-js/rsbuild-plugin": "workspace:*",
     "@lynx-js/rspeedy": "workspace:*",
     "@lynx-js/types": "4.1.0",
     "@types/react": "^19.2.18",

--- a/examples/react-externals/rslib-comp-lib.config.ts
+++ b/examples/react-externals/rslib-comp-lib.config.ts
@@ -1,5 +1,6 @@
 import { defineExternalBundleRslibConfig } from '@lynx-js/lynx-bundle-rslib-config';
 import { pluginReactLynx } from '@lynx-js/react-rsbuild-plugin';
+import { pluginLynx } from '@lynx-js/rsbuild-plugin';
 
 // REACTLYNX_ASYNC=true builds comp-lib against async (Promise) ReactLynx
 // externals to match an async host; output isolated in
@@ -14,6 +15,9 @@ export default defineExternalBundleRslibConfig({
     },
   },
   plugins: [
+    // Configures the bundle filename and brings the plugins that tap the
+    // template hooks, `pluginLynxDebugMetadata` among them.
+    ...pluginLynx(),
     pluginReactLynx(),
   ],
   // Sync and async share this config file, so rspack's persistent cache (keyed

--- a/packages/rspeedy/lynx-bundle-rslib-config/etc/lynx-bundle-rslib-config.api.md
+++ b/packages/rspeedy/lynx-bundle-rslib-config/etc/lynx-bundle-rslib-config.api.md
@@ -5,6 +5,7 @@
 ```ts
 
 import type { LibConfig } from '@rslib/core';
+import type { LynxTemplatePlugin } from '@lynx-js/template-webpack-plugin';
 import type { RslibConfig } from '@rslib/core';
 import type { Rspack } from '@rslib/core';
 
@@ -49,6 +50,8 @@ export interface ExternalBundleWebpackPluginOptions {
         buffer: Buffer;
     }>;
     engineVersion?: string | undefined;
+    // Warning: (ae-forgotten-export) The symbol "LynxTemplatePluginHooksProvider" needs to be exported by the entry point index.d.ts
+    LynxTemplatePlugin?: LynxTemplatePluginHooksProvider | undefined;
     mainThreadChunks?: string[] | undefined;
 }
 

--- a/packages/rspeedy/lynx-bundle-rslib-config/package.json
+++ b/packages/rspeedy/lynx-bundle-rslib-config/package.json
@@ -45,6 +45,7 @@
     "@lynx-js/react": "workspace:*",
     "@lynx-js/react-rsbuild-plugin": "workspace:*",
     "@lynx-js/rsbuild-plugin": "workspace:*",
+    "@lynx-js/template-webpack-plugin": "workspace:*",
     "@lynx-js/test-tools": "workspace:*",
     "@microsoft/api-extractor": "catalog:",
     "@rslib/core": "catalog:rslib",

--- a/packages/rspeedy/lynx-bundle-rslib-config/src/externalBundleRslibConfig.ts
+++ b/packages/rspeedy/lynx-bundle-rslib-config/src/externalBundleRslibConfig.ts
@@ -9,6 +9,7 @@ import type { LynxConfig } from '@lynx-js/rsbuild-plugin'
 import { RuntimeWrapperWebpackPlugin as BackgroundRuntimeWrapperWebpackPlugin } from '@lynx-js/runtime-wrapper-webpack-plugin'
 
 import { ExternalBundleWebpackPlugin } from './webpack/ExternalBundleWebpackPlugin.js'
+import type { LynxTemplatePluginHooksProvider } from './webpack/ExternalBundleWebpackPlugin.js'
 import { MainThreadRuntimeWrapperWebpackPlugin } from './webpack/MainThreadRuntimeWrapperWebpackPlugin.js'
 
 const S_LYNX_CONFIG = Symbol.for('@lynx-js/rsbuild-plugin:config')
@@ -776,13 +777,18 @@ const externalBundleRsbuildPlugin = ({
           [
             {
               // The engine config is only there when the user applied
-              // `pluginLynxConfig`, so the default stays the source of truth.
+              // `pluginLynx`, so the default stays the source of truth.
               bundleFileName: api.useExposed<LynxConfig>(S_LYNX_CONFIG)
                 ?.resolveBundleFilename({
                   entryName: libName,
                   platform: isWeb ? 'web' : 'lynx',
                 })
                 ?? `${libName}.${isWeb ? 'web' : 'lynx'}.bundle`,
+              // `pluginLynx` exposes the hooks whether or not it drives the
+              // build, so the plugins that tap them run here too.
+              LynxTemplatePlugin: api.useExposed<
+                { LynxTemplatePlugin: LynxTemplatePluginHooksProvider }
+              >(Symbol.for('LynxTemplatePlugin'))?.LynxTemplatePlugin,
               encode,
               engineVersion,
               mainThreadChunks,

--- a/packages/rspeedy/lynx-bundle-rslib-config/src/webpack/ExternalBundleWebpackPlugin.ts
+++ b/packages/rspeedy/lynx-bundle-rslib-config/src/webpack/ExternalBundleWebpackPlugin.ts
@@ -5,6 +5,18 @@ import type { Rspack } from '@rslib/core'
 
 import { cssChunksToMap } from '@lynx-js/css-serializer'
 import type { LynxStyleNode } from '@lynx-js/css-serializer'
+import type { LynxTemplatePlugin } from '@lynx-js/template-webpack-plugin'
+
+/**
+ * Provides the template lifecycle hooks, so the plugins that tap them run for
+ * a bundle assembled outside `LynxTemplatePlugin`.
+ *
+ * @public
+ */
+export interface LynxTemplatePluginHooksProvider {
+  getLynxTemplatePluginHooks:
+    typeof LynxTemplatePlugin.getLynxTemplatePluginHooks
+}
 
 /**
  * The options for {@link ExternalBundleWebpackPlugin}.
@@ -49,6 +61,17 @@ export interface ExternalBundleWebpackPluginOptions {
    * @defaultValue []
    */
   mainThreadChunks?: string[] | undefined
+
+  /**
+   * Drives the template lifecycle hooks, so the plugins that tap them run for
+   * an external bundle too.
+   *
+   * @remarks
+   *
+   * `pluginLynx` exposes this under `Symbol.for('LynxTemplatePlugin')`. Left
+   * out, the bundle is assembled without running any of them.
+   */
+  LynxTemplatePlugin?: LynxTemplatePluginHooksProvider | undefined
 
   /**
    * Whether to tag main thread chunks with the `JsBytecode` encoding so the
@@ -116,16 +139,44 @@ export class ExternalBundleWebpackPlugin {
     // of `DEFAULT_EXTERNAL_BUNDLE_LIB_CONFIG`.
     const enableJsBytecode = this.options.enableJsBytecode
       ?? process.env['NODE_ENV'] !== 'development'
+    const hooks = this.options.LynxTemplatePlugin
+      ?.getLynxTemplatePluginHooks(compilation)
+
     const { buffer, encodeOptions } = await this.#encode(
       assets,
       enableJsBytecode,
+      compilation,
+      hooks,
     )
 
     const { RawSource } = compiler.webpack.sources
+    const outputName = this.options.bundleFileName
+
+    const emitted = hooks
+      ? await hooks.beforeEmit.promise({
+        finalEncodeOptions: encodeOptions as never,
+        debugInfo: '',
+        template: buffer,
+        outputName,
+        mainThreadAssets: assets.filter(asset =>
+          this.options.mainThreadChunks?.includes(asset.name)
+        ) as never,
+        cssChunks: assets.filter(asset =>
+          asset.info.assetType === 'extract-css'
+        ) as never,
+        chunkGroups: [...compilation.chunkGroups] as never,
+      })
+      : undefined
+    const template = emitted ? emitted.template : buffer
+
     compilation.emitAsset(
-      this.options.bundleFileName,
-      new RawSource(buffer, false),
+      outputName,
+      new RawSource(template, false),
     )
+
+    if (hooks) {
+      await hooks.afterEmit.promise({ outputName })
+    }
     if (isDebug()) {
       compilation.emitAsset(
         'tasm.json',
@@ -143,6 +194,12 @@ export class ExternalBundleWebpackPlugin {
   async #encode(
     assets: readonly Rspack.Asset[],
     enableJsBytecode: boolean,
+    compilation: Rspack.Compilation,
+    hooks:
+      | ReturnType<
+        LynxTemplatePluginHooksProvider['getLynxTemplatePluginHooks']
+      >
+      | undefined,
   ) {
     const customSections = assets
       .reduce<
@@ -206,8 +263,47 @@ export class ExternalBundleWebpackPlugin {
       customSections,
     }
 
-    const { buffer } = await this.options.encode(encodeOptions)
+    if (!hooks) {
+      const { buffer } = await this.options.encode(encodeOptions)
+      return { buffer, encodeOptions }
+    }
 
-    return { buffer, encodeOptions }
+    // `beforeEncode` is where `pluginLynxDebugMetadata` collects the source
+    // maps and rewrites the trailers, so it runs before the encoder does.
+    // Every plugin that taps it reads the shape `LynxTemplatePlugin` builds,
+    // so the sections are carried in one of that shape.
+    const { encodeData } = await hooks.beforeEncode.promise({
+      encodeData: {
+        ...encodeOptions,
+        sourceContent: { ...encodeOptions.sourceContent, config: {} },
+        lepusCode: { chunks: [] },
+        manifest: {},
+        css: {},
+      } as never,
+      filenameTemplate: this.options.bundleFileName,
+      chunkGroups: [...compilation.chunkGroups] as never,
+      intermediate: '',
+      intermediateAssets: [],
+    })
+
+    const resolved = encodeData as unknown as typeof encodeOptions & {
+      sourceContent: { config?: Record<string, unknown> }
+    }
+    const { config, ...sourceContent } = resolved.sourceContent
+
+    // An external bundle carries no `lepusCode`, `manifest` or `css`: its
+    // chunks are sections. They were only there for the hooks, so encode
+    // what it actually carries, keeping whatever a tap wrote.
+    const forEncode = {
+      compilerOptions: resolved.compilerOptions,
+      sourceContent: config && Object.keys(config).length > 0
+        ? { ...sourceContent, config }
+        : sourceContent,
+      customSections: resolved.customSections,
+    } as typeof encodeOptions
+
+    const { buffer } = await this.options.encode(forEncode)
+
+    return { buffer, encodeOptions: forEncode }
   }
 }

--- a/packages/rspeedy/lynx-bundle-rslib-config/test/external-bundle.test.ts
+++ b/packages/rspeedy/lynx-bundle-rslib-config/test/external-bundle.test.ts
@@ -179,18 +179,50 @@ describe('with the engine config', () => {
   }
 
   it('emits the same bytes as a build without it', async () => {
-    await build(configFor('engine-off', []))
-    await build(configFor('engine-on', pluginLynx()))
-
-    expect(
-      sha256(
-        path.join(fixtureDir, 'dist/engine-on/engine-on.lynx.bundle'),
-      ),
-    ).toBe(
-      sha256(
-        path.join(fixtureDir, 'dist/engine-off/engine-off.lynx.bundle'),
-      ),
+    // A local production build ships no debug metadata, so the engine adds
+    // nothing to the bundle here. The rstest harness sets `DEBUG=rspeedy` and
+    // CI sets `CI`, either of which would opt the build back into it.
+    const restore = new Map(
+      ['DEBUG', 'CI', 'CI_REPO_NAME', 'BUILD_VERSION'].map(key => {
+        const value = process.env[key]
+        delete process.env[key]
+        return [key, value] as const
+      }),
     )
+    rstest.stubEnv('NODE_ENV', 'production')
+    try {
+      await build(configFor('engine-off', []))
+      await build(configFor('engine-on', pluginLynx()))
+
+      expect(
+        sha256(
+          path.join(fixtureDir, 'dist/engine-on/engine-on.lynx.bundle'),
+        ),
+      ).toBe(
+        sha256(
+          path.join(fixtureDir, 'dist/engine-off/engine-off.lynx.bundle'),
+        ),
+      )
+    } finally {
+      rstest.unstubAllEnvs()
+      for (const [key, value] of restore) {
+        if (value !== undefined) process.env[key] = value
+      }
+    }
+  })
+
+  it('runs the plugins that tap the template hooks', async () => {
+    await build(configFor('engine-debug', pluginLynx()))
+
+    const decoded = await decodeTemplate(
+      path.join(fixtureDir, 'dist/engine-debug/engine-debug.lynx.bundle'),
+    )
+    // `pluginLynxDebugMetadata` reports the release key through
+    // `_SetSourceMapRelease`, and it only runs when the template hooks are
+    // driven. The main-thread section is bytecode, so it is read from the
+    // background one.
+    expect(String(decoded['custom-sections']['utils']))
+      .toContain('[pluginDebugMetadata] SetSourceMapInfo')
   })
 
   it('resolves the bundle filename from it', async () => {

--- a/packages/rspeedy/plugin-debug-metadata/src/LynxDebugMetadataPlugin.ts
+++ b/packages/rspeedy/plugin-debug-metadata/src/LynxDebugMetadataPlugin.ts
@@ -346,7 +346,9 @@ export function rewriteSourceMappingURLs(
   args: Parameters<Parameters<TemplateHooks['beforeEncode']['tap']>[1]>[0],
   options?: RewriteSourceMappingURLsOptions,
 ): void {
-  const debugMetadataUrl = args.encodeData.sourceContent.config[
+  // A bundle assembled outside `LynxTemplatePlugin` carries no `config`, so
+  // the url is unset there in the same way an empty one is.
+  const debugMetadataUrl = args.encodeData.sourceContent.config?.[
     'debugMetadataUrl'
   ]
   if (typeof debugMetadataUrl !== 'string' || debugMetadataUrl === '') return

--- a/packages/rspeedy/plugin-debug-metadata/src/pluginLynxDebugMetadata.ts
+++ b/packages/rspeedy/plugin-debug-metadata/src/pluginLynxDebugMetadata.ts
@@ -171,10 +171,13 @@ export function pluginLynxDebugMetadata(): RsbuildPlugin {
         // the lynx one with web-asset paths, and rewriting web JS
         // trailers would point them at a metadata file whose artifacts
         // don't include the web asset paths. Web JS source maps work
-        // fine via the default `.map` sibling; skip cleanly.
+        // fine via the default `.map` sibling; skip cleanly. An external
+        // bundle is the exception: `rslib` names its environment after the
+        // library, and it drives the same template hooks.
         const isLynx = environment.name === 'lynx'
           || environment.name.startsWith('lynx-')
-        if (!isLynx) return
+        const isExternalBundle = api.context.callerName === 'rslib'
+        if (!isLynx && !isExternalBundle) return
 
         if (!exposed) return
 

--- a/packages/rspeedy/plugin-lynx/src/index.ts
+++ b/packages/rspeedy/plugin-lynx/src/index.ts
@@ -73,11 +73,16 @@ export function pluginLynx(
       },
     },
     pluginConfig(options),
+    // Exposes the template lifecycle hooks and emits nothing itself, so a
+    // caller that assembles its own bundle can drive the same hooks and get
+    // the plugins that tap them, `pluginLynxDebugMetadata` among them.
+    pluginTemplate(),
+    // Taps the hooks above, so it covers an external bundle as well.
+    pluginLynxDebugMetadata(),
     ...onlyWhenTheEngineOwnsTheBuild([
       pluginChunkLoading(),
       pluginCssMinimizer(),
       pluginDev(),
-      pluginLynxDebugMetadata(),
       pluginMinify(),
       pluginOptimization(),
       pluginOutput(),
@@ -86,7 +91,6 @@ export function pluginLynx(
       pluginSourcemap(),
       pluginSwc(),
       pluginTarget(),
-      pluginTemplate(),
     ]),
   ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -544,6 +544,9 @@ importers:
       '@lynx-js/react-rsbuild-plugin':
         specifier: workspace:*
         version: link:../../packages/rspeedy/plugin-react
+      '@lynx-js/rsbuild-plugin':
+        specifier: workspace:*
+        version: link:../../packages/rspeedy/plugin-lynx
       '@lynx-js/rspeedy':
         specifier: workspace:*
         version: link:../../packages/rspeedy/core
@@ -1680,6 +1683,9 @@ importers:
       '@lynx-js/rsbuild-plugin':
         specifier: workspace:*
         version: link:../plugin-lynx
+      '@lynx-js/template-webpack-plugin':
+        specifier: workspace:*
+        version: link:../../webpack/template-webpack-plugin
       '@lynx-js/test-tools':
         specifier: workspace:*
         version: link:../../webpack/test-tools


### PR DESCRIPTION
Closes #3660.

An external bundle assembles itself, so the plugins that tap the template lifecycle never ran for it. `pluginLynxDebugMetadata` is the one that shows: an external bundle shipped no source maps and no release key, which is what made the debug metadata a separate, hand-wired path.

`pluginLynx` exposes the hooks whether or not it drives the build, and `ExternalBundleWebpackPlugin` drives them around its own encode. The payload handed to the hooks carries the shape `LynxTemplatePlugin` builds, since every tap reads that, while the encoder is still given only what an external bundle carries.

Verified end to end on `examples/react-externals`: decoding `comp-lib.lynx.bundle` shows the release key in the background section.

```
sections: ./App.js, ./App.js:CSS, ./App.js__main-thread
  ./App.js: debugMetadata=true
```

Without the plugin the bundle is byte for byte what it was, which a test asserts by comparing sha256.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * External library bundles now honor configured bundle filenames.
  * Template lifecycle hooks are applied to externally assembled bundles.
  * External bundles now include source maps, release keys, and debug metadata.
  * Added support for configuring custom template section names.
  * Lazy-bundle sections now use consistent, runtime-compatible names.

* **Bug Fixes**
  * Improved handling of bundles without debug metadata configuration.
  * Prevented unrelated build settings from affecting externally managed builds.
  * Improved consistency between engine-managed and externally assembled bundles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->