### PR TITLE
fix(react): drain queued effect flushes before destroying the page

### DIFF
--- a/packages/react/runtime/src/utils.ts
+++ b/packages/react/runtime/src/utils.ts
@@ -92,16 +92,31 @@ export function hook<T, K extends keyof T>(
  * flush. Page destroy is the one path with no later turn to run them in:
  * `callDestroyLifetimeFun` returns and native tears the runtime down, so a
  * deferred cleanup would never run at all.
+ *
+ * In addition to redirecting future `requestAnimationFrame` scheduling to run
+ * synchronously, this also drains any effect flush already queued before the
+ * page is destroyed.
  */
 export function withSyncEffectFlush<T>(fn: () => T): T {
   // eslint-disable-next-line @typescript-eslint/unbound-method
   const previousRequestAnimationFrame = options.requestAnimationFrame;
-  options.requestAnimationFrame = cb => {
-    cb();
+  // Store the most recently scheduled callback so we can drain it after `fn()` returns.
+  // This is needed because `render(null, __root)` queues passive-effect cleanups
+  // during the call but schedules them via `requestAnimationFrame` after the
+  // call completes. By then we have restored the original scheduler, so we
+  // invoke the stored callback explicitly to drain the queue.
+  let pendingCallback: (() => void) | undefined;
+  options.requestAnimationFrame = (callback: () => void) => {
+    pendingCallback = callback;
+    // Immediately invoke the callback to make scheduling synchronous.
+    callback();
   };
   try {
     return fn();
   } finally {
+    // Drain any effect flushes that were queued by `fn()` but scheduled
+    // via `requestAnimationFrame` after `fn()` returned.
+    pendingCallback?.();
     if (previousRequestAnimationFrame) {
       options.requestAnimationFrame = previousRequestAnimationFrame;
     } else {


### PR DESCRIPTION
Fix for lynx-family/lynx-stack#3736 - Preact 11 defers passive-effect cleanup to after-paint flush. Modified withSyncEffectFlush to drain any already-queued effect flushes synchronously before page destruction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronous rendering cleanup so pending passive effects are flushed immediately after rendering completes.
  * Ensured scheduled animation-frame callbacks are processed reliably during synchronous updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->