### PR TITLE
feat(rsbuild-plugin): compile rslib with the engine SWC transforms

### DIFF
--- a/packages/rspeedy/plugin-lynx/src/index.ts
+++ b/packages/rspeedy/plugin-lynx/src/index.ts
@@ -79,7 +79,6 @@ export function pluginLynx(
     pluginChunkLoading(),
     pluginLynxDebugMetadata(),
     pluginOutput(),
-    pluginSwc(),
     pluginCssMinimizer(),
     pluginDev(),
     pluginMinify(),
@@ -107,6 +106,7 @@ export function pluginLynx(
     },
     pluginConfig(options),
     pluginResolve(),
+    pluginSwc(),
     pluginTemplate(),
     ...bundlePlugins,
   ]


### PR DESCRIPTION
The SWC target of an `rslib` build came from Rslib's own `syntax`, so a library
was compiled against a different baseline than the application loading it —
notably without `transform-block-scoping`, which QuickJS parses faster.

The transform set does not depend on who assembles the bundle.

