### PR TITLE
feat: accept DEBUG=lynx for the Lynx debug output

### DIFF
--- a/.changeset/debug-lynx.md
+++ b/.changeset/debug-lynx.md
@@ -1,0 +1,9 @@
+---
+"@lynx-js/rspeedy": patch
+"@lynx-js/rsbuild-plugin": patch
+"@lynx-js/react-rsbuild-plugin": patch
+"@lynx-js/template-webpack-plugin": patch
+"@lynx-js/debug-metadata-rsbuild-plugin": patch
+---
+
+Accept `DEBUG=lynx` (and `lynx:*`, `lynx:template`) for the Lynx debug output and intermediates. It is the recommended form now that the plugins also run under Rslib and Rsbuild; `DEBUG=rspeedy` keeps working.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -207,7 +207,7 @@ The CI runs these checks (replicate locally for confidence):
 CI=1                          # Enables CI mode
 TURBO_TELEMETRY_DISABLED=1    # Disables telemetry
 NODE_OPTIONS="--max-old-space-size=32768"  # For large builds
-DEBUG=rspeedy                 # Enable debug logging
+DEBUG=lynx                    # Enable debug logging (DEBUG=rspeedy still works)
 ```
 
 ## Trust These Instructions

--- a/examples/react-debug-metadata/package.json
+++ b/examples/react-debug-metadata/package.json
@@ -5,8 +5,8 @@
   "type": "module",
   "scripts": {
     "build": "pnpm run build:producer && pnpm run build:consumer",
-    "build:consumer": "cross-env DEBUG=rspeedy,rsbuild rspeedy build --config lynx.config.consumer.js",
-    "build:producer": "cross-env DEBUG=rspeedy,rsbuild rspeedy build --config lynx.config.producer.js",
+    "build:consumer": "cross-env DEBUG=lynx,rsbuild rspeedy build --config lynx.config.consumer.js",
+    "build:producer": "cross-env DEBUG=lynx,rsbuild rspeedy build --config lynx.config.producer.js",
     "dev": "node scripts/serve.mjs dev",
     "dev:consumer": "rspeedy dev --config lynx.config.consumer.js",
     "dev:producer": "rspeedy dev --config lynx.config.producer.js",

--- a/packages/rspeedy/core/src/debug.ts
+++ b/packages/rspeedy/core/src/debug.ts
@@ -11,7 +11,7 @@ export const isDebug = (): boolean => {
   }
 
   const values = process.env['DEBUG'].toLocaleLowerCase().split(',')
-  return ['rsbuild', 'rspeedy', '*'].some((key) => values.includes(key))
+  return ['lynx', 'rsbuild', 'rspeedy', '*'].some((key) => values.includes(key))
 }
 
 const label = color.bgCyan('lynx')

--- a/packages/rspeedy/core/test/debug.test.ts
+++ b/packages/rspeedy/core/test/debug.test.ts
@@ -1,0 +1,28 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { describe, expect, rstest, test } from '@rstest/core'
+
+import { isDebug } from '../src/debug.js'
+
+describe('isDebug', () => {
+  test('accepts the lynx namespace and the rspeedy one', () => {
+    for (const value of ['lynx', 'rspeedy', 'lynx,rsbuild', '*']) {
+      rstest.stubEnv('DEBUG', value)
+      try {
+        expect(isDebug(), value).toBe(true)
+      } finally {
+        rstest.unstubAllEnvs()
+      }
+    }
+  })
+
+  test('ignores other namespaces', () => {
+    rstest.stubEnv('DEBUG', 'rslib')
+    try {
+      expect(isDebug()).toBe(false)
+    } finally {
+      rstest.unstubAllEnvs()
+    }
+  })
+})

--- a/packages/rspeedy/plugin-debug-metadata/src/pluginLynxDebugMetadata.ts
+++ b/packages/rspeedy/plugin-debug-metadata/src/pluginLynxDebugMetadata.ts
@@ -19,7 +19,16 @@ function isDebugMode(): boolean {
   const debug = process.env['DEBUG']
   if (!debug) return false
   const values = debug.toLocaleLowerCase().split(',')
-  return ['rspeedy', 'rsbuild', '*', 'rspeedy:*', 'rspeedy:template'].some((
+  return [
+    'lynx',
+    'lynx:*',
+    'lynx:template',
+    'rspeedy',
+    'rsbuild',
+    '*',
+    'rspeedy:*',
+    'rspeedy:template',
+  ].some((
     key,
   ) => values.includes(key))
 }

--- a/packages/rspeedy/plugin-debug-metadata/test/local-prod-gate.test.ts
+++ b/packages/rspeedy/plugin-debug-metadata/test/local-prod-gate.test.ts
@@ -86,6 +86,12 @@ describe('pluginLynxDebugMetadata production gate', () => {
     expect(runChain(LYNX_PROD)).toContain('lynx:debug-metadata')
   })
 
+  test('emits on a local production build when DEBUG=lynx', () => {
+    vi.stubEnv('DEBUG', 'lynx')
+
+    expect(runChain(LYNX_PROD)).toContain('lynx:debug-metadata')
+  })
+
   test('emits on a dev build regardless of CI (the middleware serves it)', () => {
     expect(
       runChain({ environment: { name: 'lynx', entry: {} }, isProd: false }),

--- a/packages/rspeedy/plugin-lynx/src/debug.ts
+++ b/packages/rspeedy/plugin-lynx/src/debug.ts
@@ -11,7 +11,7 @@ export const isDebug = (): boolean => {
   }
 
   const values = process.env['DEBUG'].toLocaleLowerCase().split(',')
-  return ['rsbuild', 'rspeedy', '*'].some((key) => values.includes(key))
+  return ['lynx', 'rsbuild', 'rspeedy', '*'].some((key) => values.includes(key))
 }
 
 const label = color.bgCyan('lynx')

--- a/packages/rspeedy/plugin-lynx/test/debug.test.ts
+++ b/packages/rspeedy/plugin-lynx/test/debug.test.ts
@@ -1,0 +1,28 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { describe, expect, rstest, test } from '@rstest/core'
+
+import { isDebug } from '../src/debug.js'
+
+describe('isDebug', () => {
+  test('accepts the lynx namespace and the rspeedy one', () => {
+    for (const value of ['lynx', 'rspeedy', 'lynx,rsbuild', '*']) {
+      rstest.stubEnv('DEBUG', value)
+      try {
+        expect(isDebug(), value).toBe(true)
+      } finally {
+        rstest.unstubAllEnvs()
+      }
+    }
+  })
+
+  test('ignores other namespaces', () => {
+    rstest.stubEnv('DEBUG', 'rslib')
+    try {
+      expect(isDebug()).toBe(false)
+    } finally {
+      rstest.unstubAllEnvs()
+    }
+  })
+})

--- a/packages/rspeedy/plugin-react/src/entry.ts
+++ b/packages/rspeedy/plugin-react/src/entry.ts
@@ -348,7 +348,7 @@ export const isDebug = (): boolean => {
   }
 
   const values = process.env['DEBUG'].toLocaleLowerCase().split(',')
-  return ['rspeedy', '*'].some((key) => values.includes(key))
+  return ['lynx', 'rspeedy', '*'].some((key) => values.includes(key))
 }
 
 // This is copied from https://github.com/web-infra-dev/rsbuild/blob/037da7b9d92e20c7136c8b2efa21eef539fa2f88/packages/core/src/plugins/html.ts#L168

--- a/packages/rspeedy/plugin-react/test/debug.test.ts
+++ b/packages/rspeedy/plugin-react/test/debug.test.ts
@@ -1,0 +1,28 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { describe, expect, rstest, test } from '@rstest/core'
+
+import { isDebug } from '../src/entry.js'
+
+describe('isDebug', () => {
+  test('accepts the lynx namespace and the rspeedy one', () => {
+    for (const value of ['lynx', 'rspeedy', 'lynx,rsbuild', '*']) {
+      rstest.stubEnv('DEBUG', value)
+      try {
+        expect(isDebug(), value).toBe(true)
+      } finally {
+        rstest.unstubAllEnvs()
+      }
+    }
+  })
+
+  test('ignores other namespaces', () => {
+    rstest.stubEnv('DEBUG', 'rslib')
+    try {
+      expect(isDebug()).toBe(false)
+    } finally {
+      rstest.unstubAllEnvs()
+    }
+  })
+})

--- a/packages/webpack/template-webpack-plugin/src/LynxEncodePlugin.ts
+++ b/packages/webpack/template-webpack-plugin/src/LynxEncodePlugin.ts
@@ -476,6 +476,9 @@ export function isDebug(): boolean {
 
   const values = process.env['DEBUG'].toLocaleLowerCase().split(',');
   return [
+    'lynx',
+    'lynx:*',
+    'lynx:template',
     'rspeedy',
     '*',
     'rspeedy:*',

--- a/packages/webpack/template-webpack-plugin/src/LynxTemplatePlugin.ts
+++ b/packages/webpack/template-webpack-plugin/src/LynxTemplatePlugin.ts
@@ -1369,6 +1369,9 @@ export function isDebug(): boolean {
 
   const values = process.env['DEBUG'].toLocaleLowerCase().split(',');
   return [
+    'lynx',
+    'lynx:*',
+    'lynx:template',
     'rspeedy',
     '*',
     'rspeedy:*',

--- a/packages/webpack/template-webpack-plugin/src/worker/encode.ts
+++ b/packages/webpack/template-webpack-plugin/src/worker/encode.ts
@@ -40,6 +40,8 @@ export function isDebug(): boolean {
 
   const values = process.env['DEBUG'].toLocaleLowerCase().split(',');
   return [
+    'lynx:*',
+    'lynx:template',
     'rspeedy:*',
     'rspeedy:template',
   ].some(value => values.includes(value));

--- a/packages/webpack/template-webpack-plugin/test/is-debug.test.ts
+++ b/packages/webpack/template-webpack-plugin/test/is-debug.test.ts
@@ -1,0 +1,39 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { describe, expect, rstest, test } from '@rstest/core';
+
+import { isDebug as isEncodeDebug } from '../src/LynxEncodePlugin.js';
+import { isDebug as isTemplateDebug } from '../src/LynxTemplatePlugin.js';
+import { isDebug as isTraceDebug } from '../src/worker/encode.js';
+
+function withDebug(value: string, fn: () => void) {
+  rstest.stubEnv('DEBUG', value);
+  try {
+    fn();
+  } finally {
+    rstest.unstubAllEnvs();
+  }
+}
+
+describe('isDebug', () => {
+  test('the template and encode plugins accept the lynx namespace', () => {
+    for (const value of ['lynx', 'lynx:*', 'lynx:template', 'rspeedy']) {
+      withDebug(value, () => {
+        expect(isTemplateDebug(), value).toBe(true);
+        expect(isEncodeDebug(), value).toBe(true);
+      });
+    }
+    withDebug('rslib', () => {
+      expect(isTemplateDebug()).toBe(false);
+      expect(isEncodeDebug()).toBe(false);
+    });
+  });
+
+  test('the encode trace only listens to the sub-namespaces', () => {
+    for (const value of ['lynx:*', 'lynx:template', 'rspeedy:template']) {
+      withDebug(value, () => expect(isTraceDebug(), value).toBe(true));
+    }
+    withDebug('lynx', () => expect(isTraceDebug()).toBe(false));
+  });
+});


### PR DESCRIPTION
The plugins that read `DEBUG` still answer to `rspeedy` only, from before they moved out of Rspeedy, so a Rslib or Rsbuild build has no namespace of its own to turn the Lynx intermediates on with.

Accept `lynx` (and `lynx:*`, `lynx:template`) wherever `rspeedy` is accepted. `rspeedy` keeps working; `lynx` is the recommended form.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for `DEBUG=lynx`, `DEBUG=lynx:*`, and `DEBUG=lynx:template` across Lynx and Rsbuild tooling.
  * Debug metadata is now emitted for local Lynx production builds when `DEBUG=lynx` is enabled.
  * Existing `DEBUG=rspeedy` compatibility is retained.

* **Documentation**
  * Updated environment variable examples to recommend `DEBUG=lynx`.

* **Tests**
  * Added coverage for the new debug namespaces across build, plugin, and metadata workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->