### PR TITLE
feat(rsbuild-plugin): emit what a Lynx bundle can carry for an external bundle

### DIFF
--- a/.changeset/auto-lynx-per-environment.md
+++ b/.changeset/auto-lynx-per-environment.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react-rsbuild-plugin": patch
+---
+
+Fix the Lynx build engine being applied twice when `pluginLynx` is registered on an environment instead of globally.

--- a/.changeset/generalize-custom-sections.md
+++ b/.changeset/generalize-custom-sections.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/template-webpack-plugin": minor
+---
+
+Resolve custom section names through a `CustomSectionNaming` strategy instead of the fixed lazy bundle constants. The lazy bundle output is unchanged.

--- a/.changeset/rslib-auto-lynx.md
+++ b/.changeset/rslib-auto-lynx.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react-rsbuild-plugin": minor
+---
+
+Apply the Lynx build engine for the `rslib` caller too, so an external bundle no longer needs `pluginLynx` added by hand.

--- a/.changeset/rslib-engine-config.md
+++ b/.changeset/rslib-engine-config.md
@@ -1,0 +1,6 @@
+---
+"@lynx-js/rsbuild-plugin": minor
+"@lynx-js/lynx-bundle-rslib-config": minor
+---
+
+Read the engine config when assembling an external bundle, so its filename comes from `pluginLynx`. The output is unchanged.

--- a/.changeset/rslib-engine-output.md
+++ b/.changeset/rslib-engine-output.md
@@ -1,0 +1,6 @@
+---
+"@lynx-js/rsbuild-plugin": minor
+"@lynx-js/lynx-bundle-rslib-config": minor
+---
+
+Apply the Lynx output settings to an external bundle: no HTML plugin, no `.LICENSE.txt` trailer, `var` in the bundler runtime.

--- a/.changeset/rslib-engine-resolve.md
+++ b/.changeset/rslib-engine-resolve.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/rsbuild-plugin": minor
+---
+
+Resolve modules in an external bundle with the `lynx` export condition, main field and `index.lynx` entry.

--- a/.changeset/rslib-engine-swc.md
+++ b/.changeset/rslib-engine-swc.md
@@ -1,0 +1,6 @@
+---
+"@lynx-js/rsbuild-plugin": minor
+"@lynx-js/lynx-bundle-rslib-config": minor
+---
+
+Lower an external bundle to the Lynx ES baseline, so its background chunk ships `var` instead of `let`/`const`.

--- a/.changeset/rslib-template-hooks.md
+++ b/.changeset/rslib-template-hooks.md
@@ -1,0 +1,7 @@
+---
+"@lynx-js/rsbuild-plugin": minor
+"@lynx-js/lynx-bundle-rslib-config": minor
+"@lynx-js/debug-metadata-rsbuild-plugin": patch
+---
+
+Drive the template lifecycle hooks for an external bundle, so `pluginLynxDebugMetadata` covers it: it now ships source maps and a release key.

--- a/examples/react-externals/package.json
+++ b/examples/react-externals/package.json
@@ -21,6 +21,7 @@
     "@lynx-js/preact-devtools": "5.0.1-20260721114100-d7da994",
     "@lynx-js/qrcode-rsbuild-plugin": "workspace:*",
     "@lynx-js/react-rsbuild-plugin": "workspace:*",
+    "@lynx-js/rsbuild-plugin": "workspace:*",
     "@lynx-js/rspeedy": "workspace:*",
     "@lynx-js/types": "4.1.0",
     "@types/react": "^19.2.18",

--- a/examples/react-externals/rslib-comp-lib.config.ts
+++ b/examples/react-externals/rslib-comp-lib.config.ts
@@ -1,5 +1,6 @@
 import { defineExternalBundleRslibConfig } from '@lynx-js/lynx-bundle-rslib-config';
 import { pluginReactLynx } from '@lynx-js/react-rsbuild-plugin';
+import { pluginLynx } from '@lynx-js/rsbuild-plugin';
 
 // REACTLYNX_ASYNC=true builds comp-lib against async (Promise) ReactLynx
 // externals to match an async host; output isolated in
@@ -14,6 +15,9 @@ export default defineExternalBundleRslibConfig({
     },
   },
   plugins: [
+    // Configures the bundle filename and brings the plugins that tap the
+    // template hooks, `pluginLynxDebugMetadata` among them.
+    ...pluginLynx(),
     pluginReactLynx(),
   ],
   // Sync and async share this config file, so rspack's persistent cache (keyed

--- a/packages/rspeedy/lynx-bundle-rslib-config/etc/lynx-bundle-rslib-config.api.md
+++ b/packages/rspeedy/lynx-bundle-rslib-config/etc/lynx-bundle-rslib-config.api.md
@@ -5,6 +5,7 @@
 ```ts
 
 import type { LibConfig } from '@rslib/core';
+import type { LynxTemplatePlugin } from '@lynx-js/template-webpack-plugin';
 import type { RslibConfig } from '@rslib/core';
 import type { Rspack } from '@rslib/core';
 
@@ -49,6 +50,8 @@ export interface ExternalBundleWebpackPluginOptions {
         buffer: Buffer;
     }>;
     engineVersion?: string | undefined;
+    // Warning: (ae-forgotten-export) The symbol "LynxTemplatePluginHooksProvider" needs to be exported by the entry point index.d.ts
+    LynxTemplatePlugin?: LynxTemplatePluginHooksProvider | undefined;
     mainThreadChunks?: string[] | undefined;
 }
 

--- a/packages/rspeedy/lynx-bundle-rslib-config/package.json
+++ b/packages/rspeedy/lynx-bundle-rslib-config/package.json
@@ -45,6 +45,7 @@
     "@lynx-js/react": "workspace:*",
     "@lynx-js/react-rsbuild-plugin": "workspace:*",
     "@lynx-js/rsbuild-plugin": "workspace:*",
+    "@lynx-js/template-webpack-plugin": "workspace:*",
     "@lynx-js/test-tools": "workspace:*",
     "@microsoft/api-extractor": "catalog:",
     "@rslib/core": "catalog:rslib",

--- a/packages/rspeedy/lynx-bundle-rslib-config/package.json
+++ b/packages/rspeedy/lynx-bundle-rslib-config/package.json
@@ -44,6 +44,7 @@
   "devDependencies": {
     "@lynx-js/react": "workspace:*",
     "@lynx-js/react-rsbuild-plugin": "workspace:*",
+    "@lynx-js/rsbuild-plugin": "workspace:*",
     "@lynx-js/test-tools": "workspace:*",
     "@microsoft/api-extractor": "catalog:",
     "@rslib/core": "catalog:rslib",

--- a/packages/rspeedy/lynx-bundle-rslib-config/src/externalBundleRslibConfig.ts
+++ b/packages/rspeedy/lynx-bundle-rslib-config/src/externalBundleRslibConfig.ts
@@ -95,7 +95,6 @@ const DEFAULT_EXTERNAL_BUNDLE_MINIFY_CONFIG = {
  */
 export const DEFAULT_EXTERNAL_BUNDLE_LIB_CONFIG: LibConfig = {
   format: 'cjs',
-  syntax: 'es2015',
   autoExtension: false,
   shims: {
     cjs: {

--- a/packages/rspeedy/lynx-bundle-rslib-config/src/externalBundleRslibConfig.ts
+++ b/packages/rspeedy/lynx-bundle-rslib-config/src/externalBundleRslibConfig.ts
@@ -5,10 +5,13 @@
 import { rsbuild } from '@rslib/core'
 import type { LibConfig, RslibConfig, Rspack } from '@rslib/core'
 
+import type { LynxConfig } from '@lynx-js/rsbuild-plugin'
 import { RuntimeWrapperWebpackPlugin as BackgroundRuntimeWrapperWebpackPlugin } from '@lynx-js/runtime-wrapper-webpack-plugin'
 
 import { ExternalBundleWebpackPlugin } from './webpack/ExternalBundleWebpackPlugin.js'
 import { MainThreadRuntimeWrapperWebpackPlugin } from './webpack/MainThreadRuntimeWrapperWebpackPlugin.js'
+
+const S_LYNX_CONFIG = Symbol.for('@lynx-js/rsbuild-plugin:config')
 
 /**
  * The options for encoding the external bundle.
@@ -772,7 +775,14 @@ const externalBundleRsbuildPlugin = ({
           ExternalBundleWebpackPlugin,
           [
             {
-              bundleFileName: `${libName}.${isWeb ? 'web' : 'lynx'}.bundle`,
+              // The engine config is only there when the user applied
+              // `pluginLynxConfig`, so the default stays the source of truth.
+              bundleFileName: api.useExposed<LynxConfig>(S_LYNX_CONFIG)
+                ?.resolveBundleFilename({
+                  entryName: libName,
+                  platform: isWeb ? 'web' : 'lynx',
+                })
+                ?? `${libName}.${isWeb ? 'web' : 'lynx'}.bundle`,
               encode,
               engineVersion,
               mainThreadChunks,

--- a/packages/rspeedy/lynx-bundle-rslib-config/src/externalBundleRslibConfig.ts
+++ b/packages/rspeedy/lynx-bundle-rslib-config/src/externalBundleRslibConfig.ts
@@ -9,6 +9,7 @@ import type { LynxConfig } from '@lynx-js/rsbuild-plugin'
 import { RuntimeWrapperWebpackPlugin as BackgroundRuntimeWrapperWebpackPlugin } from '@lynx-js/runtime-wrapper-webpack-plugin'
 
 import { ExternalBundleWebpackPlugin } from './webpack/ExternalBundleWebpackPlugin.js'
+import type { LynxTemplatePluginHooksProvider } from './webpack/ExternalBundleWebpackPlugin.js'
 import { MainThreadRuntimeWrapperWebpackPlugin } from './webpack/MainThreadRuntimeWrapperWebpackPlugin.js'
 
 const S_LYNX_CONFIG = Symbol.for('@lynx-js/rsbuild-plugin:config')
@@ -776,13 +777,18 @@ const externalBundleRsbuildPlugin = ({
           [
             {
               // The engine config is only there when the user applied
-              // `pluginLynxConfig`, so the default stays the source of truth.
+              // `pluginLynx`, so the default stays the source of truth.
               bundleFileName: api.useExposed<LynxConfig>(S_LYNX_CONFIG)
                 ?.resolveBundleFilename({
                   entryName: libName,
                   platform: isWeb ? 'web' : 'lynx',
                 })
                 ?? `${libName}.${isWeb ? 'web' : 'lynx'}.bundle`,
+              // `pluginLynx` exposes the hooks whether or not it drives the
+              // build, so the plugins that tap them run here too.
+              LynxTemplatePlugin: api.useExposed<
+                { LynxTemplatePlugin: LynxTemplatePluginHooksProvider }
+              >(Symbol.for('LynxTemplatePlugin'))?.LynxTemplatePlugin,
               encode,
               engineVersion,
               mainThreadChunks,

--- a/packages/rspeedy/lynx-bundle-rslib-config/src/webpack/ExternalBundleWebpackPlugin.ts
+++ b/packages/rspeedy/lynx-bundle-rslib-config/src/webpack/ExternalBundleWebpackPlugin.ts
@@ -7,6 +7,10 @@ import { cssChunksToMap } from '@lynx-js/css-serializer'
 import type { LynxStyleNode } from '@lynx-js/css-serializer'
 import type { LynxTemplatePlugin } from '@lynx-js/template-webpack-plugin'
 
+function sectionName(assetName: string, extension: string): string {
+  return assetName.slice(assetName.lastIndexOf('/') + 1, -extension.length)
+}
+
 /**
  * Provides the template lifecycle hooks, so the plugins that tap them run for
  * a bundle assembled outside `LynxTemplatePlugin`.
@@ -214,7 +218,7 @@ export class ExternalBundleWebpackPlugin {
             case 'javascript':
               return ({
                 ...prev,
-                [cur.name.replace(/\.js$/, '')]: {
+                [sectionName(cur.name, '.js')]: {
                   ...(enableJsBytecode
                       && this.options.mainThreadChunks?.includes(cur.name)
                     ? {
@@ -227,7 +231,10 @@ export class ExternalBundleWebpackPlugin {
             case 'extract-css':
               return ({
                 ...prev,
-                [`${cur.name.replace(/\.css$/, '')}:CSS`]: {
+                // A section is named after the entry it belongs to. The engine
+                // emits CSS into a directory of its own, so the name is taken
+                // from the file rather than from the path leading to it.
+                [`${sectionName(cur.name, '.css')}:CSS`]: {
                   'encoding': 'CSS',
                   content: {
                     ruleList: cssChunksToMap(

--- a/packages/rspeedy/lynx-bundle-rslib-config/src/webpack/ExternalBundleWebpackPlugin.ts
+++ b/packages/rspeedy/lynx-bundle-rslib-config/src/webpack/ExternalBundleWebpackPlugin.ts
@@ -5,6 +5,18 @@ import type { Rspack } from '@rslib/core'
 
 import { cssChunksToMap } from '@lynx-js/css-serializer'
 import type { LynxStyleNode } from '@lynx-js/css-serializer'
+import type { LynxTemplatePlugin } from '@lynx-js/template-webpack-plugin'
+
+/**
+ * Provides the template lifecycle hooks, so the plugins that tap them run for
+ * a bundle assembled outside `LynxTemplatePlugin`.
+ *
+ * @public
+ */
+export interface LynxTemplatePluginHooksProvider {
+  getLynxTemplatePluginHooks:
+    typeof LynxTemplatePlugin.getLynxTemplatePluginHooks
+}
 
 /**
  * The options for {@link ExternalBundleWebpackPlugin}.
@@ -49,6 +61,17 @@ export interface ExternalBundleWebpackPluginOptions {
    * @defaultValue []
    */
   mainThreadChunks?: string[] | undefined
+
+  /**
+   * Drives the template lifecycle hooks, so the plugins that tap them run for
+   * an external bundle too.
+   *
+   * @remarks
+   *
+   * `pluginLynx` exposes this under `Symbol.for('LynxTemplatePlugin')`. Left
+   * out, the bundle is assembled without running any of them.
+   */
+  LynxTemplatePlugin?: LynxTemplatePluginHooksProvider | undefined
 
   /**
    * Whether to tag main thread chunks with the `JsBytecode` encoding so the
@@ -116,16 +139,44 @@ export class ExternalBundleWebpackPlugin {
     // of `DEFAULT_EXTERNAL_BUNDLE_LIB_CONFIG`.
     const enableJsBytecode = this.options.enableJsBytecode
       ?? process.env['NODE_ENV'] !== 'development'
+    const hooks = this.options.LynxTemplatePlugin
+      ?.getLynxTemplatePluginHooks(compilation)
+
     const { buffer, encodeOptions } = await this.#encode(
       assets,
       enableJsBytecode,
+      compilation,
+      hooks,
     )
 
     const { RawSource } = compiler.webpack.sources
+    const outputName = this.options.bundleFileName
+
+    const emitted = hooks
+      ? await hooks.beforeEmit.promise({
+        finalEncodeOptions: encodeOptions as never,
+        debugInfo: '',
+        template: buffer,
+        outputName,
+        mainThreadAssets: assets.filter(asset =>
+          this.options.mainThreadChunks?.includes(asset.name)
+        ) as never,
+        cssChunks: assets.filter(asset =>
+          asset.info.assetType === 'extract-css'
+        ) as never,
+        chunkGroups: [...compilation.chunkGroups] as never,
+      })
+      : undefined
+    const template = emitted ? emitted.template : buffer
+
     compilation.emitAsset(
-      this.options.bundleFileName,
-      new RawSource(buffer, false),
+      outputName,
+      new RawSource(template, false),
     )
+
+    if (hooks) {
+      await hooks.afterEmit.promise({ outputName })
+    }
     if (isDebug()) {
       compilation.emitAsset(
         'tasm.json',
@@ -143,6 +194,12 @@ export class ExternalBundleWebpackPlugin {
   async #encode(
     assets: readonly Rspack.Asset[],
     enableJsBytecode: boolean,
+    compilation: Rspack.Compilation,
+    hooks:
+      | ReturnType<
+        LynxTemplatePluginHooksProvider['getLynxTemplatePluginHooks']
+      >
+      | undefined,
   ) {
     const customSections = assets
       .reduce<
@@ -206,8 +263,47 @@ export class ExternalBundleWebpackPlugin {
       customSections,
     }
 
-    const { buffer } = await this.options.encode(encodeOptions)
+    if (!hooks) {
+      const { buffer } = await this.options.encode(encodeOptions)
+      return { buffer, encodeOptions }
+    }
 
-    return { buffer, encodeOptions }
+    // `beforeEncode` is where `pluginLynxDebugMetadata` collects the source
+    // maps and rewrites the trailers, so it runs before the encoder does.
+    // Every plugin that taps it reads the shape `LynxTemplatePlugin` builds,
+    // so the sections are carried in one of that shape.
+    const { encodeData } = await hooks.beforeEncode.promise({
+      encodeData: {
+        ...encodeOptions,
+        sourceContent: { ...encodeOptions.sourceContent, config: {} },
+        lepusCode: { chunks: [] },
+        manifest: {},
+        css: {},
+      } as never,
+      filenameTemplate: this.options.bundleFileName,
+      chunkGroups: [...compilation.chunkGroups] as never,
+      intermediate: '',
+      intermediateAssets: [],
+    })
+
+    const resolved = encodeData as unknown as typeof encodeOptions & {
+      sourceContent: { config?: Record<string, unknown> }
+    }
+    const { config, ...sourceContent } = resolved.sourceContent
+
+    // An external bundle carries no `lepusCode`, `manifest` or `css`: its
+    // chunks are sections. They were only there for the hooks, so encode
+    // what it actually carries, keeping whatever a tap wrote.
+    const forEncode = {
+      compilerOptions: resolved.compilerOptions,
+      sourceContent: config && Object.keys(config).length > 0
+        ? { ...sourceContent, config }
+        : sourceContent,
+      customSections: resolved.customSections,
+    } as typeof encodeOptions
+
+    const { buffer } = await this.options.encode(forEncode)
+
+    return { buffer, encodeOptions: forEncode }
   }
 }

--- a/packages/rspeedy/lynx-bundle-rslib-config/test/external-bundle.test.ts
+++ b/packages/rspeedy/lynx-bundle-rslib-config/test/external-bundle.test.ts
@@ -178,10 +178,14 @@ describe('with the engine config', () => {
     })
   }
 
-  it('emits the same bytes as a build without it', async () => {
-    // A local production build ships no debug metadata, so the engine adds
-    // nothing to the bundle here. The rstest harness sets `DEBUG=rspeedy` and
-    // CI sets `CI`, either of which would opt the build back into it.
+  it('emits the same bytes whether the engine is applied by hand or not', async () => {
+    // `pluginReactLynx` applies the engine, so adding `pluginLynx` on top of it
+    // has to be a no-op rather than a second copy.
+    //
+    // A local production build ships no debug metadata, which keeps the bytes
+    // free of the build paths that differ between the two. The rstest harness
+    // sets `DEBUG=rspeedy` and CI sets `CI`, either of which would opt the
+    // build back into it.
     const restore = new Map(
       ['DEBUG', 'CI', 'CI_REPO_NAME', 'BUILD_VERSION'].map(key => {
         const value = process.env[key]
@@ -191,7 +195,7 @@ describe('with the engine config', () => {
     )
     rstest.stubEnv('NODE_ENV', 'production')
     try {
-      await build(configFor('engine-off', []))
+      await build(configFor('engine-auto', []))
       await build(configFor('engine-on', pluginLynx()))
 
       expect(
@@ -200,7 +204,7 @@ describe('with the engine config', () => {
         ),
       ).toBe(
         sha256(
-          path.join(fixtureDir, 'dist/engine-off/engine-off.lynx.bundle'),
+          path.join(fixtureDir, 'dist/engine-auto/engine-auto.lynx.bundle'),
         ),
       )
     } finally {
@@ -211,8 +215,8 @@ describe('with the engine config', () => {
     }
   })
 
-  it('runs the plugins that tap the template hooks', async () => {
-    await build(configFor('engine-debug', pluginLynx()))
+  it('runs the plugins that tap the template hooks without being applied by hand', async () => {
+    await build(configFor('engine-debug', []))
 
     const decoded = await decodeTemplate(
       path.join(fixtureDir, 'dist/engine-debug/engine-debug.lynx.bundle'),

--- a/packages/rspeedy/lynx-bundle-rslib-config/test/external-bundle.test.ts
+++ b/packages/rspeedy/lynx-bundle-rslib-config/test/external-bundle.test.ts
@@ -179,18 +179,50 @@ describe('with the engine config', () => {
   }
 
   it('emits the same bytes as a build without it', async () => {
-    await build(configFor('engine-off', []))
-    await build(configFor('engine-on', pluginLynx()))
-
-    expect(
-      sha256(
-        path.join(fixtureDir, 'dist/engine-on/engine-on.lynx.bundle'),
-      ),
-    ).toBe(
-      sha256(
-        path.join(fixtureDir, 'dist/engine-off/engine-off.lynx.bundle'),
-      ),
+    // A local production build ships no debug metadata, so the engine adds
+    // nothing to the bundle here. The rstest harness sets `DEBUG=rspeedy` and
+    // CI sets `CI`, either of which would opt the build back into it.
+    const restore = new Map(
+      ['DEBUG', 'CI', 'CI_REPO_NAME', 'BUILD_VERSION'].map(key => {
+        const value = process.env[key]
+        delete process.env[key]
+        return [key, value] as const
+      }),
     )
+    rstest.stubEnv('NODE_ENV', 'production')
+    try {
+      await build(configFor('engine-off', []))
+      await build(configFor('engine-on', pluginLynx()))
+
+      expect(
+        sha256(
+          path.join(fixtureDir, 'dist/engine-on/engine-on.lynx.bundle'),
+        ),
+      ).toBe(
+        sha256(
+          path.join(fixtureDir, 'dist/engine-off/engine-off.lynx.bundle'),
+        ),
+      )
+    } finally {
+      rstest.unstubAllEnvs()
+      for (const [key, value] of restore) {
+        if (value !== undefined) process.env[key] = value
+      }
+    }
+  })
+
+  it('runs the plugins that tap the template hooks', async () => {
+    await build(configFor('engine-debug', pluginLynx()))
+
+    const decoded = await decodeTemplate(
+      path.join(fixtureDir, 'dist/engine-debug/engine-debug.lynx.bundle'),
+    )
+    // `pluginLynxDebugMetadata` reports the release key through
+    // `_SetSourceMapRelease`, and it only runs when the template hooks are
+    // driven. The main-thread section is bytecode, so it is read from the
+    // background one.
+    expect(String(decoded['custom-sections']['utils']))
+      .toContain('[pluginDebugMetadata] SetSourceMapInfo')
   })
 
   it('resolves the bundle filename from it', async () => {

--- a/packages/rspeedy/lynx-bundle-rslib-config/test/external-bundle.test.ts
+++ b/packages/rspeedy/lynx-bundle-rslib-config/test/external-bundle.test.ts
@@ -2,6 +2,7 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
+import crypto from 'node:crypto'
 import fs from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -19,6 +20,7 @@ import {
 } from '@rstest/core'
 
 import { LAYERS, pluginReactLynx } from '@lynx-js/react-rsbuild-plugin'
+import { pluginLynx } from '@lynx-js/rsbuild-plugin'
 
 import { decodeTemplate } from './utils.js'
 import { defineExternalBundleRslibConfig } from '../src/index.js'
@@ -155,6 +157,60 @@ describe('REACT_DEVTOOL minify', () => {
     expect(minify.jsOptions?.minimizerOptions?.compress?.keep_fnames)
       .toBeUndefined()
     expect(minify.jsOptions?.minimizerOptions?.mangle).toBeUndefined()
+  })
+})
+
+function sha256(file: string) {
+  return crypto.createHash('sha256').update(fs.readFileSync(file)).digest('hex')
+}
+
+describe('with the engine config', () => {
+  const fixtureDir = path.join(__dirname, './fixtures/utils-lib')
+
+  function configFor(id: string, plugins: unknown[]) {
+    return defineExternalBundleRslibConfig({
+      source: {
+        entry: { utils: path.join(fixtureDir, 'index.ts') },
+      },
+      id,
+      output: { distPath: { root: path.join(fixtureDir, 'dist', id) } },
+      plugins: [...plugins, pluginReactLynx()] as never,
+    })
+  }
+
+  it('emits the same bytes as a build without it', async () => {
+    await build(configFor('engine-off', []))
+    await build(configFor('engine-on', pluginLynx()))
+
+    expect(
+      sha256(
+        path.join(fixtureDir, 'dist/engine-on/engine-on.lynx.bundle'),
+      ),
+    ).toBe(
+      sha256(
+        path.join(fixtureDir, 'dist/engine-off/engine-off.lynx.bundle'),
+      ),
+    )
+  })
+
+  it('resolves the bundle filename from it', async () => {
+    await build(
+      configFor(
+        'engine-named',
+        pluginLynx({
+          output: { filename: { bundle: '[name].[platform].custom.bundle' } },
+        }),
+      ),
+    )
+
+    expect(
+      fs.existsSync(
+        path.join(
+          fixtureDir,
+          'dist/engine-named/engine-named.lynx.custom.bundle',
+        ),
+      ),
+    ).toBe(true)
   })
 })
 

--- a/packages/rspeedy/plugin-debug-metadata/src/LynxDebugMetadataPlugin.ts
+++ b/packages/rspeedy/plugin-debug-metadata/src/LynxDebugMetadataPlugin.ts
@@ -346,7 +346,9 @@ export function rewriteSourceMappingURLs(
   args: Parameters<Parameters<TemplateHooks['beforeEncode']['tap']>[1]>[0],
   options?: RewriteSourceMappingURLsOptions,
 ): void {
-  const debugMetadataUrl = args.encodeData.sourceContent.config[
+  // A bundle assembled outside `LynxTemplatePlugin` carries no `config`, so
+  // the url is unset there in the same way an empty one is.
+  const debugMetadataUrl = args.encodeData.sourceContent.config?.[
     'debugMetadataUrl'
   ]
   if (typeof debugMetadataUrl !== 'string' || debugMetadataUrl === '') return

--- a/packages/rspeedy/plugin-debug-metadata/src/pluginLynxDebugMetadata.ts
+++ b/packages/rspeedy/plugin-debug-metadata/src/pluginLynxDebugMetadata.ts
@@ -171,10 +171,13 @@ export function pluginLynxDebugMetadata(): RsbuildPlugin {
         // the lynx one with web-asset paths, and rewriting web JS
         // trailers would point them at a metadata file whose artifacts
         // don't include the web asset paths. Web JS source maps work
-        // fine via the default `.map` sibling; skip cleanly.
+        // fine via the default `.map` sibling; skip cleanly. An external
+        // bundle is the exception: `rslib` names its environment after the
+        // library, and it drives the same template hooks.
         const isLynx = environment.name === 'lynx'
           || environment.name.startsWith('lynx-')
-        if (!isLynx) return
+        const isExternalBundle = api.context.callerName === 'rslib'
+        if (!isLynx && !isExternalBundle) return
 
         if (!exposed) return
 

--- a/packages/rspeedy/plugin-lynx/src/index.ts
+++ b/packages/rspeedy/plugin-lynx/src/index.ts
@@ -79,6 +79,9 @@ export function pluginLynx(
     pluginTemplate(),
     // Taps the hooks above, so it covers an external bundle as well.
     pluginLynxDebugMetadata(),
+    // What a module resolves to is a property of the Lynx runtime, not of who
+    // assembles the bundle, so an external bundle resolves the same way.
+    pluginResolve(),
     ...onlyWhenTheEngineOwnsTheBuild([
       pluginChunkLoading(),
       pluginCssMinimizer(),
@@ -86,7 +89,6 @@ export function pluginLynx(
       pluginMinify(),
       pluginOptimization(),
       pluginOutput(),
-      pluginResolve(),
       pluginServer(),
       pluginSourcemap(),
       pluginSwc(),

--- a/packages/rspeedy/plugin-lynx/src/index.ts
+++ b/packages/rspeedy/plugin-lynx/src/index.ts
@@ -86,13 +86,15 @@ export function pluginLynx(
     // bundle is lowered to it the same way.
     pluginSwc(),
     pluginTarget(),
+    // What the output may contain — no HTML, no license trailer, `var` in the
+    // bundler runtime — follows from the Lynx runtime, not from the caller.
+    pluginOutput(),
     ...onlyWhenTheEngineOwnsTheBuild([
       pluginChunkLoading(),
       pluginCssMinimizer(),
       pluginDev(),
       pluginMinify(),
       pluginOptimization(),
-      pluginOutput(),
       pluginServer(),
       pluginSourcemap(),
     ]),

--- a/packages/rspeedy/plugin-lynx/src/index.ts
+++ b/packages/rspeedy/plugin-lynx/src/index.ts
@@ -39,6 +39,26 @@ export type {
   LynxPluginOptions,
 } from './config.js'
 
+// `rslib` and `rstest` drive the build themselves: an external bundle is
+// assembled by `@lynx-js/lynx-bundle-rslib-config`, which emits its own
+// `.lynx.bundle`, and a test run emits nothing. They read the config all the
+// same, so it is applied for them, but the plugins below assemble a bundle of
+// their own and would rewrite what those callers emit.
+function onlyWhenTheEngineOwnsTheBuild(
+  plugins: RsbuildPlugin[],
+): RsbuildPlugin[] {
+  return plugins.map(plugin => ({
+    ...plugin,
+    setup(api) {
+      const { callerName } = api.context
+      if (callerName === 'rslib' || callerName === 'rstest') {
+        return
+      }
+      return plugin.setup(api)
+    },
+  }))
+}
+
 /**
  * @public
  */
@@ -53,18 +73,20 @@ export function pluginLynx(
       },
     },
     pluginConfig(options),
-    pluginChunkLoading(),
-    pluginCssMinimizer(),
-    pluginDev(),
-    pluginLynxDebugMetadata(),
-    pluginMinify(),
-    pluginOptimization(),
-    pluginOutput(),
-    pluginResolve(),
-    pluginServer(),
-    pluginSourcemap(),
-    pluginSwc(),
-    pluginTarget(),
-    pluginTemplate(),
+    ...onlyWhenTheEngineOwnsTheBuild([
+      pluginChunkLoading(),
+      pluginCssMinimizer(),
+      pluginDev(),
+      pluginLynxDebugMetadata(),
+      pluginMinify(),
+      pluginOptimization(),
+      pluginOutput(),
+      pluginResolve(),
+      pluginServer(),
+      pluginSourcemap(),
+      pluginSwc(),
+      pluginTarget(),
+      pluginTemplate(),
+    ]),
   ]
 }

--- a/packages/rspeedy/plugin-lynx/src/index.ts
+++ b/packages/rspeedy/plugin-lynx/src/index.ts
@@ -82,6 +82,10 @@ export function pluginLynx(
     // What a module resolves to is a property of the Lynx runtime, not of who
     // assembles the bundle, so an external bundle resolves the same way.
     pluginResolve(),
+    // The ES baseline is what the Lynx runtime can parse, so an external
+    // bundle is lowered to it the same way.
+    pluginSwc(),
+    pluginTarget(),
     ...onlyWhenTheEngineOwnsTheBuild([
       pluginChunkLoading(),
       pluginCssMinimizer(),
@@ -91,8 +95,6 @@ export function pluginLynx(
       pluginOutput(),
       pluginServer(),
       pluginSourcemap(),
-      pluginSwc(),
-      pluginTarget(),
     ]),
   ]
 }

--- a/packages/rspeedy/plugin-lynx/src/index.ts
+++ b/packages/rspeedy/plugin-lynx/src/index.ts
@@ -73,11 +73,16 @@ export function pluginLynx(
       },
     },
     pluginConfig(options),
+    // Exposes the template lifecycle hooks and emits nothing itself, so a
+    // caller that assembles its own bundle can drive the same hooks and get
+    // the plugins that tap them, `pluginLynxDebugMetadata` among them.
+    pluginTemplate(),
+    // Taps the hooks above, so it covers an external bundle as well.
+    pluginLynxDebugMetadata(),
     ...onlyWhenTheEngineOwnsTheBuild([
       pluginChunkLoading(),
       pluginCssMinimizer(),
       pluginDev(),
-      pluginLynxDebugMetadata(),
       pluginMinify(),
       pluginOptimization(),
       pluginOutput(),
@@ -86,7 +91,6 @@ export function pluginLynx(
       pluginSourcemap(),
       pluginSwc(),
       pluginTarget(),
-      pluginTemplate(),
     ]),
   ]
 }

--- a/packages/rspeedy/plugin-lynx/test/index.test.ts
+++ b/packages/rspeedy/plugin-lynx/test/index.test.ts
@@ -22,3 +22,34 @@ describe('pluginLynx', () => {
     await expect(rsbuild.initConfigs()).resolves.toBeDefined()
   })
 })
+
+async function configForRslib() {
+  const rsbuild = await createRsbuild({
+    callerName: 'rslib',
+    cwd: path.dirname(fileURLToPath(import.meta.url)),
+    rsbuildConfig: {
+      mode: 'production',
+      environments: { lynx: {} },
+      plugins: [pluginLynx()],
+    },
+  })
+
+  const [config] = await rsbuild.initConfigs()
+  return config
+}
+
+describe('pluginLynx with a caller that assembles its own bundle', () => {
+  test('resolves a module the way the Lynx runtime needs', async () => {
+    const config = await configForRslib()
+
+    expect(config?.resolve?.conditionNames).toContain('lynx')
+    expect(config?.resolve?.mainFields).toContain('lynx')
+    expect(config?.resolve?.mainFiles).toContain('index.lynx')
+  })
+
+  test('leaves the bundle assembly to the caller', async () => {
+    const config = await configForRslib()
+
+    expect(config?.output?.chunkLoading).toBeUndefined()
+  })
+})

--- a/packages/rspeedy/plugin-lynx/test/index.test.ts
+++ b/packages/rspeedy/plugin-lynx/test/index.test.ts
@@ -23,6 +23,20 @@ describe('pluginLynx', () => {
   })
 })
 
+function swcEnvIncludes(config: unknown): string[] {
+  const includes: string[] = []
+  JSON.stringify(config, (key: string, value: unknown) => {
+    if (key === 'env' && value !== null && typeof value === 'object') {
+      const { include } = value as { include?: unknown }
+      if (Array.isArray(include)) {
+        includes.push(...include.map(String))
+      }
+    }
+    return value
+  })
+  return includes
+}
+
 async function configForRslib() {
   const rsbuild = await createRsbuild({
     callerName: 'rslib',
@@ -45,6 +59,13 @@ describe('pluginLynx with a caller that assembles its own bundle', () => {
     expect(config?.resolve?.conditionNames).toContain('lynx')
     expect(config?.resolve?.mainFields).toContain('lynx')
     expect(config?.resolve?.mainFiles).toContain('index.lynx')
+  })
+
+  test('lowers to the ES baseline the Lynx runtime parses', async () => {
+    const config = await configForRslib()
+
+    expect(config?.target).toContain('es2017')
+    expect(swcEnvIncludes(config)).toContain('transform-block-scoping')
   })
 
   test('leaves the bundle assembly to the caller', async () => {

--- a/packages/rspeedy/plugin-lynx/test/index.test.ts
+++ b/packages/rspeedy/plugin-lynx/test/index.test.ts
@@ -68,6 +68,18 @@ describe('pluginLynx with a caller that assembles its own bundle', () => {
     expect(swcEnvIncludes(config)).toContain('transform-block-scoping')
   })
 
+  test('emits what a Lynx bundle can carry', async () => {
+    const config = await configForRslib()
+
+    // Lynx has no HTML, and a bundle has nowhere to link a license file to.
+    expect(
+      config?.plugins?.some(plugin =>
+        plugin?.constructor.name.includes('Html')
+      ),
+    ).toBe(false)
+    expect(config?.output?.environment?.const).toBe(false)
+  })
+
   test('leaves the bundle assembly to the caller', async () => {
     const config = await configForRslib()
 

--- a/packages/rspeedy/plugin-react/src/autoLynx.ts
+++ b/packages/rspeedy/plugin-react/src/autoLynx.ts
@@ -2,7 +2,11 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
-import type { RsbuildContext, RsbuildPlugin } from '@rsbuild/core'
+import type {
+  RsbuildConfig,
+  RsbuildContext,
+  RsbuildPlugin,
+} from '@rsbuild/core'
 
 import { PLUGIN_LYNX_NAME, pluginLynx } from '@lynx-js/rsbuild-plugin'
 
@@ -11,6 +15,19 @@ import { PLUGIN_LYNX_NAME, pluginLynx } from '@lynx-js/rsbuild-plugin'
 // instead. `Symbol.for` keeps the marker shared with any other copy of this
 // package, and with any other plugin that applies the engine the same way.
 const S_PLUGIN_LYNX_APPLIED = Symbol.for('@lynx-js/rsbuild-plugin:applied')
+
+// Without an environment, `isPluginExists` only reports the global plugins, so
+// an engine registered per environment — which is how `rslib` passes the
+// plugins of a lib entry along — would be applied a second time here.
+function isEngineRegistered(
+  api: Parameters<NonNullable<RsbuildPlugin['setup']>>[0],
+  original: RsbuildConfig,
+): boolean {
+  return api.isPluginExists(PLUGIN_LYNX_NAME)
+    || Object.keys(original.environments ?? {}).some(environment =>
+      api.isPluginExists(PLUGIN_LYNX_NAME, { environment })
+    )
+}
 
 // Rspeedy applies `pluginLynx` itself. With plain Rsbuild nothing does, so the
 // build engine is applied here to keep `pluginReactLynx` the only plugin a user
@@ -27,15 +44,15 @@ export function pluginAutoLynx(): RsbuildPlugin {
         return
       }
 
+      const original = api.getRsbuildConfig('original')
+
       if (
-        api.isPluginExists(PLUGIN_LYNX_NAME)
+        isEngineRegistered(api, original)
         || Object.hasOwn(api.context, S_PLUGIN_LYNX_APPLIED)
       ) {
         return
       }
       Object.defineProperty(api.context, S_PLUGIN_LYNX_APPLIED, { value: true })
-
-      const original = api.getRsbuildConfig('original')
 
       for (const plugin of pluginLynx()) {
         // `setup` is called directly instead of registering the plugins, since

--- a/packages/rspeedy/plugin-react/src/autoLynx.ts
+++ b/packages/rspeedy/plugin-react/src/autoLynx.ts
@@ -36,11 +36,11 @@ export function pluginAutoLynx(): RsbuildPlugin {
   return {
     name: 'lynx:react:auto-lynx',
     async setup(api) {
-      // `rslib` and `rstest` drive the build themselves — an external bundle
-      // assembles its own `.lynx.bundle`, and a test run emits nothing — so
-      // the engine has nothing to add. See the same condition in `applyEntry`.
-      const { callerName } = api.context
-      if (callerName === 'rslib' || callerName === 'rstest') {
+      // A test run emits nothing, so the engine has nothing to add. `rslib`
+      // does emit a bundle and reads the engine config, so the engine is
+      // applied for it; `pluginLynx` leaves out the plugins that would rewrite
+      // what an external bundle assembles itself.
+      if (api.context.callerName === 'rstest') {
         return
       }
 

--- a/packages/rspeedy/plugin-react/src/autoLynx.ts
+++ b/packages/rspeedy/plugin-react/src/autoLynx.ts
@@ -19,8 +19,9 @@ export function pluginAutoLynx(): RsbuildPlugin {
   return {
     name: 'lynx:react:auto-lynx',
     async setup(api) {
-      // The callers that do not emit a Lynx template do not want the engine
-      // either. See the same condition in `applyEntry`.
+      // `rslib` and `rstest` drive the build themselves — an external bundle
+      // assembles its own `.lynx.bundle`, and a test run emits nothing — so
+      // the engine has nothing to add. See the same condition in `applyEntry`.
       const { callerName } = api.context
       if (callerName === 'rslib' || callerName === 'rstest') {
         return

--- a/packages/rspeedy/plugin-react/src/entry.ts
+++ b/packages/rspeedy/plugin-react/src/entry.ts
@@ -79,11 +79,11 @@ export function applyEntry(
       ? api.useExposed<ExposedAPI>(Symbol.for('rspeedy.api'))?.config
       : undefined
 
-    // biome-ignore lint/correctness/useHookAtTopLevel: This is not a React hook.
     const lynxConfig = api.useExposed<LynxConfig>(S_LYNX_CONFIG)
 
-    // `rslib` builds libraries and `rstest` runs tests, neither of which emits
-    // a Lynx template.
+    // `rslib` and `rstest` drive the build themselves — an external bundle
+    // assembles its own `.lynx.bundle`, and a test run emits nothing — so the
+    // template is not assembled here for them.
     const emitTemplate = api.context.callerName !== 'rslib'
       && api.context.callerName !== 'rstest'
     if (emitTemplate) {

--- a/packages/rspeedy/plugin-react/src/entry.ts
+++ b/packages/rspeedy/plugin-react/src/entry.ts
@@ -87,8 +87,8 @@ export function applyEntry(
     const emitTemplate = api.context.callerName !== 'rslib'
       && api.context.callerName !== 'rstest'
     if (emitTemplate) {
-      // `pluginAutoLynx` applies the engine for the same callers, so the config
-      // is there whenever a template is emitted.
+      // `pluginAutoLynx` applies the engine for every caller that assembles a
+      // template here, so the config is there whenever one is emitted.
       if (!lynxConfig) {
         throw new Error(
           'No Lynx config exposed. `pluginLynx` has to be applied for the Lynx build engine to be configured.',

--- a/packages/rspeedy/plugin-react/test/auto-lynx.test.ts
+++ b/packages/rspeedy/plugin-react/test/auto-lynx.test.ts
@@ -77,7 +77,31 @@ describe('pluginAutoLynx', () => {
     expect(include).toStrictEqual([...new Set(include)])
   })
 
-  test('does not apply the engine for the rslib caller', async () => {
+  test('applies the engine for the rslib caller', async () => {
+    const rsbuild = await createRsbuild({
+      callerName: 'rslib',
+      // eslint-disable-next-line n/no-unsupported-features/node-builtins
+      cwd: import.meta.dirname,
+      rsbuildConfig: {
+        mode: 'development',
+        environments: { lynx: {} },
+        source: { entry: { main: './fixtures/basic.tsx' } },
+        plugins: [pluginReactLynx()],
+      },
+    })
+
+    const [config] = await rsbuild.initConfigs()
+
+    // `pluginLynxDebugMetadata` taps the template hooks, which an external
+    // bundle drives itself, so the engine reaches it without assembling one.
+    expect(
+      config?.plugins?.some(plugin =>
+        plugin?.constructor.name === 'LynxDebugMetadataPlugin'
+      ),
+    ).toBe(true)
+  })
+
+  test('leaves out the plugins that assemble a bundle for the rslib caller', async () => {
     const rsbuild = await createRsbuild({
       callerName: 'rslib',
       // eslint-disable-next-line n/no-unsupported-features/node-builtins
@@ -97,6 +121,9 @@ describe('pluginAutoLynx', () => {
         plugin?.constructor.name === 'LynxTemplatePlugin'
       ),
     ).toBe(false)
+    // `pluginChunkLoading` loads a chunk the way a template does, which is not
+    // how an external bundle is consumed.
+    expect(config?.output?.chunkLoading).toBeUndefined()
   })
 
   test('honors the apply condition of the engine plugins', async () => {

--- a/packages/rspeedy/plugin-react/test/auto-lynx.test.ts
+++ b/packages/rspeedy/plugin-react/test/auto-lynx.test.ts
@@ -59,6 +59,24 @@ describe('pluginAutoLynx', () => {
     expect(include).toStrictEqual([...new Set(include)])
   })
 
+  test('does not apply the engine again when it is registered per environment', async () => {
+    const rsbuild = await createRsbuild({
+      // eslint-disable-next-line n/no-unsupported-features/node-builtins
+      cwd: import.meta.dirname,
+      rsbuildConfig: {
+        mode: 'production',
+        environments: { lynx: { plugins: [...pluginLynx()] } },
+        source: { entry: { main: './fixtures/basic.tsx' } },
+        plugins: [pluginReactLynx()],
+      },
+    })
+
+    const [config] = await rsbuild.initConfigs()
+
+    const include = swcInclude(config)
+    expect(include).toStrictEqual([...new Set(include)])
+  })
+
   test('does not apply the engine for the rslib caller', async () => {
     const rsbuild = await createRsbuild({
       callerName: 'rslib',

--- a/packages/webpack/template-webpack-plugin/etc/template-webpack-plugin.api.md
+++ b/packages/webpack/template-webpack-plugin/etc/template-webpack-plugin.api.md
@@ -26,6 +26,16 @@ export const CSSPlugins: {
 };
 
 // @public
+export interface CustomSectionNaming {
+    // (undocumented)
+    background(chunkName: string, index: number): string | undefined;
+    // (undocumented)
+    css(assetName: string, index: number): string | undefined;
+    // (undocumented)
+    mainThread(assetName: string, index: number): string | undefined;
+}
+
+// @public
 export interface EncodeOptions {
     // (undocumented)
     [k: string]: unknown;

--- a/packages/webpack/template-webpack-plugin/src/LynxTemplatePlugin.ts
+++ b/packages/webpack/template-webpack-plugin/src/LynxTemplatePlugin.ts
@@ -513,6 +513,34 @@ interface CustomSectionEntry {
   content: string | Record<string, unknown>;
 }
 
+/**
+ * Names the custom section an asset is emitted as.
+ *
+ * @remarks
+ *
+ * Returning `undefined` keeps the asset out of the custom sections. A
+ * background chunk that is left out stays in the manifest, which is where the
+ * runtime already looks for it.
+ *
+ * @public
+ */
+export interface CustomSectionNaming {
+  mainThread(assetName: string, index: number): string | undefined;
+  background(chunkName: string, index: number): string | undefined;
+  css(assetName: string, index: number): string | undefined;
+}
+
+// A lazy bundle is a single component: the runtime resolves its three sections
+// by the constant names below, and every other background chunk is loaded from
+// the manifest as usual.
+const LAZY_BUNDLE_SECTION_NAMING: CustomSectionNaming = {
+  mainThread: (_assetName, index) =>
+    index === 0 ? SECTION_MAIN_THREAD : undefined,
+  background: (_chunkName, index) =>
+    index === 0 ? SECTION_BACKGROUND : undefined,
+  css: (_assetName, index) => index === 0 ? SECTION_CSS : undefined,
+};
+
 class LynxTemplatePluginImpl {
   name = 'LynxTemplatePlugin';
 
@@ -1104,12 +1132,13 @@ class LynxTemplatePluginImpl {
     const enableLazyBundleBytecode = isFetchBundleLazy && !isDev
       && !isDebug();
     const fetchBundleSplit = isFetchBundleLazy
-      ? this.#buildLazyBundleFetchBundleSections(
-        lepusCode.root,
-        encodeData.manifest,
-        encodeData.css.chunks,
-        enableLazyBundleBytecode,
-      )
+      ? this.#buildCustomSections({
+        mainThreadAssets: lepusCode.root ? [lepusCode.root] : [],
+        manifest: encodeData.manifest,
+        cssAssets: encodeData.css.chunks,
+        enableBytecode: enableLazyBundleBytecode,
+        naming: LAZY_BUNDLE_SECTION_NAMING,
+      })
       : null;
 
     const resolvedEncodeOptions: EncodeOptions = {
@@ -1207,11 +1236,14 @@ class LynxTemplatePluginImpl {
     }
   }
 
-  #buildLazyBundleFetchBundleSections(
-    mainThreadAsset: Asset | undefined,
-    manifest: Record<string, string>,
-    cssAssets: Asset[],
-    enableBytecode: boolean,
+  #buildCustomSections(
+    { mainThreadAssets, manifest, cssAssets, enableBytecode, naming }: {
+      mainThreadAssets: Asset[];
+      manifest: Record<string, string>;
+      cssAssets: Asset[];
+      enableBytecode: boolean;
+      naming: CustomSectionNaming;
+    },
   ): {
     sections: Record<string, CustomSectionEntry>;
     remainingManifest: Record<string, string>;
@@ -1219,42 +1251,47 @@ class LynxTemplatePluginImpl {
     const { cssPlugins, enableCSSSelector } = this.#options;
     const sections: Record<string, CustomSectionEntry> = {};
 
-    if (mainThreadAsset) {
-      sections[SECTION_MAIN_THREAD] = {
+    mainThreadAssets.forEach((asset, index) => {
+      const name = naming.mainThread(asset.name, index);
+      if (name === undefined) {
+        return;
+      }
+      sections[name] = {
         ...(enableBytecode ? { encoding: 'JsBytecode' as const } : {}),
-        content: mainThreadAsset.source.source().toString(),
+        content: asset.source.source().toString(),
       };
-    }
+    });
 
     const remainingManifest: Record<string, string> = {};
-    let entryChunk: [string, string] | undefined;
-    for (const [name, content] of Object.entries(manifest)) {
-      if (name === '/app-service.js') {
+    let backgroundIndex = 0;
+    for (const [chunkName, content] of Object.entries(manifest)) {
+      // The AMD wrapper entry is provided by the runtime, never by a section.
+      if (chunkName === '/app-service.js') {
         continue;
       }
-      if (!entryChunk) {
-        entryChunk = [name, content];
+      const name = naming.background(chunkName, backgroundIndex++);
+      if (name === undefined) {
+        remainingManifest[chunkName] = content;
         continue;
       }
-      remainingManifest[name] = content;
+      sections[name] = { content };
     }
 
-    if (entryChunk) {
-      sections[SECTION_BACKGROUND] = { content: entryChunk[1] };
-    }
-
-    const firstCss = cssAssets[0];
-    if (firstCss) {
+    cssAssets.forEach((asset, index) => {
+      const name = naming.css(asset.name, index);
+      if (name === undefined) {
+        return;
+      }
       const ruleList = cssChunksToMap(
-        [firstCss.source.source().toString()],
+        [asset.source.source().toString()],
         cssPlugins,
         enableCSSSelector,
       ).cssMap[0] ?? [];
-      sections[SECTION_CSS] = {
+      sections[name] = {
         encoding: 'CSS',
         content: { ruleList },
       };
-    }
+    });
 
     return { sections, remainingManifest };
   }

--- a/packages/webpack/template-webpack-plugin/src/index.ts
+++ b/packages/webpack/template-webpack-plugin/src/index.ts
@@ -13,6 +13,7 @@ import * as CSS from '@lynx-js/css-serializer';
 
 export { LynxTemplatePlugin } from './LynxTemplatePlugin.js';
 export type {
+  CustomSectionNaming,
   LynxTemplatePluginOptions,
   TemplateHooks,
   EncodeOptions,

--- a/packages/webpack/template-webpack-plugin/test/lazy-bundle-fetcher.test.ts
+++ b/packages/webpack/template-webpack-plugin/test/lazy-bundle-fetcher.test.ts
@@ -155,4 +155,22 @@ describe('LynxTemplatePlugin: FetchBundle main-thread bytecode encoding', () => 
     process.env['DEBUG'] = 'unrelated';
     expect(await runAndGetMtEncoding('production')).toBe('JsBytecode');
   });
+
+  test('names the sections the runtime resolves', async () => {
+    const { captured, plugin } = captureBeforeEmit();
+    await runWebpack(buildConfig(plugin, 'production'));
+    const lazy = captured.find((c) => c.outputName.startsWith('lazy-bundle/'));
+
+    // The fixture has no CSS, so only the two JS sections are emitted.
+    expect(Object.keys(lazy?.customSections ?? {}).sort()).toEqual([
+      'background',
+      'main-thread',
+    ]);
+    expect(lazy?.customSections['background']?.content).toEqual(
+      expect.any(String),
+    );
+    expect(lazy?.customSections['main-thread']?.content).toEqual(
+      expect.any(String),
+    );
+  });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -544,6 +544,9 @@ importers:
       '@lynx-js/react-rsbuild-plugin':
         specifier: workspace:*
         version: link:../../packages/rspeedy/plugin-react
+      '@lynx-js/rsbuild-plugin':
+        specifier: workspace:*
+        version: link:../../packages/rspeedy/plugin-lynx
       '@lynx-js/rspeedy':
         specifier: workspace:*
         version: link:../../packages/rspeedy/core
@@ -1680,6 +1683,9 @@ importers:
       '@lynx-js/rsbuild-plugin':
         specifier: workspace:*
         version: link:../plugin-lynx
+      '@lynx-js/template-webpack-plugin':
+        specifier: workspace:*
+        version: link:../../webpack/template-webpack-plugin
       '@lynx-js/test-tools':
         specifier: workspace:*
         version: link:../../webpack/test-tools

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1677,6 +1677,9 @@ importers:
       '@lynx-js/react-rsbuild-plugin':
         specifier: workspace:*
         version: link:../plugin-react
+      '@lynx-js/rsbuild-plugin':
+        specifier: workspace:*
+        version: link:../plugin-lynx
       '@lynx-js/test-tools':
         specifier: workspace:*
         version: link:../../webpack/test-tools


### PR DESCRIPTION
`pluginOutput` sat behind the caller gate, so an external bundle was built with the Rsbuild HTML plugin registered, with a `.LICENSE.txt` trailer it has nowhere to link to, and with `const`/`let` in the bundler runtime that QuickJS parses slower than `var`.

What the output may contain follows from the Lynx runtime rather than from who assembles the bundle, so apply it for every caller.

Two consequences:

- `HtmlRspackPlugin` and `RsbuildHtmlPlugin` are no longer registered, and the `.LICENSE.txt` files are gone from the fixture output.
- The engine emits CSS into a directory of its own (`[name]/[name].css`), which used to leak into the section name as `index/index:CSS`. A section is now named after the file rather than the path leading to it, and the sorted section order shifts accordingly.