### PR TITLE
fix(lynx-bundle-rslib-config): encode the sections in a stable order

### DIFF
--- a/.changeset/external-bundle-section-order.md
+++ b/.changeset/external-bundle-section-order.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/lynx-bundle-rslib-config": patch
+---
+
+Write the custom sections of an external bundle in a stable order, so the same input always encodes to the same bytes.

--- a/packages/rspeedy/lynx-bundle-rslib-config/src/webpack/ExternalBundleWebpackPlugin.ts
+++ b/packages/rspeedy/lynx-bundle-rslib-config/src/webpack/ExternalBundleWebpackPlugin.ts
@@ -133,7 +133,13 @@ export class ExternalBundleWebpackPlugin {
     compiler: Rspack.Compiler,
     compilation: Rspack.Compilation,
   ): Promise<void> {
-    const assets = compilation.getAssets()
+    // The custom sections are written in the order the assets come in, and
+    // `getAssets` orders them by however the compilation happened to emit
+    // them, which shifts with the plugins that took part. Sort them so the
+    // same input encodes to the same bytes.
+    const assets = compilation.getAssets().slice().sort((a, b) =>
+      a.name < b.name ? -1 : (a.name > b.name ? 1 : 0)
+    )
     // `rslib build` always compiles with rspack mode `production`, so the
     // development signal here is `NODE_ENV`, matching the `minify` default
     // of `DEFAULT_EXTERNAL_BUNDLE_LIB_CONFIG`.

--- a/packages/rspeedy/lynx-bundle-rslib-config/test/external-bundle.test.ts
+++ b/packages/rspeedy/lynx-bundle-rslib-config/test/external-bundle.test.ts
@@ -391,11 +391,12 @@ describe('should build external bundle', () => {
       path.join(fixtureDir, 'dist', 'css-bundle.lynx.bundle'),
     )
 
-    // Check custom-sections for CSS keys
-    expect(Object.keys(decodedResult['custom-sections']).sort()).toEqual([
+    // Check custom-sections for CSS keys. The order is the one the assets sort
+    // in, so the same input always encodes to the same bytes.
+    expect(Object.keys(decodedResult['custom-sections'])).toEqual([
+      'index__main-thread',
       'index',
       'index:CSS',
-      'index__main-thread',
     ])
 
     expect(Array.isArray(decodedResult['custom-sections']['index:CSS'])).toBe(


### PR DESCRIPTION
The custom sections of an external bundle were written in whatever order `compilation.getAssets` returned. That order shifts with the plugins that took part in the compilation, so the same input could encode to different bytes.

Sort the assets by name before encoding. On the `css-lib` fixture the section order goes from `['index', 'index__main-thread', 'index:CSS']` to `['index__main-thread', 'index', 'index:CSS']` and stays there; the test asserts it instead of sorting the keys before comparing.