### PR TITLE
fix(react-rsbuild-plugin): do not apply the engine twice per environment

### DIFF
--- a/.changeset/auto-lynx-per-environment.md
+++ b/.changeset/auto-lynx-per-environment.md
@@ -1,0 +1,7 @@
+---
+"@lynx-js/react-rsbuild-plugin": patch
+"@lynx-js/rsbuild-plugin": patch
+"@lynx-js/rspeedy": patch
+---
+
+Do not apply the Lynx build engine again when `pluginLynx` is registered on an environment rather than globally, which silently replaced the options it was given.

--- a/packages/rspeedy/core/src/plugins/index.ts
+++ b/packages/rspeedy/core/src/plugins/index.ts
@@ -61,7 +61,7 @@ export async function applyDefaultPlugins(
 
   const promises: Promise<void>[] = [
     Promise.all(defaultPlugins).then(async plugins => {
-      const { PLUGIN_LYNX_NAME, pluginLynx } = await import(
+      const { isPluginLynxRegistered, pluginLynx } = await import(
         '@lynx-js/rsbuild-plugin'
       )
 
@@ -69,7 +69,10 @@ export async function applyDefaultPlugins(
       // themselves. Applying it again here would build a second config from
       // the Rspeedy options and overwrite theirs.
       rsbuildInstance.addPlugins([
-        ...rsbuildInstance.isPluginExists(PLUGIN_LYNX_NAME)
+        ...isPluginLynxRegistered(
+            rsbuildInstance,
+            Object.keys(config.environments ?? {}),
+          )
           ? []
           : pluginLynx(toLynxPluginOptions(config)),
         ...plugins,

--- a/packages/rspeedy/plugin-lynx/etc/rsbuild-plugin.api.md
+++ b/packages/rspeedy/plugin-lynx/etc/rsbuild-plugin.api.md
@@ -17,6 +17,13 @@ export interface BundleFilenameContext {
     platform: string;
 }
 
+// @public
+export function isPluginLynxRegistered(host: {
+    isPluginExists(name: string, options?: {
+        environment?: string;
+    }): boolean;
+}, environments: string[]): boolean;
+
 // @beta
 export interface LynxConfig {
     readonly output: LynxOutput;

--- a/packages/rspeedy/plugin-lynx/src/index.ts
+++ b/packages/rspeedy/plugin-lynx/src/index.ts
@@ -40,6 +40,35 @@ export type {
 } from './config.js'
 
 /**
+ * Whether the Lynx build engine is already registered.
+ *
+ * @remarks
+ *
+ * The engine is a global one. `isPluginExists` without an environment only
+ * reports the global plugins, so it misses an engine a caller — `rslib`, for
+ * one — registered on an environment instead.
+ *
+ * @param host - The Rsbuild instance or plugin API to look it up on.
+ * @param environments - The names of the configured environments.
+ *
+ * @public
+ */
+export function isPluginLynxRegistered(
+  host: {
+    isPluginExists(
+      name: string,
+      options?: { environment?: string },
+    ): boolean
+  },
+  environments: string[],
+): boolean {
+  return host.isPluginExists(PLUGIN_LYNX_NAME)
+    || environments.some(environment =>
+      host.isPluginExists(PLUGIN_LYNX_NAME, { environment })
+    )
+}
+
+/**
  * @public
  */
 export function pluginLynx(

--- a/packages/rspeedy/plugin-lynx/src/plugins/swc.plugin.ts
+++ b/packages/rspeedy/plugin-lynx/src/plugins/swc.plugin.ts
@@ -34,12 +34,17 @@ export function pluginSwc(): RsbuildPlugin {
               config.env = {
                 ...config.env,
                 targets: ES_ENV_TARGETS,
+                // A `Set`, so applying the engine more than once to the same
+                // environment does not repeat the transforms.
                 include: [
-                  // Lower `let`/`const` to `var`; QuickJS parses `var` faster.
-                  // Listing it in `env.exclude` opts out (exclude > include).
-                  'transform-block-scoping',
-                  ...getESVersionEnvInclude(),
-                  ...(config.env?.include ?? []),
+                  ...new Set([
+                    // Lower `let`/`const` to `var`; QuickJS parses `var`
+                    // faster. Listing it in `env.exclude` opts out
+                    // (exclude > include).
+                    'transform-block-scoping',
+                    ...getESVersionEnvInclude(),
+                    ...(config.env?.include ?? []),
+                  ]),
                 ],
               }
             },

--- a/packages/rspeedy/plugin-react/src/autoLynx.ts
+++ b/packages/rspeedy/plugin-react/src/autoLynx.ts
@@ -4,17 +4,10 @@
 
 import type { RsbuildContext, RsbuildPlugin } from '@rsbuild/core'
 
-import { PLUGIN_LYNX_NAME, pluginLynx } from '@lynx-js/rsbuild-plugin'
-
-// Calling `setup` does not register the plugins, so `PLUGIN_LYNX_NAME` cannot
-// be used to tell that the engine was applied this way. The context is marked
-// instead. `Symbol.for` keeps the marker shared with any other copy of this
-// package, and with any other plugin that applies the engine the same way.
-const S_PLUGIN_LYNX_APPLIED = Symbol.for('@lynx-js/rsbuild-plugin:applied')
+import { isPluginLynxRegistered, pluginLynx } from '@lynx-js/rsbuild-plugin'
 
 // Rspeedy applies `pluginLynx` itself. With plain Rsbuild nothing does, so the
-// build engine is applied here to keep `pluginReactLynx` the only plugin a user
-// has to add.
+// build engine is applied here.
 export function pluginAutoLynx(): RsbuildPlugin {
   return {
     name: 'lynx:react:auto-lynx',
@@ -26,22 +19,16 @@ export function pluginAutoLynx(): RsbuildPlugin {
         return
       }
 
-      if (
-        api.isPluginExists(PLUGIN_LYNX_NAME)
-        || Object.hasOwn(api.context, S_PLUGIN_LYNX_APPLIED)
-      ) {
+      const { environments } = api.getRsbuildConfig('original')
+      if (isPluginLynxRegistered(api, Object.keys(environments ?? {}))) {
         return
       }
-      Object.defineProperty(api.context, S_PLUGIN_LYNX_APPLIED, { value: true })
 
       const original = api.getRsbuildConfig('original')
 
       for (const plugin of pluginLynx()) {
-        // `setup` is called directly instead of registering the plugins, since
-        // a plugin cannot add plugins. `apply` is honored here because Rsbuild
-        // only evaluates it for registered plugins.
-        // `action` is only set once a build or a server starts, and Rsbuild
-        // passes it along as-is, so it is passed along the same way here.
+        // A plugin cannot add plugins, so `setup` is called directly. That
+        // skips the `apply` Rsbuild would evaluate for a registered plugin.
         const { action } = api.context
         if (
           typeof plugin.apply === 'function'

--- a/packages/rspeedy/plugin-react/test/auto-lynx.test.ts
+++ b/packages/rspeedy/plugin-react/test/auto-lynx.test.ts
@@ -59,6 +59,111 @@ describe('pluginAutoLynx', () => {
     expect(include).toStrictEqual([...new Set(include)])
   })
 
+  test('does not apply the engine again when it is registered per environment', async () => {
+    const rsbuild = await createRsbuild({
+      // eslint-disable-next-line n/no-unsupported-features/node-builtins
+      cwd: import.meta.dirname,
+      rsbuildConfig: {
+        mode: 'production',
+        environments: { lynx: { plugins: [...pluginLynx()] } },
+        source: { entry: { main: './fixtures/basic.tsx' } },
+        plugins: [pluginReactLynx()],
+      },
+    })
+
+    const [config] = await rsbuild.initConfigs()
+
+    const include = swcInclude(config)
+    expect(include).toStrictEqual([...new Set(include)])
+  })
+
+  test('does not apply the engine again when it is applied after it', async () => {
+    const rsbuild = await createRsbuild({
+      // eslint-disable-next-line n/no-unsupported-features/node-builtins
+      cwd: import.meta.dirname,
+      rsbuildConfig: {
+        mode: 'production',
+        environments: { lynx: {} },
+        source: { entry: { main: './fixtures/basic.tsx' } },
+        plugins: [pluginReactLynx(), ...pluginLynx()],
+      },
+    })
+
+    const [config] = await rsbuild.initConfigs()
+
+    const include = swcInclude(config)
+    expect(include).toStrictEqual([...new Set(include)])
+  })
+
+  test('applies the engine once for each environment that has the DSL plugin', async () => {
+    const rsbuild = await createRsbuild({
+      // eslint-disable-next-line n/no-unsupported-features/node-builtins
+      cwd: import.meta.dirname,
+      rsbuildConfig: {
+        environments: {
+          lynx: { plugins: [pluginReactLynx()] },
+          web: { plugins: [pluginReactLynx()] },
+        },
+        source: { entry: { main: './fixtures/basic.tsx' } },
+      },
+    })
+
+    const configs = await rsbuild.initConfigs()
+
+    expect(configs).toHaveLength(2)
+    for (const config of configs) {
+      const include = swcInclude(config)
+      expect(include).not.toHaveLength(0)
+      expect(include).toStrictEqual([...new Set(include)])
+    }
+  })
+
+  test('applies the engine for an environment that does not register it', async () => {
+    const rsbuild = await createRsbuild({
+      // eslint-disable-next-line n/no-unsupported-features/node-builtins
+      cwd: import.meta.dirname,
+      rsbuildConfig: {
+        environments: {
+          lynx: { plugins: [...pluginLynx(), pluginReactLynx()] },
+          web: { plugins: [pluginReactLynx()] },
+        },
+        source: { entry: { main: './fixtures/basic.tsx' } },
+      },
+    })
+
+    const configs = await rsbuild.initConfigs()
+
+    expect(configs).toHaveLength(2)
+    for (const config of configs) {
+      const include = swcInclude(config)
+      expect(include).not.toHaveLength(0)
+      expect(include).toStrictEqual([...new Set(include)])
+    }
+  })
+
+  test('does not repeat the engine when every environment registers it', async () => {
+    const rsbuild = await createRsbuild({
+      // eslint-disable-next-line n/no-unsupported-features/node-builtins
+      cwd: import.meta.dirname,
+      rsbuildConfig: {
+        environments: {
+          lynx: { plugins: [...pluginLynx(), pluginReactLynx()] },
+          web: { plugins: [...pluginLynx(), pluginReactLynx()] },
+        },
+        source: { entry: { main: './fixtures/basic.tsx' } },
+      },
+    })
+
+    const configs = await rsbuild.initConfigs()
+
+    expect(configs).toHaveLength(2)
+    for (const config of configs) {
+      const include = swcInclude(config)
+      expect(include).not.toHaveLength(0)
+      expect(include).toStrictEqual([...new Set(include)])
+    }
+  })
+
   test('does not apply the engine for the rslib caller', async () => {
     const rsbuild = await createRsbuild({
       callerName: 'rslib',

--- a/packages/rspeedy/plugin-react/test/web.test.ts
+++ b/packages/rspeedy/plugin-react/test/web.test.ts
@@ -8,6 +8,7 @@ import { fileURLToPath } from 'node:url'
 
 import { describe, expect, rstest, test } from '@rstest/core'
 
+import { pluginLynx } from '@lynx-js/rsbuild-plugin'
 import { WebEncodePlugin } from '@lynx-js/template-webpack-plugin'
 import type { LynxTemplatePlugin } from '@lynx-js/template-webpack-plugin'
 
@@ -305,6 +306,79 @@ describe('Web', () => {
         '/packages/react/runtime/lib/internal.js'.replaceAll('/', path.sep),
       ),
     )
+  })
+
+  test('the bundle filename can differ per environment', async () => {
+    rstest.stubEnv('NODE_ENV', 'development')
+    const { pluginReactLynx } = await import('../src/index.js')
+
+    const rsbuild = await createRspeedy({
+      rspeedyConfig: {
+        environments: { lynx: {}, web: {} },
+        plugins: [
+          ...pluginLynx({
+            output: {
+              filename: {
+                bundle: ({ entryName, platform }) =>
+                  `${entryName ?? '[name]'}.for-${platform}.bundle`,
+              },
+            },
+          }),
+          pluginReactLynx(),
+        ],
+      },
+      // eslint-disable-next-line n/no-unsupported-features/node-builtins
+      cwd: import.meta.dirname,
+    })
+
+    const [lynxConfig, webConfig] = await rsbuild.initConfigs()
+
+    expect(
+      lynxConfig?.plugins?.find((
+        p,
+      ): p is LynxTemplatePlugin => p?.constructor.name === 'LynxTemplatePlugin' // @ts-expect-error private field
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      )?.options?.filename,
+    ).toMatchInlineSnapshot(`"main.for-lynx.bundle"`)
+    expect(
+      webConfig?.plugins?.find((
+        p,
+      ): p is LynxTemplatePlugin => p?.constructor.name === 'LynxTemplatePlugin' // @ts-expect-error private field
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      )?.options?.filename,
+    ).toMatchInlineSnapshot(`"main.for-web.bundle"`)
+  })
+
+  test('keeps the engine options of a `pluginLynx` an environment registers', async () => {
+    rstest.stubEnv('NODE_ENV', 'development')
+    const { pluginReactLynx } = await import('../src/index.js')
+
+    const rsbuild = await createRspeedy({
+      rspeedyConfig: {
+        environments: {
+          lynx: {
+            plugins: [
+              ...pluginLynx({
+                output: { filename: { bundle: '[name].configured.bundle' } },
+              }),
+              pluginReactLynx(),
+            ],
+          },
+        },
+      },
+      // eslint-disable-next-line n/no-unsupported-features/node-builtins
+      cwd: import.meta.dirname,
+    })
+
+    const [config] = await rsbuild.initConfigs()
+
+    expect(
+      config?.plugins?.find((
+        p,
+      ): p is LynxTemplatePlugin => p?.constructor.name === 'LynxTemplatePlugin' // @ts-expect-error private field
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      )?.options?.filename,
+    ).toMatchInlineSnapshot(`"main.configured.bundle"`)
   })
 
   // TODO: stack overflow, should be fixed in the later PRs


### PR DESCRIPTION
`isPluginExists` without an environment only reports the global plugins, so an
engine registered on an environment went unnoticed. `pluginAutoLynx` applied a
second one, and Rspeedy applied a third built from its own config, which
silently replaced the options the user had given theirs.

The engine is a global one wherever it is registered, so look it up in both
scopes from a single helper. Applying it twice is harmless now either way: the
SWC transforms it contributes are a set.

