### PR TITLE
feat(rsbuild-plugin): minify an external bundle with the engine options

### DIFF
--- a/.changeset/rslib-engine-minify.md
+++ b/.changeset/rslib-engine-minify.md
@@ -1,0 +1,6 @@
+---
+"@lynx-js/lynx-bundle-rslib-config": minor
+"@lynx-js/rsbuild-plugin": patch
+---
+
+The minify options come from `pluginLynx` now; `output.minify` only decides whether to minify at all. `pluginLynx` applies them per environment, so `output.minify: true` on an environment no longer drops them (part of #3723).

--- a/packages/rspeedy/lynx-bundle-rslib-config/src/externalBundleRslibConfig.ts
+++ b/packages/rspeedy/lynx-bundle-rslib-config/src/externalBundleRslibConfig.ts
@@ -58,38 +58,6 @@ export interface EncodeOptions {
   enableJsBytecode?: boolean
 }
 
-// When preact devtools is enabled (`REACT_DEVTOOL`), keep function and class
-// names. Devtools relies on them to resolve component names (`type.name`) and
-// to reconstruct the hook tree (it matches minified stack frames by function
-// name). Minification would otherwise mangle/inline those names away. Only
-// enabled with devtools since it slightly increases bundle size. Mirrors
-// `pluginMinify` in @lynx-js/rspeedy (lynx-family/lynx-stack#2880).
-const keepNames = Boolean(process.env['REACT_DEVTOOL'])
-
-const DEFAULT_EXTERNAL_BUNDLE_MINIFY_CONFIG = {
-  jsOptions: {
-    minimizerOptions: {
-      compress: {
-        /**
-         * the module wrapper iife need to be kept to provide the return value
-         * for the module loader in lynx_core.js
-         */
-        negate_iife: false,
-        // Allow return in module wrapper
-        side_effects: false,
-
-        // `mangle.keep_*` below preserves most names, but the compressor can
-        // still inline single-use functions (incl. one-shot components) into
-        // anonymity; `compress.keep_*` stops that. Cheap, so we keep both.
-        ...(keepNames ? { keep_fnames: true, keep_classnames: true } : {}),
-      },
-      ...(keepNames
-        ? { mangle: { keep_fnames: true, keep_classnames: true } }
-        : {}),
-    },
-  },
-}
-
 /**
  * The default lib config{@link LibConfig} for external bundle.
  *
@@ -109,9 +77,10 @@ export const DEFAULT_EXTERNAL_BUNDLE_LIB_CONFIG: LibConfig = {
       dependencies: false,
       peerDependencies: false,
     },
-    minify: process.env['NODE_ENV'] === 'development'
-      ? false
-      : DEFAULT_EXTERNAL_BUNDLE_MINIFY_CONFIG,
+    // `rslib build` always compiles with rspack mode `production`, so the
+    // development signal here is `NODE_ENV`. What minification may do is
+    // `pluginLynx`'s to say.
+    minify: process.env['NODE_ENV'] !== 'development',
     target: 'web',
     dataUriLimit: Number.POSITIVE_INFINITY,
     distPath: {
@@ -590,10 +559,6 @@ export function defineExternalBundleRslibConfig(
   userLibConfig: ExternalBundleLibConfig,
   encodeOptions: EncodeOptions = {},
 ): RslibConfig {
-  const normalizedOutputMinify = userLibConfig.output?.minify === true
-    ? DEFAULT_EXTERNAL_BUNDLE_MINIFY_CONFIG
-    : userLibConfig.output?.minify
-
   // Taken before `id` is overridden below, which names the environment.
   const bundleName = userLibConfig.id ?? 'index'
 
@@ -616,7 +581,6 @@ export function defineExternalBundleRslibConfig(
           },
           output: {
             ...userLibConfig.output,
-            minify: normalizedOutputMinify,
             externals: transformExternals(
               userLibConfig.output?.externalsPresets,
               userLibConfig.output?.externals,

--- a/packages/rspeedy/lynx-bundle-rslib-config/test/external-bundle.test.ts
+++ b/packages/rspeedy/lynx-bundle-rslib-config/test/external-bundle.test.ts
@@ -8,15 +8,7 @@ import { fileURLToPath } from 'node:url'
 
 import { createRslib } from '@rslib/core'
 import type { RslibConfig, Rspack, rsbuild } from '@rslib/core'
-import {
-  afterAll,
-  afterEach,
-  beforeAll,
-  describe,
-  expect,
-  it,
-  rstest,
-} from '@rstest/core'
+import { afterAll, beforeAll, describe, expect, it, rstest } from '@rstest/core'
 
 import { LAYERS, pluginReactLynx } from '@lynx-js/react-rsbuild-plugin'
 import { pluginLynx } from '@lynx-js/rsbuild-plugin'
@@ -156,77 +148,31 @@ describe('define config', () => {
     expect(rslibConfig.lib[0]?.syntax).toBe('es2019')
   })
 
-  it('should preserve default minify jsOptions when output.minify is true', () => {
-    const rslibConfig = defineExternalBundleRslibConfig({
-      output: {
-        minify: true,
-      },
-    })
-
-    expect(rslibConfig.lib[0]?.output?.minify).toMatchObject({
-      jsOptions: {
-        minimizerOptions: {
-          compress: {
-            negate_iife: false,
-            side_effects: false,
+  it('leaves the minify options to the engine', async () => {
+    for (const output of [{}, { minify: true }] as const) {
+      const rslibConfig = defineExternalBundleRslibConfig({
+        source: {
+          entry: {
+            utils: path.join(__dirname, './fixtures/utils-lib/index.ts'),
           },
         },
-      },
-    })
-  })
-})
+        output,
+        plugins: [pluginReactLynx()],
+      })
+      expect(rslibConfig.lib[0]?.output?.minify).toBe(true)
 
-describe('REACT_DEVTOOL minify', () => {
-  const prevReactDevtool = process.env['REACT_DEVTOOL']
-
-  afterEach(() => {
-    if (prevReactDevtool === undefined) {
-      delete process.env['REACT_DEVTOOL']
-    } else {
-      process.env['REACT_DEVTOOL'] = prevReactDevtool
-    }
-    rstest.resetModules()
-  })
-
-  it('keeps function and class names when REACT_DEVTOOL is set', async () => {
-    process.env['REACT_DEVTOOL'] = '1'
-    rstest.resetModules()
-    const { defineExternalBundleRslibConfig } = await import('../src/index.js')
-
-    const rslibConfig = defineExternalBundleRslibConfig({
-      output: { minify: true },
-    })
-
-    expect(rslibConfig.lib[0]?.output?.minify).toMatchObject({
-      jsOptions: {
-        minimizerOptions: {
-          compress: { keep_fnames: true, keep_classnames: true },
-          mangle: { keep_fnames: true, keep_classnames: true },
+      const { optimization } = await inspectRspackConfig(rslibConfig)
+      const [minimizer] = optimization!.minimizer as [
+        {
+          _args: [{ minimizerOptions: { compress: { negate_iife?: boolean } } }]
         },
-      },
-    })
-  })
-
-  it('does not keep names when REACT_DEVTOOL is unset', async () => {
-    delete process.env['REACT_DEVTOOL']
-    rstest.resetModules()
-    const { defineExternalBundleRslibConfig } = await import('../src/index.js')
-
-    const rslibConfig = defineExternalBundleRslibConfig({
-      output: { minify: true },
-    })
-
-    const minify = rslibConfig.lib[0]?.output?.minify as {
-      jsOptions?: {
-        minimizerOptions?: {
-          compress?: { keep_fnames?: boolean }
-          mangle?: unknown
-        }
-      }
+      ]
+      // The wrapper IIFE has to keep its shape, or a section evaluates to a
+      // boolean instead of `module.exports`.
+      expect(minimizer._args[0].minimizerOptions.compress.negate_iife).toBe(
+        false,
+      )
     }
-    expect(minify.jsOptions?.minimizerOptions?.compress?.keep_fnames)
-      .toBeUndefined()
-    expect(minify.jsOptions?.minimizerOptions?.mangle).toBeUndefined()
   })
 })
 

--- a/packages/rspeedy/plugin-lynx/src/plugins/minify.plugin.ts
+++ b/packages/rspeedy/plugin-lynx/src/plugins/minify.plugin.ts
@@ -3,7 +3,12 @@
 // LICENSE file in the root directory of this source tree.
 
 import { mergeRsbuildConfig } from '@rsbuild/core'
-import type { RsbuildConfig, RsbuildPlugin, Rspack } from '@rsbuild/core'
+import type {
+  MergedEnvironmentConfig,
+  RsbuildConfig,
+  RsbuildPlugin,
+  Rspack,
+} from '@rsbuild/core'
 
 import { getLynxConfig } from '../config.js'
 import { debug } from '../debug.js'
@@ -139,13 +144,9 @@ export function pluginMinify(): RsbuildPlugin {
   return {
     name: 'lynx:rsbuild:minify',
     setup(api) {
-      if (
-        api.context.callerName === 'rslib'
-        || api.context.callerName === 'rstest'
-      ) {
-        return
-      }
-      api.modifyRsbuildConfig((config, { mergeRsbuildConfig }) => {
+      // Per environment, so a `minify` set on one is normalized the same way
+      // and cannot replace the options merged into the global config.
+      api.modifyEnvironmentConfig((config) => {
         const userMinify = config.output?.minify
 
         // Disable minification
@@ -156,15 +157,20 @@ export function pluginMinify(): RsbuildPlugin {
 
         if (typeof userMinify === 'object') {
           debug(`merging minification options`)
-          return mergeRsbuildConfig(defaultConfig, config)
+          return mergeRsbuildConfig<RsbuildConfig>(
+            defaultConfig,
+            config,
+          ) as MergedEnvironmentConfig
         }
 
-        return mergeRsbuildConfig(config, defaultConfig)
+        return mergeRsbuildConfig<RsbuildConfig>(
+          config,
+          defaultConfig,
+        ) as MergedEnvironmentConfig
       })
 
-      api.modifyBundlerChain((chain, { rspack, CHAIN_ID }) => {
-        const currentConfig = api.getRsbuildConfig('normalized')
-        const minify = currentConfig.output?.minify as
+      api.modifyBundlerChain((chain, { rspack, CHAIN_ID, environment }) => {
+        const minify = environment.config.output?.minify as
           | Minify
           | boolean
           | undefined

--- a/packages/rspeedy/plugin-lynx/test/minify.plugin.test.ts
+++ b/packages/rspeedy/plugin-lynx/test/minify.plugin.test.ts
@@ -2,7 +2,7 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 import type { RsbuildConfig, Rspack } from '@rsbuild/core'
-import { describe, expect, test } from '@rstest/core'
+import { describe, expect, rstest, test } from '@rstest/core'
 
 import { createStubRsbuild } from './createStubRsbuild.js'
 
@@ -176,5 +176,52 @@ describe('pluginMinify', () => {
     )
     expect(serialized).toContain('from.rsbuild-config')
     expect(serialized).toContain('from.lynx-config')
+  })
+
+  test('keeps its options when an environment turns minify on', async () => {
+    const rsbuild = await createStubRsbuild({
+      mode: 'production',
+      environments: { lynx: { output: { minify: true } } },
+    })
+    const config = await rsbuild.unwrapConfig({ action: 'build' })
+
+    const options = findJsMinimizers(config)[0]?._args[0]?.minimizerOptions
+
+    // A boolean on the environment would otherwise replace the options the
+    // plugin merged into the global config.
+    expect(options?.compress).toMatchObject({ negate_iife: false })
+  })
+
+  test('keeps function and class names when REACT_DEVTOOL is set', async () => {
+    rstest.stubEnv('REACT_DEVTOOL', '1')
+    try {
+      const rsbuild = await createStubRsbuild({ mode: 'production' })
+      const config = await rsbuild.unwrapConfig({ action: 'build' })
+
+      const options = findJsMinimizers(config)[0]?._args[0]?.minimizerOptions
+
+      // Devtools resolves component names from `type.name` and matches
+      // minified stack frames by function name.
+      expect(options?.compress).toMatchObject({
+        keep_fnames: true,
+        keep_classnames: true,
+      })
+      expect(options?.mangle).toMatchObject({
+        keep_fnames: true,
+        keep_classnames: true,
+      })
+    } finally {
+      rstest.unstubAllEnvs()
+    }
+  })
+
+  test('does not keep names when REACT_DEVTOOL is unset', async () => {
+    const rsbuild = await createStubRsbuild({ mode: 'production' })
+    const config = await rsbuild.unwrapConfig({ action: 'build' })
+
+    const options = findJsMinimizers(config)[0]?._args[0]?.minimizerOptions
+
+    expect(options?.compress).not.toHaveProperty('keep_fnames')
+    expect(options?.mangle).not.toHaveProperty('keep_fnames')
   })
 })


### PR DESCRIPTION
`@lynx-js/lynx-bundle-rslib-config` carried its own minify defaults, down to the same `negate_iife: false` and `side_effects: false` that keep the module wrapper callable from `lynx_core.js` — its comment said as much, that it mirrors `pluginMinify`. The copy was a subset: an external bundle missed the compressor and CSS minifier settings a template build gets.

Apply `pluginMinify` for every caller and drop the copy. Only whether to minify at all is still decided by the rslib config, since `rslib build` always compiles with rspack mode `production` and the development signal is `NODE_ENV`.

`pluginMinify` merged its options into the global config only. Rslib keeps a library's config on an environment, where a `minify: true` replaced them with the SWC defaults, and `negate_iife` turned the module wrapper into a boolean that `lynx.loadScript` handed back instead of the exports. It merges per environment now, which also covers an application setting `minify` on one.

Part of #3723.
