### PR TITLE
refactor(lynx-bundle-rslib-config): assemble the sections with the shared builder

### DIFF
--- a/.changeset/external-bundle-custom-sections.md
+++ b/.changeset/external-bundle-custom-sections.md
@@ -1,0 +1,6 @@
+---
+"@lynx-js/template-webpack-plugin": minor
+"@lynx-js/lynx-bundle-rslib-config": patch
+---
+
+Export `buildCustomSections` and assemble an external bundle with it, so it shares the template path instead of a copy.

--- a/packages/rspeedy/lynx-bundle-rslib-config/etc/lynx-bundle-rslib-config.api.md
+++ b/packages/rspeedy/lynx-bundle-rslib-config/etc/lynx-bundle-rslib-config.api.md
@@ -50,7 +50,6 @@ export interface ExternalBundleWebpackPluginOptions {
         buffer: Buffer;
     }>;
     engineVersion?: string | undefined;
-    // Warning: (ae-forgotten-export) The symbol "LynxTemplatePluginHooksProvider" needs to be exported by the entry point index.d.ts
     LynxTemplatePlugin?: LynxTemplatePluginHooksProvider | undefined;
     mainThreadChunks?: string[] | undefined;
 }
@@ -82,6 +81,12 @@ export type ExternalsPresets = {
 export type ExternalsPresetValue = boolean | {
     async?: boolean;
 };
+
+// @public
+export interface LynxTemplatePluginHooksProvider {
+    // (undocumented)
+    getLynxTemplatePluginHooks: typeof LynxTemplatePlugin.getLynxTemplatePluginHooks;
+}
 
 // @public
 export class MainThreadRuntimeWrapperWebpackPlugin {

--- a/packages/rspeedy/lynx-bundle-rslib-config/src/index.ts
+++ b/packages/rspeedy/lynx-bundle-rslib-config/src/index.ts
@@ -25,6 +25,9 @@ export type {
   OutputConfig,
 } from './externalBundleRslibConfig.js'
 export { ExternalBundleWebpackPlugin } from './webpack/ExternalBundleWebpackPlugin.js'
-export type { ExternalBundleWebpackPluginOptions } from './webpack/ExternalBundleWebpackPlugin.js'
+export type {
+  ExternalBundleWebpackPluginOptions,
+  LynxTemplatePluginHooksProvider,
+} from './webpack/ExternalBundleWebpackPlugin.js'
 export { MainThreadRuntimeWrapperWebpackPlugin } from './webpack/MainThreadRuntimeWrapperWebpackPlugin.js'
 export type { MainThreadRuntimeWrapperWebpackPluginOptions } from './webpack/MainThreadRuntimeWrapperWebpackPlugin.js'

--- a/packages/rspeedy/lynx-bundle-rslib-config/src/webpack/ExternalBundleWebpackPlugin.ts
+++ b/packages/rspeedy/lynx-bundle-rslib-config/src/webpack/ExternalBundleWebpackPlugin.ts
@@ -3,12 +3,23 @@
 // LICENSE file in the root directory of this source tree.
 import type { Rspack } from '@rslib/core'
 
-import { cssChunksToMap } from '@lynx-js/css-serializer'
-import type { LynxStyleNode } from '@lynx-js/css-serializer'
-import type { LynxTemplatePlugin } from '@lynx-js/template-webpack-plugin'
+import { buildCustomSections } from '@lynx-js/template-webpack-plugin'
+import type {
+  CustomSectionNaming,
+  LynxTemplatePlugin,
+} from '@lynx-js/template-webpack-plugin'
 
 function sectionName(assetName: string, extension: string): string {
   return assetName.slice(assetName.lastIndexOf('/') + 1, -extension.length)
+}
+
+// A section is named after the entry it belongs to. The engine emits CSS into
+// a directory of its own, so the name is taken from the file rather than from
+// the path leading to it.
+const EXTERNAL_BUNDLE_SECTION_NAMING: CustomSectionNaming = {
+  mainThread: assetName => sectionName(assetName, '.js'),
+  background: chunkName => sectionName(chunkName, '.js'),
+  css: assetName => `${sectionName(assetName, '.css')}:CSS`,
 }
 
 /**
@@ -205,52 +216,28 @@ export class ExternalBundleWebpackPlugin {
       >
       | undefined,
   ) {
-    const customSections = assets
-      .reduce<
-        Record<string, {
-          content: string | {
-            ruleList: LynxStyleNode[]
-          }
-        }>
-      >(
-        (prev, cur) => {
-          switch (cur.info.assetType) {
-            case 'javascript':
-              return ({
-                ...prev,
-                [sectionName(cur.name, '.js')]: {
-                  ...(enableJsBytecode
-                      && this.options.mainThreadChunks?.includes(cur.name)
-                    ? {
-                      'encoding': 'JsBytecode',
-                    }
-                    : {}),
-                  content: cur.source.source().toString(),
-                },
-              })
-            case 'extract-css':
-              return ({
-                ...prev,
-                // A section is named after the entry it belongs to. The engine
-                // emits CSS into a directory of its own, so the name is taken
-                // from the file rather than from the path leading to it.
-                [`${sectionName(cur.name, '.css')}:CSS`]: {
-                  'encoding': 'CSS',
-                  content: {
-                    ruleList: cssChunksToMap(
-                      [cur.source.source().toString()],
-                      [],
-                      true,
-                    ).cssMap[0] ?? [],
-                  },
-                },
-              })
-            default:
-              return prev
-          }
-        },
-        {},
-      )
+    const javascript = assets.filter(asset =>
+      asset.info.assetType === 'javascript'
+    )
+    const mainThreadChunks = this.options.mainThreadChunks ?? []
+
+    // Every chunk of an external bundle is a section: there is no manifest for
+    // the runtime to fall back to, so none of them is left unnamed.
+    const { sections: customSections } = buildCustomSections({
+      mainThreadAssets: javascript.filter(asset =>
+        mainThreadChunks.includes(asset.name)
+      ),
+      manifest: Object.fromEntries(
+        javascript
+          .filter(asset => !mainThreadChunks.includes(asset.name))
+          .map(asset => [asset.name, asset.source.source().toString()]),
+      ),
+      cssAssets: assets.filter(asset => asset.info.assetType === 'extract-css'),
+      enableBytecode: enableJsBytecode,
+      naming: EXTERNAL_BUNDLE_SECTION_NAMING,
+      cssPlugins: [],
+      enableCSSSelector: true,
+    })
 
     const compilerOptions: Record<string, unknown> = {
       enableFiberArch: true,

--- a/packages/webpack/template-webpack-plugin/etc/template-webpack-plugin.api.md
+++ b/packages/webpack/template-webpack-plugin/etc/template-webpack-plugin.api.md
@@ -16,6 +16,20 @@ import { Plugins } from '@lynx-js/css-serializer';
 import { SyncWaterfallHook } from '@rspack/lite-tapable';
 import Tinypool from 'tinypool';
 
+// @public
+export function buildCustomSections(input: {
+    mainThreadAssets: Asset[];
+    manifest: Record<string, string>;
+    cssAssets: Asset[];
+    enableBytecode: boolean;
+    naming: CustomSectionNaming;
+    cssPlugins: CSS.Plugin[];
+    enableCSSSelector: boolean;
+}): {
+    sections: Record<string, CustomSectionEntry>;
+    remainingManifest: Record<string, string>;
+};
+
 export { CSS }
 
 // Warning: (ae-missing-release-tag) "CSSPlugins" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -24,6 +38,16 @@ export { CSS }
 export const CSSPlugins: {
     parserPlugins: typeof Plugins;
 };
+
+// @public
+export interface CustomSectionEntry {
+    // (undocumented)
+    content: string | Record<string, unknown>;
+    // (undocumented)
+    encoding?: 'JsBytecode' | 'CSS';
+    // (undocumented)
+    type?: 'lazy';
+}
 
 // @public
 export interface CustomSectionNaming {

--- a/packages/webpack/template-webpack-plugin/src/LynxTemplatePlugin.ts
+++ b/packages/webpack/template-webpack-plugin/src/LynxTemplatePlugin.ts
@@ -507,7 +507,12 @@ const SECTION_MAIN_THREAD = 'main-thread';
 const SECTION_BACKGROUND = 'background';
 const SECTION_CSS = 'CSS';
 
-interface CustomSectionEntry {
+/**
+ * One custom section of a Lynx bundle.
+ *
+ * @public
+ */
+export interface CustomSectionEntry {
   type?: 'lazy';
   encoding?: 'JsBytecode' | 'CSS';
   content: string | Record<string, unknown>;
@@ -528,6 +533,87 @@ export interface CustomSectionNaming {
   mainThread(assetName: string, index: number): string | undefined;
   background(chunkName: string, index: number): string | undefined;
   css(assetName: string, index: number): string | undefined;
+}
+
+/**
+ * Assemble the custom sections of a Lynx bundle.
+ *
+ * @remarks
+ *
+ * A chunk that {@link CustomSectionNaming} leaves unnamed stays in
+ * `remainingManifest`, which is where the runtime already looks for it.
+ *
+ * @param options - The chunks to assemble and how to name them.
+ *
+ * @public
+ */
+export function buildCustomSections(
+  {
+    mainThreadAssets,
+    manifest,
+    cssAssets,
+    enableBytecode,
+    naming,
+    cssPlugins,
+    enableCSSSelector,
+  }: {
+    mainThreadAssets: Asset[];
+    manifest: Record<string, string>;
+    cssAssets: Asset[];
+    enableBytecode: boolean;
+    naming: CustomSectionNaming;
+    cssPlugins: CSS.Plugin[];
+    enableCSSSelector: boolean;
+  },
+): {
+  sections: Record<string, CustomSectionEntry>;
+  remainingManifest: Record<string, string>;
+} {
+  const sections: Record<string, CustomSectionEntry> = {};
+
+  mainThreadAssets.forEach((asset, index) => {
+    const name = naming.mainThread(asset.name, index);
+    if (name === undefined) {
+      return;
+    }
+    sections[name] = {
+      ...(enableBytecode ? { encoding: 'JsBytecode' as const } : {}),
+      content: asset.source.source().toString(),
+    };
+  });
+
+  const remainingManifest: Record<string, string> = {};
+  let backgroundIndex = 0;
+  for (const [chunkName, content] of Object.entries(manifest)) {
+    // The AMD wrapper entry is provided by the runtime, never by a section.
+    if (chunkName === '/app-service.js') {
+      continue;
+    }
+    const name = naming.background(chunkName, backgroundIndex++);
+    if (name === undefined) {
+      remainingManifest[chunkName] = content;
+      continue;
+    }
+    sections[name] = { content };
+  }
+
+  cssAssets.forEach((asset, index) => {
+    const name = naming.css(asset.name, index);
+    if (name === undefined) {
+      return;
+    }
+    const ruleList = cssChunksToMap(
+      [asset.source.source().toString()],
+      cssPlugins,
+      enableCSSSelector,
+    ).cssMap[0] ?? [];
+    sections[name] = {
+      encoding: 'CSS',
+      content: { ruleList },
+    };
+  });
+
+  return { sections, remainingManifest };
 }
 
 // A lazy bundle is a single component: the runtime resolves its three sections
@@ -1132,12 +1218,14 @@ class LynxTemplatePluginImpl {
     const enableLazyBundleBytecode = isFetchBundleLazy && !isDev
       && !isDebug();
     const fetchBundleSplit = isFetchBundleLazy
-      ? this.#buildCustomSections({
+      ? buildCustomSections({
         mainThreadAssets: lepusCode.root ? [lepusCode.root] : [],
         manifest: encodeData.manifest,
         cssAssets: encodeData.css.chunks,
         enableBytecode: enableLazyBundleBytecode,
         naming: LAZY_BUNDLE_SECTION_NAMING,
+        cssPlugins: this.#options.cssPlugins,
+        enableCSSSelector: this.#options.enableCSSSelector,
       })
       : null;
 
@@ -1234,66 +1322,6 @@ class LynxTemplatePluginImpl {
         compilation.errors.push(error as Error);
       }
     }
-  }
-
-  #buildCustomSections(
-    { mainThreadAssets, manifest, cssAssets, enableBytecode, naming }: {
-      mainThreadAssets: Asset[];
-      manifest: Record<string, string>;
-      cssAssets: Asset[];
-      enableBytecode: boolean;
-      naming: CustomSectionNaming;
-    },
-  ): {
-    sections: Record<string, CustomSectionEntry>;
-    remainingManifest: Record<string, string>;
-  } {
-    const { cssPlugins, enableCSSSelector } = this.#options;
-    const sections: Record<string, CustomSectionEntry> = {};
-
-    mainThreadAssets.forEach((asset, index) => {
-      const name = naming.mainThread(asset.name, index);
-      if (name === undefined) {
-        return;
-      }
-      sections[name] = {
-        ...(enableBytecode ? { encoding: 'JsBytecode' as const } : {}),
-        content: asset.source.source().toString(),
-      };
-    });
-
-    const remainingManifest: Record<string, string> = {};
-    let backgroundIndex = 0;
-    for (const [chunkName, content] of Object.entries(manifest)) {
-      // The AMD wrapper entry is provided by the runtime, never by a section.
-      if (chunkName === '/app-service.js') {
-        continue;
-      }
-      const name = naming.background(chunkName, backgroundIndex++);
-      if (name === undefined) {
-        remainingManifest[chunkName] = content;
-        continue;
-      }
-      sections[name] = { content };
-    }
-
-    cssAssets.forEach((asset, index) => {
-      const name = naming.css(asset.name, index);
-      if (name === undefined) {
-        return;
-      }
-      const ruleList = cssChunksToMap(
-        [asset.source.source().toString()],
-        cssPlugins,
-        enableCSSSelector,
-      ).cssMap[0] ?? [];
-      sections[name] = {
-        encoding: 'CSS',
-        content: { ruleList },
-      };
-    });
-
-    return { sections, remainingManifest };
   }
 
   /**

--- a/packages/webpack/template-webpack-plugin/src/index.ts
+++ b/packages/webpack/template-webpack-plugin/src/index.ts
@@ -11,8 +11,12 @@
 import { Plugins } from '@lynx-js/css-serializer';
 import * as CSS from '@lynx-js/css-serializer';
 
-export { LynxTemplatePlugin } from './LynxTemplatePlugin.js';
+export {
+  buildCustomSections,
+  LynxTemplatePlugin,
+} from './LynxTemplatePlugin.js';
 export type {
+  CustomSectionEntry,
   CustomSectionNaming,
   LynxTemplatePluginOptions,
   TemplateHooks,


### PR DESCRIPTION
`ExternalBundleWebpackPlugin` built its custom sections by hand, repeating the CSS rule-list conversion and the `JsBytecode` encoding that `LynxTemplatePlugin` already does. The generalization in #3692 that made the template side pluggable stopped at an interface no other caller used.

Export `buildCustomSections` and drive it from both, with a naming strategy for the external bundle that keys the sections off the entry names. `CustomSectionEntry` is exported with it, which also clears an `ae-forgotten-export` warning from the API report.

The section order shifts with the change (the template side groups by role rather than by asset), so the test that locks the order is updated. It stays deterministic.