### PR TITLE
fix(web-core): add an empty BTS entry for main-only Lynx XML

### DIFF
--- a/.changeset/fix-main-only-lynx-xml.md
+++ b/.changeset/fix-main-only-lynx-xml.md
@@ -1,0 +1,7 @@
+---
+"@lynx-js/web-core": patch
+---
+
+Render main-only Lynx XML cards without requesting a missing `app-service.js`
+by registering an empty background entry when the optional background script
+is omitted.

--- a/.github/web-core-lynx-markup.instructions.md
+++ b/.github/web-core-lynx-markup.instructions.md
@@ -1,5 +1,7 @@
 ---
-applyTo: "packages/web-platform/web-core/ts/common/xml/**,packages/web-platform/web-core/tests/parseLynxXML.spec.ts,packages/web-platform/web-core/tests/fixtures/*.xml"
+applyTo: "packages/web-platform/web-core/{ts/common/xml/**,ts/encode/xmlToTasmJSON.ts,tests/parseLynxXML.spec.ts,tests/xml-to-web-bundle.spec.ts,tests/template-manager.spec.ts,tests/fixtures/*.xml}"
 ---
 
 Keep the Web Core single-file Lynx XML boundary on the current Vanilla Lynx syntax: lowercase `<!doctype lynx>` when a doctype is present, a `<lynx engine-version="...">` root, optional raw `<style>` content, a required `<script thread="main">`, and an optional `<script thread="background">`. Do not accept the legacy `version`, `main-thread`, `background`, XML declaration, uppercase doctype, or CDATA spellings. Keep parser tests and markup fixtures on the current syntax and add explicit rejection coverage before changing this boundary.
+
+When encoding a Lynx XML card for Web, always register the fixed `/app-service.js` manifest entry expected by Lynx Core. Preserve an explicit background script verbatim; when the optional background block is absent, synthesize an empty chunk instead of omitting the entry and allowing a network fallback.

--- a/packages/web-platform/web-core/tests/template-manager.spec.ts
+++ b/packages/web-platform/web-core/tests/template-manager.spec.ts
@@ -697,6 +697,10 @@ describe('Template Manager', () => {
       '<script thread="background">globalThis.__bts = 1;</script>',
       '</lynx>',
     ].join('\n');
+    const mainOnlyMarkupSource = markupSource.replace(
+      '<script thread="background">globalThis.__bts = 1;</script>\n',
+      '',
+    );
 
     function serveBytes(bytes: Uint8Array, chunkSize = bytes.length) {
       const stream = new ReadableStream({
@@ -758,6 +762,19 @@ describe('Template Manager', () => {
         url,
         false,
       );
+      expect(mockLynxViewInstance.onBTSScriptsLoaded).toHaveBeenCalledWith(url);
+    });
+
+    test('registers an empty app-service entry for a main-only card', async () => {
+      const url = 'http://example.com/main-only.xml';
+      serveText(mainOnlyMarkupSource);
+
+      await load(url);
+
+      const bundle = templateManager.getBundle(url);
+      expect(Object.keys(bundle?.backgroundCode ?? {})).toStrictEqual([
+        '/app-service.js',
+      ]);
       expect(mockLynxViewInstance.onBTSScriptsLoaded).toHaveBeenCalledWith(url);
     });
 

--- a/packages/web-platform/web-core/tests/xml-to-web-bundle.spec.ts
+++ b/packages/web-platform/web-core/tests/xml-to-web-bundle.spec.ts
@@ -220,17 +220,25 @@ describe('XML markup document to web bundle', () => {
     expect(css).toContain('.a:not([l-e-name])');
   });
 
-  test('omits the sections an XML document cannot fill', () => {
+  test('synthesizes the required empty background entry when omitted', () => {
     // No `<style>` and no background script: the encoder must still frame a
-    // readable bundle rather than emit an empty or malformed section.
+    // readable bundle and satisfy Lynx Core's fixed app-service load without a
+    // network fallback.
     const { buffer } = build(xml());
     const { sections } = readBundle(buffer);
     expect(readStringMap(sections.get(TemplateSectionLabel.Manifest)!))
-      .toStrictEqual({});
+      .toStrictEqual({ '/app-service.js': '' });
     expect(
       readJSONSection(sections.get(TemplateSectionLabel.CustomSections)!),
     ).toStrictEqual({});
     expect(sections.has(TemplateSectionLabel.ElementTemplates)).toBe(false);
+  });
+
+  test('preserves an explicitly empty background script', () => {
+    const { buffer } = build(xml({ background: '' }));
+    const { sections } = readBundle(buffer);
+    expect(readStringMap(sections.get(TemplateSectionLabel.Manifest)!))
+      .toStrictEqual({ '/app-service.js': '' });
   });
 
   /**

--- a/packages/web-platform/web-core/ts/encode/xmlToTasmJSON.ts
+++ b/packages/web-platform/web-core/ts/encode/xmlToTasmJSON.ts
@@ -273,9 +273,12 @@ export function xmlToTasmJSON(source: string): XMLToTasmJSONResult {
       // bts chunk through `new Function(...paramNames, jsContent)`, which is the
       // web equivalent of the engine's module wrapper, so wrapping here would
       // nest two module functions and hide the source's top-level bindings.
-      manifest: parsed.backgroundThreadScript !== undefined
-        ? { [backgroundChunkPath]: parsed.backgroundThreadScript }
-        : {},
+      // Lynx Core still loads the card's fixed app-service entry when the XML
+      // omits its optional background script. Keep that syntax optional by
+      // registering an empty chunk instead of falling back to an HTTP request.
+      manifest: {
+        [backgroundChunkPath]: parsed.backgroundThreadScript ?? '',
+      },
       cardType: 'react',
       appType: 'card',
       pageConfig: { ...markupPageConfig },


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed rendering for main-only Lynx XML cards when no background script is provided.
  * Prevented requests for missing background resources by registering an empty background entry.
  * Ensured explicitly empty background scripts behave consistently with omitted scripts.

* **Tests**
  * Added coverage for main-only cards and empty background script scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
