### PR TITLE
fix: generated AutoLink package output

### DIFF
--- a/.changeset/tidy-libraries-fix.md
+++ b/.changeset/tidy-libraries-fix.md
@@ -1,0 +1,6 @@
+---
+"@lynx-js/autolink-codegen": patch
+"create-lynx-library": patch
+---
+
+Fix strict TypeScript checks for generated Node-API facades and scope generated podspecs to iOS.

--- a/packages/lynx/autolink-codegen/package.json
+++ b/packages/lynx/autolink-codegen/package.json
@@ -34,6 +34,9 @@
     "dev": "rslib build --watch",
     "test": "vitest run"
   },
+  "devDependencies": {
+    "typescript": "catalog:"
+  },
   "engines": {
     "node": "^20 || ^22 || ^24"
   }

--- a/packages/lynx/autolink-codegen/src/index.ts
+++ b/packages/lynx/autolink-codegen/src/index.ts
@@ -1728,7 +1728,7 @@ ${
     installNodeApiShim
       ? `  const loadResult = tryLoadNodeApiAddon();
   if ('addon' in loadResult && loadResult.addon !== undefined) {
-    return loadResult.addon as ${module.name}Spec;
+    return loadResult.addon as unknown as ${module.name}Spec;
   }
   if ('error' in loadResult) {
     throw loadResult.error;
@@ -1739,7 +1739,7 @@ ${
     supportsNodeApi && !installNodeApiShim
       ? `  const addon = loadNodeApiAddon();
   if (addon !== undefined) {
-    return addon as ${module.name}Spec;
+    return addon as unknown as ${module.name}Spec;
   }
 `
       : ''

--- a/packages/lynx/autolink-codegen/test/codegen.test.ts
+++ b/packages/lynx/autolink-codegen/test/codegen.test.ts
@@ -6,6 +6,7 @@ import os from 'node:os';
 import path from 'node:path';
 import vm from 'node:vm';
 
+import ts from 'typescript';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { generate, parseNativeModules, runCodegen } from '../src/index.js';
@@ -693,7 +694,7 @@ export declare class StorageNapiModule {
       files.find((file) => file.path === 'generated/StorageNapiModule.ts')
         ?.content,
     ).toMatch(
-      /const nativeModules = nativeModulesBeforeShim;[\s\S]*return existingModule as StorageNapiModuleSpec;[\s\S]*const loadResult = tryLoadNodeApiAddon\(\);[\s\S]*throw loadResult\.error;/,
+      /const nativeModules = nativeModulesBeforeShim;[\s\S]*return existingModule as StorageNapiModuleSpec;[\s\S]*const loadResult = tryLoadNodeApiAddon\(\);[\s\S]*return loadResult\.addon as unknown as StorageNapiModuleSpec;[\s\S]*throw loadResult\.error;/,
     );
     expect(
       files.find((file) => file.path === 'generated/StorageNapiModule.ts')
@@ -834,6 +835,49 @@ export declare class StorageNapiModule {
       '#include "../../../shared/nativeModule/StorageNapiModule.cc"',
     );
     expect(fs.readFileSync(wrapperPath, 'utf8')).not.toContain('stale');
+  });
+
+  it('generates NAPI facades that pass strict TypeScript checks', () => {
+    const root = createFixture({
+      manifest: {
+        platforms: {
+          lynxtron: {
+            path: 'dist',
+          },
+        },
+      },
+      types: '',
+    });
+    writeTypesFile(
+      root,
+      'napi-native-module.d.ts',
+      `/** @lynxmodule */
+export declare class ScannerModule {
+  scan(image: ArrayBuffer): ArrayBuffer;
+}
+`,
+    );
+
+    runCodegen({ root });
+
+    const facadePath = path.join(root, 'generated/ScannerModule.ts');
+    const program = ts.createProgram([facadePath], {
+      lib: ['lib.es2022.d.ts', 'lib.dom.d.ts'],
+      module: ts.ModuleKind.ESNext,
+      noEmit: true,
+      skipLibCheck: true,
+      strict: true,
+      target: ts.ScriptTarget.ES2022,
+    });
+    const errors = ts.getPreEmitDiagnostics(program).filter((diagnostic) =>
+      diagnostic.category === ts.DiagnosticCategory.Error
+    );
+
+    expect(
+      errors.map((diagnostic) =>
+        ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n')
+      ),
+    ).toEqual([]);
   });
 
   it('rejects multiple NAPI native modules in one library', () => {

--- a/packages/lynx/create-lynx-library/template-common/ios/__PODSPEC_NAME__.podspec
+++ b/packages/lynx/create-lynx-library/template-common/ios/__PODSPEC_NAME__.podspec
@@ -5,6 +5,7 @@ Pod::Spec.new do |s|
   s.homepage = 'https://github.com/lynx-family/lynx'
   s.license = { :type => 'Apache-2.0' }
   s.author = 'Lynx'
+  s.platform = :ios, '10.0'
   s.source = { :path => '..' }
   s.source_files = 'src/**/*.{h,m,mm}'
   s.dependency 'Lynx'

--- a/packages/lynx/create-lynx-library/test/create.test.ts
+++ b/packages/lynx/create-lynx-library/test/create.test.ts
@@ -306,6 +306,9 @@ describe('create-lynx-library', () => {
     expect(read(dir, 'ios/example-lynx-button.podspec')).toContain(
       's.dependency \'LynxServiceAPI\'',
     );
+    expect(read(dir, 'ios/example-lynx-button.podspec')).toContain(
+      's.platform = :ios, \'10.0\'',
+    );
     expect(read(dir, 'types/index.d.ts')).toContain(
       'export * from \'./platform-native-module\';',
     );
@@ -1129,6 +1132,9 @@ describe('create-lynx-library', () => {
       'android',
     );
     expect(read(dir, 'ios/ios-library.podspec')).toContain('LynxServiceAPI');
+    expect(read(dir, 'ios/ios-library.podspec')).toContain(
+      's.platform = :ios, \'10.0\'',
+    );
     expect(read(dir, 'README.md')).toContain('`ios/`');
     expect(read(dir, 'README.md')).not.toContain('`android/`');
   });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1215,7 +1215,11 @@ importers:
         specifier: 0.2.1
         version: 0.2.1(@rsbuild/core@2.1.10(core-js@3.50.0))(i18next-cli@1.67.7(@swc/helpers@0.5.23)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(typescript@6.0.3))(rollup@4.62.2)
 
-  packages/lynx/autolink-codegen: {}
+  packages/lynx/autolink-codegen:
+    devDependencies:
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
 
   packages/lynx/benchx_cli:
     dependencies:


### PR DESCRIPTION
Fix Node-API facade casts so generated code passes strict TypeScript checks.

Add an explicit iOS 10.0 deployment platform to generated podspecs.

AutoSubmit: true

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved generated Node-API facades to pass strict TypeScript checks.
  * Generated iOS podspecs now specify iOS 10.0 as the minimum deployment target.

* **Tests**
  * Added coverage validating strict TypeScript compilation and iOS podspec platform settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
