### PR TITLE
feat(rsbuild-plugin): minify an external bundle with the engine options

### DIFF
--- a/.changeset/rslib-engine-minify.md
+++ b/.changeset/rslib-engine-minify.md
@@ -1,0 +1,6 @@
+---
+"@lynx-js/rsbuild-plugin": minor
+"@lynx-js/lynx-bundle-rslib-config": minor
+---
+
+Minify an external bundle with the engine options instead of a copy of them.

--- a/packages/rspeedy/lynx-bundle-rslib-config/src/externalBundleRslibConfig.ts
+++ b/packages/rspeedy/lynx-bundle-rslib-config/src/externalBundleRslibConfig.ts
@@ -56,38 +56,6 @@ export interface EncodeOptions {
   enableJsBytecode?: boolean
 }
 
-// When preact devtools is enabled (`REACT_DEVTOOL`), keep function and class
-// names. Devtools relies on them to resolve component names (`type.name`) and
-// to reconstruct the hook tree (it matches minified stack frames by function
-// name). Minification would otherwise mangle/inline those names away. Only
-// enabled with devtools since it slightly increases bundle size. Mirrors
-// `pluginMinify` in @lynx-js/rspeedy (lynx-family/lynx-stack#2880).
-const keepNames = Boolean(process.env['REACT_DEVTOOL'])
-
-const DEFAULT_EXTERNAL_BUNDLE_MINIFY_CONFIG = {
-  jsOptions: {
-    minimizerOptions: {
-      compress: {
-        /**
-         * the module wrapper iife need to be kept to provide the return value
-         * for the module loader in lynx_core.js
-         */
-        negate_iife: false,
-        // Allow return in module wrapper
-        side_effects: false,
-
-        // `mangle.keep_*` below preserves most names, but the compressor can
-        // still inline single-use functions (incl. one-shot components) into
-        // anonymity; `compress.keep_*` stops that. Cheap, so we keep both.
-        ...(keepNames ? { keep_fnames: true, keep_classnames: true } : {}),
-      },
-      ...(keepNames
-        ? { mangle: { keep_fnames: true, keep_classnames: true } }
-        : {}),
-    },
-  },
-}
-
 /**
  * The default lib config{@link LibConfig} for external bundle.
  *
@@ -107,9 +75,10 @@ export const DEFAULT_EXTERNAL_BUNDLE_LIB_CONFIG: LibConfig = {
       dependencies: false,
       peerDependencies: false,
     },
-    minify: process.env['NODE_ENV'] === 'development'
-      ? false
-      : DEFAULT_EXTERNAL_BUNDLE_MINIFY_CONFIG,
+    // `rslib build` always compiles with rspack mode `production`, so the
+    // development signal here is `NODE_ENV`. What minification may do is
+    // `pluginLynx`'s to say.
+    minify: process.env['NODE_ENV'] !== 'development',
     target: 'web',
     dataUriLimit: Number.POSITIVE_INFINITY,
     distPath: {
@@ -571,10 +540,6 @@ export function defineExternalBundleRslibConfig(
   userLibConfig: ExternalBundleLibConfig,
   encodeOptions: EncodeOptions = {},
 ): RslibConfig {
-  const normalizedOutputMinify = userLibConfig.output?.minify === true
-    ? DEFAULT_EXTERNAL_BUNDLE_MINIFY_CONFIG
-    : userLibConfig.output?.minify
-
   return {
     lib: [
       rsbuild.mergeRsbuildConfig<LibConfig>(
@@ -583,7 +548,6 @@ export function defineExternalBundleRslibConfig(
           ...userLibConfig,
           output: {
             ...userLibConfig.output,
-            minify: normalizedOutputMinify,
             externals: transformExternals(
               userLibConfig.output?.externalsPresets,
               userLibConfig.output?.externals,

--- a/packages/rspeedy/lynx-bundle-rslib-config/test/external-bundle.test.ts
+++ b/packages/rspeedy/lynx-bundle-rslib-config/test/external-bundle.test.ts
@@ -9,15 +9,7 @@ import { fileURLToPath } from 'node:url'
 
 import { createRslib } from '@rslib/core'
 import type { RslibConfig, rsbuild } from '@rslib/core'
-import {
-  afterAll,
-  afterEach,
-  beforeAll,
-  describe,
-  expect,
-  it,
-  rstest,
-} from '@rstest/core'
+import { afterAll, beforeAll, describe, expect, it, rstest } from '@rstest/core'
 
 import { LAYERS, pluginReactLynx } from '@lynx-js/react-rsbuild-plugin'
 import { pluginLynx } from '@lynx-js/rsbuild-plugin'
@@ -86,77 +78,12 @@ describe('define config', () => {
     expect(rslibConfig.lib[0]?.syntax).toBe('es2019')
   })
 
-  it('should preserve default minify jsOptions when output.minify is true', () => {
-    const rslibConfig = defineExternalBundleRslibConfig({
-      output: {
-        minify: true,
-      },
-    })
+  it('leaves the minify options to the engine', () => {
+    const rslibConfig = defineExternalBundleRslibConfig({})
 
-    expect(rslibConfig.lib[0]?.output?.minify).toMatchObject({
-      jsOptions: {
-        minimizerOptions: {
-          compress: {
-            negate_iife: false,
-            side_effects: false,
-          },
-        },
-      },
-    })
-  })
-})
-
-describe('REACT_DEVTOOL minify', () => {
-  const prevReactDevtool = process.env['REACT_DEVTOOL']
-
-  afterEach(() => {
-    if (prevReactDevtool === undefined) {
-      delete process.env['REACT_DEVTOOL']
-    } else {
-      process.env['REACT_DEVTOOL'] = prevReactDevtool
-    }
-    rstest.resetModules()
-  })
-
-  it('keeps function and class names when REACT_DEVTOOL is set', async () => {
-    process.env['REACT_DEVTOOL'] = '1'
-    rstest.resetModules()
-    const { defineExternalBundleRslibConfig } = await import('../src/index.js')
-
-    const rslibConfig = defineExternalBundleRslibConfig({
-      output: { minify: true },
-    })
-
-    expect(rslibConfig.lib[0]?.output?.minify).toMatchObject({
-      jsOptions: {
-        minimizerOptions: {
-          compress: { keep_fnames: true, keep_classnames: true },
-          mangle: { keep_fnames: true, keep_classnames: true },
-        },
-      },
-    })
-  })
-
-  it('does not keep names when REACT_DEVTOOL is unset', async () => {
-    delete process.env['REACT_DEVTOOL']
-    rstest.resetModules()
-    const { defineExternalBundleRslibConfig } = await import('../src/index.js')
-
-    const rslibConfig = defineExternalBundleRslibConfig({
-      output: { minify: true },
-    })
-
-    const minify = rslibConfig.lib[0]?.output?.minify as {
-      jsOptions?: {
-        minimizerOptions?: {
-          compress?: { keep_fnames?: boolean }
-          mangle?: unknown
-        }
-      }
-    }
-    expect(minify.jsOptions?.minimizerOptions?.compress?.keep_fnames)
-      .toBeUndefined()
-    expect(minify.jsOptions?.minimizerOptions?.mangle).toBeUndefined()
+    // `pluginLynx` supplies them, so only whether to minify at all is decided
+    // here.
+    expect(rslibConfig.lib[0]?.output?.minify).toBe(true)
   })
 })
 

--- a/packages/rspeedy/plugin-lynx/src/index.ts
+++ b/packages/rspeedy/plugin-lynx/src/index.ts
@@ -89,11 +89,13 @@ export function pluginLynx(
     // What the output may contain — no HTML, no license trailer, `var` in the
     // bundler runtime — follows from the Lynx runtime, not from the caller.
     pluginOutput(),
+    // How far the output may be compressed is a property of the Lynx runtime
+    // too: the module wrapper has to keep its IIFE and its return.
+    pluginMinify(),
     ...onlyWhenTheEngineOwnsTheBuild([
       pluginChunkLoading(),
       pluginCssMinimizer(),
       pluginDev(),
-      pluginMinify(),
       pluginOptimization(),
       pluginServer(),
       pluginSourcemap(),

--- a/packages/rspeedy/plugin-lynx/test/minify.plugin.test.ts
+++ b/packages/rspeedy/plugin-lynx/test/minify.plugin.test.ts
@@ -2,7 +2,7 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 import type { RsbuildConfig, Rspack } from '@rsbuild/core'
-import { describe, expect, test } from '@rstest/core'
+import { describe, expect, rstest, test } from '@rstest/core'
 
 import { createStubRsbuild } from './createStubRsbuild.js'
 
@@ -42,6 +42,39 @@ describe('pluginMinify', () => {
       keep_quoted_props: true,
       comments: false,
     })
+  })
+
+  test('keeps function and class names when REACT_DEVTOOL is set', async () => {
+    rstest.stubEnv('REACT_DEVTOOL', '1')
+    try {
+      const rsbuild = await createStubRsbuild({ mode: 'production' })
+      const config = await rsbuild.unwrapConfig({ action: 'build' })
+
+      const options = findJsMinimizers(config)[0]?._args[0]?.minimizerOptions
+
+      // Devtools resolves component names from `type.name` and matches
+      // minified stack frames by function name.
+      expect(options?.compress).toMatchObject({
+        keep_fnames: true,
+        keep_classnames: true,
+      })
+      expect(options?.mangle).toMatchObject({
+        keep_fnames: true,
+        keep_classnames: true,
+      })
+    } finally {
+      rstest.unstubAllEnvs()
+    }
+  })
+
+  test('does not keep names when REACT_DEVTOOL is unset', async () => {
+    const rsbuild = await createStubRsbuild({ mode: 'production' })
+    const config = await rsbuild.unwrapConfig({ action: 'build' })
+
+    const options = findJsMinimizers(config)[0]?._args[0]?.minimizerOptions
+
+    expect(options?.compress).not.toHaveProperty('keep_fnames')
+    expect(options?.mangle).not.toHaveProperty('keep_fnames')
   })
 
   test('output.minify: false disables minification', async () => {


### PR DESCRIPTION
`@lynx-js/lynx-bundle-rslib-config` carried its own minify defaults, down to the same `negate_iife: false` and `side_effects: false` that keep the module wrapper callable from `lynx_core.js` — its comment said as much, that it mirrors `pluginMinify`. The copy was a subset: an external bundle missed `join_vars`, `ecma`, `inline`, `comparisons`, `toplevel`, the `format` options and the whole CSS minifier config a template build gets.

Apply `pluginMinify` for every caller and drop the copy. Only whether to minify at all is still decided by the rslib config, since `rslib build` always compiles with rspack mode `production` and the development signal is `NODE_ENV`.

The `REACT_DEVTOOL` coverage moves to `pluginMinify`, which had none of its own.