### PR TITLE
feat(rsbuild-plugin): emit what a Lynx bundle can carry for rslib

### DIFF
--- a/packages/rspeedy/lynx-bundle-rslib-config/test/external-bundle.test.ts
+++ b/packages/rspeedy/lynx-bundle-rslib-config/test/external-bundle.test.ts
@@ -1115,6 +1115,24 @@ describe('DSL plugin without layer loaders', () => {
   })
 })
 
+describe('license comments', () => {
+  const fixtureDir = path.join(__dirname, './fixtures/utils-lib')
+  const distRoot = path.join(fixtureDir, 'dist', 'license-comments')
+
+  it('does not emit a license file a Lynx bundle cannot link to', async () => {
+    await build(defineExternalBundleRslibConfig({
+      source: { entry: { utils: path.join(fixtureDir, 'index.ts') } },
+      id: 'utils-legal-comments',
+      output: { distPath: { root: distRoot } },
+      plugins: [pluginReactLynx()],
+    }))
+
+    const emitted = await fs.promises.readdir(distRoot)
+
+    expect(emitted.filter(name => name.includes('LICENSE'))).toEqual([])
+  })
+})
+
 describe('debug info outside', () => {
   const fixtureDir = path.join(__dirname, './fixtures/utils-lib')
 

--- a/packages/rspeedy/plugin-lynx/src/index.ts
+++ b/packages/rspeedy/plugin-lynx/src/index.ts
@@ -78,7 +78,6 @@ export function pluginLynx(
   const bundlePlugins = [
     pluginChunkLoading(),
     pluginLynxDebugMetadata(),
-    pluginOutput(),
     pluginCssMinimizer(),
     pluginDev(),
     pluginMinify(),
@@ -107,6 +106,7 @@ export function pluginLynx(
     pluginConfig(options),
     pluginResolve(),
     pluginSwc(),
+    pluginOutput(),
     pluginTemplate(),
     ...bundlePlugins,
   ]


### PR DESCRIPTION
An `rslib` build emitted a `.LICENSE.txt` next to every chunk, which a Lynx
bundle has nowhere to link to, and left the bundler runtime on the `const`
Rspack picks by default.

