### PR TITLE
ci: check peer dependency ranges against the whole release plan

### DIFF
--- a/.github/changeset-ci.instructions.md
+++ b/.github/changeset-ci.instructions.md
@@ -2,11 +2,15 @@
 applyTo: "{.github/workflows/**,.github/scripts/**}"
 ---
 
-When validating changesets in CI, use `pnpm changeset status --since=origin/main --output <file>` and consume the JSON in a script for stable checks (for example, blocking `major` bumps) instead of parsing CLI text output.
+CI works from two release plans, because the checks ask two different questions.
 
-Changesets CLI v3 resolves `config.baseBranch` as a local Git ref when `status` is run without `--since`. Pull request checkouts are detached and may only have `origin/main`, so pass `--since=origin/main` explicitly in PR workflows; keep the default all-changesets behavior in release workflows that run from a checked-out local `main` branch.
+`pnpm changeset status --since=origin/main --output <file>` answers what the pull request itself introduces. Use it for checks about the branch: blocking `major` bumps, validating the Markdown of the changesets it adds, and pairing dependency changes with a changeset. It also fails when a change has no changeset at all, and that detection is what needs a Git ref — without `--since` it falls back to `config.baseBranch` as a local ref, which a detached pull request checkout may not have.
 
-When validating changeset Markdown files in CI, run `node .github/scripts/check-no-heading-changeset.cjs .changeset-status.json` so the script resolves files from `changeset status` output, and fail the job if any listed changeset file contains H1 (`#`), H2 (`##`) or H3 (`###`) headings.
+`pnpm changeset status --output <file>` without `--since` answers what the next release publishes, because it assembles the plan from every changeset in `.changeset`. Use it for checks about the released versions, such as the peer dependency range check. It resolves `config.baseBranch` as a local Git ref, which a detached pull request checkout does not have, so point one at the base first with `git branch -f main origin/main`.
+
+Do not answer the second question with the first plan. `--since` scopes it to the changesets added since the ref, so a package another branch already queued for a release is planned at its current version rather than the one it will be published at, and a range check reads violations the release does not have. Do not answer the first question with the second plan either: it carries the changesets of every merged branch, so a pull request would be blocked by a `major` it did not introduce.
+
+When validating changeset Markdown files in CI, run `node .github/scripts/check-no-heading-changeset.cjs .changeset-status.json` so the script resolves files from the pull request's own changesets, and fail the job if any listed changeset file contains H1 (`#`), H2 (`##`) or H3 (`###`) headings.
 
 When running `changeset status --since=origin/<base>` after `actions/checkout` with shallow history in pull request workflows, fetch and iteratively deepen both the base branch ref and the current pull request merge ref. Deepening only `origin/<base>` can leave `HEAD` shallow and make `git merge-base origin/<base> HEAD` fail even after repeated fetches.
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,12 +71,19 @@ jobs:
         run: pnpm turbo api-extractor
       - name: Changeset Check
         run: pnpm changeset status --since=origin/main --output .changeset-status.json
+      - name: Release Plan
+        run: |
+          # Without `--since` the whole plan is assembled, which is what the
+          # release publishes. It resolves `config.baseBranch` as a local ref,
+          # and a pull request checkout is detached, so point one at the base.
+          git branch -f main origin/main
+          pnpm changeset status --output .changeset-release-plan.json
       - name: Changeset Script Tests
         run: node --test .github/scripts/*.test.cjs
       - name: Major Bump Check
         run: node .github/scripts/check-no-major-changeset.cjs .changeset-status.json
       - name: Peer Dependency Range Check
-        run: node .github/scripts/check-peer-dependency-ranges.cjs .changeset-status.json
+        run: node .github/scripts/check-peer-dependency-ranges.cjs .changeset-release-plan.json
       - name: Changeset Heading Check
         run: node .github/scripts/check-no-heading-changeset.cjs .changeset-status.json
       - name: Dependency Changeset Check


### PR DESCRIPTION
The peer dependency range check read the plan from `changeset status --since=origin/main`. That plan is scoped to the changesets the branch adds, so a package another branch has already queued for a release is planned at its current version rather than the one it will be published at.

Concretely: a branch that bumps `@lynx-js/template-webpack-plugin` gives `@lynx-js/rspeedy` a dependent `patch` to 0.16.6, which fails against the `^0.17.0` peer ranges of `qrcode-`, `react-` and `vanilla-rsbuild-plugin` — while `main` already carries changesets that publish it as 0.17.0, so the release itself has no violation. The only way past it was to add an `@lynx-js/rspeedy` changeset to a branch that does not touch `rspeedy`.

`.github/scripts/write-release-plan.mjs` assembles the plan from every changeset in `.changeset`, which is what the next release publishes, and needs no Git ref to do it. Its output is the same `ReleasePlan` object `changeset status --output` writes, so the check reading it is unchanged.

The branch-scoped plan stays where the question really is about the branch — a `major` bump, the Markdown of the changesets it adds, dependency changes that need one — since the whole plan carries every merged branch's changesets and would block a pull request for a `major` it did not introduce. `changeset status` also keeps detecting a change that has no changeset at all, which is the part that genuinely needs the ref: without `--since` it falls back to `config.baseBranch` as a local ref, which a detached pull request checkout may not have.

Verified on `main`: the whole plan is 25 releases with `@lynx-js/rspeedy` at 0.17.0, and all four checks pass on their respective inputs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified release validation guidance by distinguishing pull request checks from full release checks.
  - Added guidance for validating changesets, dependency updates, release types, and missing release notes.

- **Chores**
  - Improved automated release checks to use the appropriate release plan for peer dependency range validation.
  - Added release plan generation to code-style checks for more reliable CI results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->