### PR TITLE
feat(rsbuild-plugin): minify the CSS and emit the source maps of an external bundle

### DIFF
--- a/.changeset/rslib-engine-artifact.md
+++ b/.changeset/rslib-engine-artifact.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/rsbuild-plugin": minor
+---
+
+Minify the CSS of an external bundle and emit its source maps.

--- a/packages/rspeedy/plugin-lynx/src/index.ts
+++ b/packages/rspeedy/plugin-lynx/src/index.ts
@@ -39,12 +39,12 @@ export type {
   LynxPluginOptions,
 } from './config.js'
 
-// `rslib` and `rstest` drive the build themselves: an external bundle is
-// assembled by `@lynx-js/lynx-bundle-rslib-config`, which emits its own
-// `.lynx.bundle`, and a test run emits nothing. They read the config all the
-// same, so it is applied for them, but the plugins below assemble a bundle of
-// their own and would rewrite what those callers emit.
-function onlyWhenTheEngineOwnsTheBuild(
+// What the engine puts in a bundle applies wherever it is assembled. How a
+// bundle is loaded and served does not: an external bundle is loaded by
+// `lynx_core.js` as sections of the template that embeds it, and a test run
+// loads nothing. `rslib` and `rstest` are the callers that assemble their own,
+// so the plugins below would describe a way of loading that is not theirs.
+function onlyWhenTheEngineLoadsTheBundle(
   plugins: RsbuildPlugin[],
 ): RsbuildPlugin[] {
   return plugins.map(plugin => ({
@@ -92,13 +92,16 @@ export function pluginLynx(
     // How far the output may be compressed is a property of the Lynx runtime
     // too: the module wrapper has to keep its IIFE and its return.
     pluginMinify(),
-    ...onlyWhenTheEngineOwnsTheBuild([
+    // The CSS minimizer is what makes the CSS options above take effect, and
+    // the source maps are the other half of what `pluginLynxDebugMetadata`
+    // collects, so both follow the bundle wherever it is assembled.
+    pluginCssMinimizer(),
+    pluginSourcemap(),
+    ...onlyWhenTheEngineLoadsTheBundle([
       pluginChunkLoading(),
-      pluginCssMinimizer(),
       pluginDev(),
       pluginOptimization(),
       pluginServer(),
-      pluginSourcemap(),
     ]),
   ]
 }

--- a/packages/rspeedy/plugin-lynx/test/index.test.ts
+++ b/packages/rspeedy/plugin-lynx/test/index.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 import { createRsbuild } from '@rsbuild/core'
+import type { RsbuildConfig, Rspack } from '@rsbuild/core'
 import { describe, expect, test } from '@rstest/core'
 
 import { pluginLynx } from '../src/index.js'
@@ -37,19 +38,24 @@ function swcEnvIncludes(config: unknown): string[] {
   return includes
 }
 
-async function configForRslib() {
+async function configForRslib(output: RsbuildConfig['output'] = {}) {
   const rsbuild = await createRsbuild({
     callerName: 'rslib',
     cwd: path.dirname(fileURLToPath(import.meta.url)),
     rsbuildConfig: {
       mode: 'production',
       environments: { lynx: {} },
+      output,
       plugins: [pluginLynx()],
     },
   })
 
   const [config] = await rsbuild.initConfigs()
   return config
+}
+
+function pluginNames(config: Rspack.Configuration | undefined): string[] {
+  return (config?.plugins ?? []).map(plugin => plugin?.constructor.name ?? '')
 }
 
 describe('pluginLynx with a caller that assembles its own bundle', () => {
@@ -80,7 +86,24 @@ describe('pluginLynx with a caller that assembles its own bundle', () => {
     expect(config?.output?.environment?.const).toBe(false)
   })
 
-  test('leaves the bundle assembly to the caller', async () => {
+  test('minifies the CSS it encodes', async () => {
+    const config = await configForRslib()
+
+    expect(
+      (config?.optimization?.minimizer ?? []).map(minimizer =>
+        (minimizer as { constructor?: { name?: string } })?.constructor?.name
+      ),
+    ).toContain('CssMinimizerPlugin')
+  })
+
+  test('emits the source maps the debug metadata is collected from', async () => {
+    const config = await configForRslib({ sourceMap: true })
+
+    expect(pluginNames(config)).toContain('SourceMapDevToolPlugin')
+    expect(pluginNames(config)).toContain('DropSourceMapAssetsPlugin')
+  })
+
+  test('leaves loading the bundle to the caller', async () => {
     const config = await configForRslib()
 
     expect(config?.output?.chunkLoading).toBeUndefined()


### PR DESCRIPTION
`pluginMinify` brought the Lynx CSS minifier options along, but the minimizer that reads them stayed behind the caller gate, so they were dead config for an external bundle. `pluginLynxDebugMetadata` likewise collects source maps that `pluginSourcemap` was not there to produce.

Apply both for every caller. What is left behind the gate — `pluginChunkLoading`, `pluginDev`, `pluginOptimization`, `pluginServer` — describes how a bundle is loaded and served, which an external bundle does not do for itself: it is loaded by `lynx_core.js` as sections of the template that embeds it. The gate is named for that now.

I measured the four that stay gated: applying them changes nothing in the `utils-lib` bundle and two bytes in the `css-lib` main-thread section. I could not attribute those two bytes to a specific plugin, and `pluginOptimization`'s `avoidEntryIife` reads as a direct conflict with the `negate_iife: false` that keeps the module wrapper callable, so I left them where they are rather than claim they are safe.