### PR TITLE
feat(rsbuild-plugin): emit the debug metadata for an external bundle

### DIFF
--- a/packages/rspeedy/lynx-bundle-rslib-config/test/external-bundle.test.ts
+++ b/packages/rspeedy/lynx-bundle-rslib-config/test/external-bundle.test.ts
@@ -1115,6 +1115,24 @@ describe('DSL plugin without layer loaders', () => {
   })
 })
 
+describe('debug metadata', () => {
+  const fixtureDir = path.join(__dirname, './fixtures/utils-lib')
+  const distRoot = path.join(fixtureDir, 'dist', 'debug-metadata')
+
+  it('emits the metadata a devtool remaps an external bundle with', async () => {
+    await build(defineExternalBundleRslibConfig({
+      source: { entry: { utils: path.join(fixtureDir, 'index.ts') } },
+      id: 'utils-debug-metadata',
+      output: { distPath: { root: distRoot } },
+      plugins: [pluginReactLynx()],
+    }))
+
+    expect(
+      fs.existsSync(path.join(distRoot, '.lynx', 'debug-metadata.json')),
+    ).toBe(true)
+  })
+})
+
 describe('license comments', () => {
   const fixtureDir = path.join(__dirname, './fixtures/utils-lib')
   const distRoot = path.join(fixtureDir, 'dist', 'license-comments')

--- a/packages/rspeedy/plugin-lynx/src/index.ts
+++ b/packages/rspeedy/plugin-lynx/src/index.ts
@@ -77,7 +77,6 @@ export function pluginLynx(
   // `rslib` assembles the bundle itself and `rstest` has none.
   const bundlePlugins = [
     pluginChunkLoading(),
-    pluginLynxDebugMetadata(),
     pluginCssMinimizer(),
     pluginDev(),
     pluginMinify(),
@@ -104,6 +103,7 @@ export function pluginLynx(
       },
     },
     pluginConfig(options),
+    pluginLynxDebugMetadata(),
     pluginResolve(),
     pluginSwc(),
     pluginOutput(),


### PR DESCRIPTION
The metadata was emitted only for an environment named after Lynx, which is
what an application build calls one. An external bundle environment is named
after the library, so it got none, and a devtool had nothing to remap its stack
traces with.

Key it on the build encoding a Lynx template instead, read off the compiler so
it does not depend on the order the bundler chain is assembled in.

