### PR TITLE
fix(react): drain queued effect flushes before destroying the page

### DIFF
--- a/packages/react/runtime/__test__/snapshot/lifecycle/destroy-pending-cleanup.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/lifecycle/destroy-pending-cleanup.test.jsx
@@ -1,0 +1,98 @@
+import { beforeAll, describe, expect, test, vi } from 'vitest';
+
+describe('page destroy with queued unmount cleanups', () => {
+  beforeAll(() => {
+    lynx.getCoreContext = vi.fn(() => ({ addEventListener: vi.fn(), removeEventListener: vi.fn() }));
+  });
+
+  test('runs a cleanup deferred by an earlier unmount', async () => {
+    vi.resetModules();
+    await import('../../../src/lynx');
+
+    const { h, render, Fragment } = await import('preact');
+    const { useEffect } = await import('../../../src/index');
+    const { __root } = await import('../../../src/root');
+
+    const cleanup = vi.fn();
+    function WithEffect() {
+      useEffect(() => cleanup, []);
+      return null;
+    }
+    function WithoutHooks() {
+      return null;
+    }
+
+    render(h(Fragment, null, h(WithEffect, null), h(WithoutHooks, null)), __root);
+    await Promise.resolve().then(() => {});
+
+    // Removing it queues the cleanup for the after-paint flush.
+    render(h(Fragment, null, h(WithoutHooks, null)), __root);
+    expect(cleanup).toHaveBeenCalledTimes(0);
+
+    // Destroy before that flush runs. Nothing left in the tree has a passive
+    // effect, so no later `afterPaint` reschedules the queued flush.
+    lynx.getApp().callDestroyLifetimeFun();
+
+    expect(cleanup).toHaveBeenCalledTimes(1);
+  });
+
+  test('still runs it when another effect component unmounts during destroy', async () => {
+    vi.resetModules();
+    await import('../../../src/lynx');
+
+    const { h, render, Fragment } = await import('preact');
+    const { useEffect } = await import('../../../src/index');
+    const { __root } = await import('../../../src/root');
+
+    const removedCleanup = vi.fn();
+    const remainingCleanup = vi.fn();
+    function Removed() {
+      useEffect(() => removedCleanup, []);
+      return null;
+    }
+    function Remaining() {
+      useEffect(() => remainingCleanup, []);
+      return null;
+    }
+
+    render(h(Fragment, null, h(Removed, null), h(Remaining, null)), __root);
+    await Promise.resolve().then(() => {});
+
+    render(h(Fragment, null, h(Remaining, null)), __root);
+    expect(removedCleanup).toHaveBeenCalledTimes(0);
+
+    lynx.getApp().callDestroyLifetimeFun();
+
+    expect(remainingCleanup).toHaveBeenCalledTimes(1);
+    expect(removedCleanup).toHaveBeenCalledTimes(1);
+  });
+
+  test('runs it on the reload path too', async () => {
+    vi.resetModules();
+    await import('../../../src/lynx');
+
+    const { h, render, Fragment } = await import('preact');
+    const { useEffect } = await import('../../../src/index');
+    const { __root } = await import('../../../src/root');
+    const { reloadBackground } = await import('../../../src/snapshot/lifecycle/reload');
+
+    const cleanup = vi.fn();
+    function WithEffect() {
+      useEffect(() => cleanup, []);
+      return null;
+    }
+    function WithoutHooks() {
+      return null;
+    }
+
+    render(h(Fragment, null, h(WithEffect, null), h(WithoutHooks, null)), __root);
+    await Promise.resolve().then(() => {});
+
+    render(h(Fragment, null, h(WithoutHooks, null)), __root);
+    expect(cleanup).toHaveBeenCalledTimes(0);
+
+    reloadBackground({});
+
+    expect(cleanup).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/react/runtime/src/lynx.ts
+++ b/packages/react/runtime/src/lynx.ts
@@ -22,7 +22,7 @@ import { initTimingAPI } from './snapshot/lynx/performance.js';
 import { injectPrepareLazyBundleMTS } from './snapshot/lynx/prepareLazyBundleMTS.js';
 import { injectTt } from './snapshot/lynx/tt.js';
 import { injectUpdateMTRefInitValue } from './snapshot/worklet/ref/updateInitValue.js';
-import { lynxQueueMicrotask } from './utils.js';
+import { deferEffectFlush } from './utils.js';
 
 export { runWithForce } from './snapshot/lynx/runWithForce.js';
 
@@ -72,7 +72,7 @@ if (typeof __ALOG_ELEMENT_API__ !== 'undefined' && __ALOG_ELEMENT_API__) {
 if (typeof __BACKGROUND__ !== 'undefined' && __BACKGROUND__) {
   // Trick Preact and TypeScript to accept our custom document adapter.
   options.document = document as unknown as Document;
-  options.requestAnimationFrame = lynxQueueMicrotask;
+  options.requestAnimationFrame = deferEffectFlush;
   setupBackgroundDocument();
   injectTt();
   addCtxNotFoundEventListener();

--- a/packages/react/runtime/src/utils.ts
+++ b/packages/react/runtime/src/utils.ts
@@ -85,8 +85,40 @@ export function hook<T, K extends keyof T>(
   } as T[K];
 }
 
+let pendingEffectFlushes: (() => void)[] = [];
+
 /**
- * Runs `fn` with Preact's after-paint scheduler switched to synchronous.
+ * Preact's after-paint scheduler, deferred to a microtask.
+ *
+ * The scheduled callbacks are also tracked so that {@link withSyncEffectFlush}
+ * can run the ones still outstanding: switching `options.requestAnimationFrame`
+ * only redirects future scheduling, and Preact reschedules an already-queued
+ * flush solely when a later `afterPaint` call observes the swap.
+ */
+export const deferEffectFlush: (cb: () => void) => void = cb => {
+  pendingEffectFlushes.push(cb);
+  lynxQueueMicrotask(() => {
+    const index = pendingEffectFlushes.indexOf(cb);
+    if (index !== -1) {
+      pendingEffectFlushes.splice(index, 1);
+      cb();
+    }
+  });
+};
+
+function drainPendingEffectFlushes(): void {
+  // Runs after the scheduler swap above, so anything these callbacks schedule
+  // is invoked synchronously instead of landing back in the queue.
+  const callbacks = pendingEffectFlushes;
+  pendingEffectFlushes = [];
+  callbacks.forEach(cb => {
+    cb();
+  });
+}
+
+/**
+ * Runs `fn` with Preact's after-paint scheduler switched to synchronous, after
+ * draining the flushes already scheduled for a later microtask.
  *
  * Preact 11 defers passive-effect cleanups of unmounted components to that
  * flush. Page destroy is the one path with no later turn to run them in:
@@ -100,6 +132,7 @@ export function withSyncEffectFlush<T>(fn: () => T): T {
     cb();
   };
   try {
+    drainPendingEffectFlushes();
     return fn();
   } finally {
     if (previousRequestAnimationFrame) {


### PR DESCRIPTION
Preact 11 defers a passive-effect cleanup of an unmounted component to the after-paint flush. If the page is destroyed before that flush runs, the cleanup can be lost.

`withSyncEffectFlush` swaps `options.requestAnimationFrame` for a synchronous scheduler, but that only redirects *future* scheduling. Preact reschedules an already-queued flush only when a later `afterPaint` call observes the swap:

```js
if (newQueueLength == 1 || prevRaf != options.requestAnimationFrame) { ... }
```

So the pending cleanup survives only when some other component with a passive effect happens to unmount during destroy. When nothing else schedules, it stays on a microtask that never runs — `callDestroyLifetimeFun` returns and native tears the runtime down.

The scheduler now records what it defers, and `withSyncEffectFlush` drains the outstanding callbacks after switching to synchronous mode.

Both destroy paths (`destroyBackground` and `destroyElementTemplateBackgroundRuntime`) go through `withSyncEffectFlush`, so both are covered. `reloadBackground` too.

First commit is the failing repro, second is the fix. The control case in the test pins the carve-out where the bug does *not* reproduce, so removing the fix fails two of the three tests rather than none.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved background rendering lifecycle handling so deferred effect cleanups reliably run when a page is destroyed, reloaded, or components are unmounted.
  - Ensured pending effect updates are flushed at the appropriate time during scheduler transitions, preventing cleanup work from being skipped.

- **Tests**
  - Added coverage for cleanup behavior across page destruction, component unmounting, and background reload scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->