### PR TITLE
feat(genui): generate main-thread script from XML fragments

### DIFF
--- a/.github/genui-lynx-xml.instructions.md
+++ b/.github/genui-lynx-xml.instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: "packages/genui/lynx-xml/**,packages/genui/server/agent/{lynx-xml-agent,html-fragment-to-main-thread-script-tool}.ts"
+applyTo: "packages/genui/lynx-xml/**,packages/genui/server/agent/{lynx-xml-agent,html-fragment-to-main-thread-script-tool}.ts,packages/genui/server/service/lynx-xml-agent.ts"
 ---
 
 Keep Lynx XML prompt construction in `packages/genui/lynx-xml`; the server
@@ -32,6 +32,11 @@ lifecycle registration, cleanup, and CSS to the agent-authored artifact.
 Bound element nesting before recursive emission, ignore whitespace-only text
 nodes, and preserve the original text of every non-empty node. Cover both
 limits with converter regression tests.
+Keep generated fragment JavaScript in a Mastra `RequestContext` registry scoped
+to one agent run. Return only an opaque placeholder plus XML-id node bindings to
+the model, require the placeholder exactly once on its own line, and expand it
+before final artifact validation and delivery. Never store generated scripts on
+the cached Agent or in a process-global registry.
 Maintain mobile-specific defaults in `src/mobile-design.ts`: start from a
 narrow portrait, single-primary-scroll layout; use responsive units and a
 consistent semantic palette; consume each safe-area edge once; reserve space

--- a/.github/genui-lynx-xml.instructions.md
+++ b/.github/genui-lynx-xml.instructions.md
@@ -29,6 +29,9 @@ deterministic initial-tree conversion. Parse well-formed fragments in source
 order, emit Element PAPI creation, literal property, and append calls that assume
 `page` and `pageId` already exist, and leave state, event handlers, updates,
 lifecycle registration, cleanup, and CSS to the agent-authored artifact.
+Bound element nesting before recursive emission, ignore whitespace-only text
+nodes, and preserve the original text of every non-empty node. Cover both
+limits with converter regression tests.
 Maintain mobile-specific defaults in `src/mobile-design.ts`: start from a
 narrow portrait, single-primary-scroll layout; use responsive units and a
 consistent semantic palette; consume each safe-area edge once; reserve space

--- a/.github/genui-lynx-xml.instructions.md
+++ b/.github/genui-lynx-xml.instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: "packages/genui/lynx-xml/**,packages/genui/server/agent/lynx-xml-agent.ts"
+applyTo: "packages/genui/lynx-xml/**,packages/genui/server/agent/{lynx-xml-agent,html-fragment-to-main-thread-script-tool}.ts"
 ---
 
 Keep Lynx XML prompt construction in `packages/genui/lynx-xml`; the server
@@ -24,6 +24,11 @@ Keep numeric component ids separate from Element PAPI node references. Both
 arguments to `__AppendElement` must be nodes, append helpers must receive the
 parent node rather than its id, and `pageId` is reserved for page-owned element
 creation APIs.
+Keep the Lynx XML agent's `html_fragment_to_main_thread_script` tool limited to
+deterministic initial-tree conversion. Parse well-formed fragments in source
+order, emit Element PAPI creation, literal property, and append calls that assume
+`page` and `pageId` already exist, and leave state, event handlers, updates,
+lifecycle registration, cleanup, and CSS to the agent-authored artifact.
 Maintain mobile-specific defaults in `src/mobile-design.ts`: start from a
 narrow portrait, single-primary-scroll layout; use responsive units and a
 consistent semantic palette; consume each safe-area edge once; reserve space

--- a/.github/genui-lynx-xml.instructions.md
+++ b/.github/genui-lynx-xml.instructions.md
@@ -24,11 +24,14 @@ Keep numeric component ids separate from Element PAPI node references. Both
 arguments to `__AppendElement` must be nodes, append helpers must receive the
 parent node rather than its id, and `pageId` is reserved for page-owned element
 creation APIs.
-Keep the Lynx XML agent's `html_fragment_to_main_thread_script` tool limited to
-deterministic initial-tree conversion. Parse well-formed fragments in source
-order, emit Element PAPI creation, literal property, and append calls that assume
-`page` and `pageId` already exist, and leave state, event handlers, updates,
-lifecycle registration, cleanup, and CSS to the agent-authored artifact.
+Keep XML fragment parsing and deterministic Element PAPI generation in
+`packages/genui/lynx-xml` and export those headless utilities from its package
+entry point. Keep the server's `html_fragment_to_main_thread_script` module
+limited to Mastra tool and request-scope wiring. Parse well-formed fragments in
+source order, emit Element PAPI creation, literal property, and append calls
+that assume `page` and `pageId` already exist, and leave state, event handlers,
+updates, lifecycle registration, cleanup, and CSS to the agent-authored
+artifact.
 Bound element nesting before recursive emission, ignore whitespace-only text
 nodes, and preserve the original text of every non-empty node. Cover both
 limits with converter regression tests.

--- a/packages/genui/lynx-xml/README.md
+++ b/packages/genui/lynx-xml/README.md
@@ -1,7 +1,9 @@
-# Lynx XML Prompt
+# Lynx XML
 
 `@lynx-js/genui-lynx-xml` owns the system prompt used to generate complete,
-zero-build `.lynxml` artifacts with Vanilla Lynx and Element PAPI.
+zero-build `.lynxml` artifacts with Vanilla Lynx and Element PAPI. It also
+provides headless utilities for converting well-formed XML fragments into
+deterministic Element PAPI JavaScript.
 
 The built-in prompt is composed from selected guidance in the direct,
 version-pinned `@lynx-js/skill-vanilla-lynx` dependency plus a small Lynx XML
@@ -43,5 +45,16 @@ const prompt = buildLynxXmlSystemPrompt({
 });
 ```
 
-The package intentionally has no model-provider, agent-runtime, renderer, or
-XML extraction dependencies. Consumers own those integration concerns.
+Convert an XML fragment into main-thread script and stable bindings for its
+`id` attributes:
+
+```ts
+import { generateMainThreadScriptResult } from '@lynx-js/genui-lynx-xml';
+
+const { bindings, javascript } = generateMainThreadScriptResult(
+  '<view id="root"><text>Hello</text></view>',
+);
+```
+
+The package intentionally has no model-provider, agent-runtime, or renderer
+dependencies. Consumers own those integration concerns.

--- a/packages/genui/lynx-xml/package.json
+++ b/packages/genui/lynx-xml/package.json
@@ -2,7 +2,7 @@
   "name": "@lynx-js/genui-lynx-xml",
   "version": "0.0.0",
   "private": true,
-  "description": "Lynx XML system prompt construction utilities for GenUI.",
+  "description": "Headless Lynx XML prompt and fragment conversion utilities for GenUI.",
   "repository": {
     "type": "git",
     "url": "https://github.com/lynx-family/lynx-stack.git",
@@ -26,7 +26,8 @@
     "test": "rstest"
   },
   "dependencies": {
-    "@lynx-js/skill-vanilla-lynx": "0.2.0"
+    "@lynx-js/skill-vanilla-lynx": "0.2.0",
+    "fast-xml-parser": "^5.11.1"
   },
   "devDependencies": {
     "@rslib/core": "catalog:rslib",

--- a/packages/genui/lynx-xml/src/html-fragment.ts
+++ b/packages/genui/lynx-xml/src/html-fragment.ts
@@ -1,0 +1,225 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { XMLParser, XMLValidator } from 'fast-xml-parser';
+
+const FRAGMENT_ROOT = 'genui-fragment';
+const MAX_XML_FRAGMENT_DEPTH = 64;
+export const MAX_XML_FRAGMENT_LENGTH = 100_000;
+const TEXT_NODE_NAME = '#text';
+const ATTRIBUTE_NODE_NAME = ':@';
+
+const ELEMENT_FACTORIES: Readonly<Record<string, string>> = {
+  frame: '__CreateFrame',
+  image: '__CreateImage',
+  'scroll-view': '__CreateScrollView',
+  text: '__CreateText',
+  view: '__CreateView',
+  wrapper: '__CreateWrapperElement',
+};
+const FORBIDDEN_FRAGMENT_ELEMENTS = new Set([
+  'lynx',
+  'page',
+  'raw-text',
+  'script',
+  'style',
+]);
+
+const parser = new XMLParser({
+  preserveOrder: true,
+  ignoreAttributes: false,
+  attributeNamePrefix: '',
+  parseAttributeValue: false,
+  parseTagValue: false,
+  trimValues: false,
+});
+
+interface GeneratorState {
+  bindings: Map<string, string>;
+  lines: string[];
+  nextNodeIndex: number;
+}
+
+export interface GeneratedMainThreadScript {
+  bindings: Record<string, string>;
+  javascript: string;
+}
+
+type OrderedXmlNode = Record<string, unknown>;
+
+/** Escape a value for safe inclusion in an inline main-thread script. */
+function javascriptString(value: string): string {
+  return JSON.stringify(value).replace(
+    /<\/script/giu,
+    (match) => `<\\/${match.slice(2)}`,
+  );
+}
+
+/** Return the Element PAPI expression that creates one XML element. */
+function createElementExpression(tagName: string): string {
+  const factory = ELEMENT_FACTORIES[tagName];
+  return factory
+    ? `${factory}(pageId)`
+    : `__CreateElement(${javascriptString(tagName)}, pageId)`;
+}
+
+/** Emit a non-empty text node while preserving its original whitespace. */
+function appendText(
+  text: string,
+  parent: string,
+  parentTagName: string | undefined,
+  state: GeneratorState,
+): void {
+  if (!text.trim()) return;
+
+  if (parentTagName === 'text') {
+    state.lines.push(
+      `__AppendElement(${parent}, __CreateRawText(${javascriptString(text)}));`,
+    );
+    return;
+  }
+
+  const node = `node${state.nextNodeIndex++}`;
+  state.lines.push(
+    `const ${node} = __CreateText(pageId);`,
+    `__AppendElement(${node}, __CreateRawText(${javascriptString(text)}));`,
+    `__AppendElement(${parent}, ${node});`,
+  );
+}
+
+/** Emit the Element PAPI call for one literal XML attribute. */
+function appendAttribute(
+  node: string,
+  name: string,
+  rawValue: unknown,
+  state: GeneratorState,
+): void {
+  const value = javascriptString(String(rawValue));
+  if (name === 'class') {
+    state.lines.push(`__SetClasses(${node}, ${value});`);
+  } else if (name === 'id') {
+    const bindingName = String(rawValue);
+    if (state.bindings.has(bindingName)) {
+      throw new Error(`Duplicate XML id: ${bindingName}`);
+    }
+    state.bindings.set(bindingName, node);
+    state.lines.push(`__SetID(${node}, ${value});`);
+  } else if (name === 'style') {
+    state.lines.push(`__SetInlineStyles(${node}, ${value});`);
+  } else if (name.startsWith('data-') && name.length > 5) {
+    state.lines.push(
+      `__AddDataset(${node}, ${javascriptString(name.slice(5))}, ${value});`,
+    );
+  } else {
+    state.lines.push(
+      `__SetAttribute(${node}, ${javascriptString(name)}, ${value});`,
+    );
+  }
+}
+
+/** Emit one parsed XML node and its depth-bounded descendants. */
+function appendParsedNode(
+  parsedNode: OrderedXmlNode,
+  parent: string,
+  parentTagName: string | undefined,
+  state: GeneratorState,
+  depth: number,
+): void {
+  const entries = Object.entries(parsedNode).filter(
+    ([name]) => name !== ATTRIBUTE_NODE_NAME,
+  );
+  if (entries.length !== 1) {
+    throw new Error('XML fragment contains an unsupported node');
+  }
+
+  const [tagName, children] = entries[0]!;
+  if (tagName === TEXT_NODE_NAME) {
+    appendText(String(children), parent, parentTagName, state);
+    return;
+  }
+  if (depth > MAX_XML_FRAGMENT_DEPTH) {
+    throw new Error(
+      `XML fragment must not exceed ${MAX_XML_FRAGMENT_DEPTH} levels of element nesting`,
+    );
+  }
+  if (!/^[a-z][a-z0-9-]*$/u.test(tagName)) {
+    throw new Error(`Unsupported XML element: ${tagName}`);
+  }
+  if (FORBIDDEN_FRAGMENT_ELEMENTS.has(tagName)) {
+    throw new Error(`Element <${tagName}> is not allowed in the XML fragment`);
+  }
+  if (!Array.isArray(children)) {
+    throw new Error(`Invalid parsed children for <${tagName}>`);
+  }
+
+  const node = `node${state.nextNodeIndex++}`;
+  state.lines.push(`const ${node} = ${createElementExpression(tagName)};`);
+
+  const attributes = parsedNode[ATTRIBUTE_NODE_NAME];
+  if (attributes && typeof attributes === 'object') {
+    for (const [name, value] of Object.entries(attributes)) {
+      appendAttribute(node, name, value, state);
+    }
+  }
+
+  for (const child of children) {
+    if (!child || typeof child !== 'object' || Array.isArray(child)) {
+      throw new Error(`Invalid parsed child in <${tagName}>`);
+    }
+    appendParsedNode(child as OrderedXmlNode, node, tagName, state, depth + 1);
+  }
+  state.lines.push(`__AppendElement(${parent}, ${node});`);
+}
+
+/** Generate Element PAPI calls and stable id-to-node bindings. */
+export function generateMainThreadScriptResult(
+  xmlFragment: string,
+): GeneratedMainThreadScript {
+  if (!xmlFragment.trim()) throw new Error('XML fragment must not be empty');
+  if (xmlFragment.length > MAX_XML_FRAGMENT_LENGTH) {
+    throw new Error(
+      `XML fragment must not exceed ${MAX_XML_FRAGMENT_LENGTH} characters`,
+    );
+  }
+
+  const wrappedFragment = `<${FRAGMENT_ROOT}>${xmlFragment}</${FRAGMENT_ROOT}>`;
+  const validation = XMLValidator.validate(wrappedFragment);
+  if (validation !== true) {
+    throw new Error(`Invalid XML fragment: ${validation.err.msg}`);
+  }
+
+  const parsed = parser.parse(wrappedFragment) as unknown;
+  if (!Array.isArray(parsed) || parsed.length !== 1) {
+    throw new Error('XML fragment could not be parsed');
+  }
+  const root = parsed[0] as OrderedXmlNode;
+  const children = root[FRAGMENT_ROOT];
+  if (!Array.isArray(children)) {
+    throw new Error('XML fragment could not be parsed');
+  }
+
+  const state: GeneratorState = {
+    bindings: new Map(),
+    lines: [],
+    nextNodeIndex: 0,
+  };
+  for (const child of children) {
+    if (!child || typeof child !== 'object' || Array.isArray(child)) {
+      throw new Error('XML fragment contains an unsupported node');
+    }
+    appendParsedNode(child as OrderedXmlNode, 'page', undefined, state, 1);
+  }
+  if (state.lines.length === 0) {
+    throw new Error('XML fragment must contain visible content');
+  }
+  return {
+    bindings: Object.fromEntries(state.bindings),
+    javascript: state.lines.join('\n'),
+  };
+}
+
+/** Convert an XML element fragment into Element PAPI calls for renderPage(). */
+export function generateMainThreadScript(xmlFragment: string): string {
+  return generateMainThreadScriptResult(xmlFragment).javascript;
+}

--- a/packages/genui/lynx-xml/src/index.ts
+++ b/packages/genui/lynx-xml/src/index.ts
@@ -5,6 +5,8 @@
 export {
   buildLynxXmlSystemPrompt,
   LYNX_XML_ENGINE_VERSION,
+  LYNX_XML_HTML_FRAGMENT_TOOL_INSTRUCTIONS,
+  LYNX_XML_HTML_FRAGMENT_TOOL_SYSTEM_PROMPT,
   LYNX_XML_SYSTEM_PROMPT,
 } from './prompt.js';
 export type { BuildLynxXmlSystemPromptOptions } from './prompt.js';

--- a/packages/genui/lynx-xml/src/index.ts
+++ b/packages/genui/lynx-xml/src/index.ts
@@ -10,3 +10,9 @@ export {
   LYNX_XML_SYSTEM_PROMPT,
 } from './prompt.js';
 export type { BuildLynxXmlSystemPromptOptions } from './prompt.js';
+export {
+  generateMainThreadScript,
+  generateMainThreadScriptResult,
+  MAX_XML_FRAGMENT_LENGTH,
+} from './html-fragment.js';
+export type { GeneratedMainThreadScript } from './html-fragment.js';

--- a/packages/genui/lynx-xml/src/prompt.ts
+++ b/packages/genui/lynx-xml/src/prompt.ts
@@ -21,8 +21,10 @@ const ENGINE_VERSION_PATTERN = /^\d+(?:\.\d+)*$/u;
 /** Tool-specific guidance for converting initial XML element fragments. */
 export const LYNX_XML_HTML_FRAGMENT_TOOL_INSTRUCTIONS =
   `Initial tree conversion tool:
-- Draft the initial static Lynx element tree as one well-formed XML fragment, then call html_fragment_to_main_thread_script with that fragment.
-- Use the returned JavaScript inside renderPage(). It assumes page and pageId already exist and appends every top-level fragment node to page.
+- Draft the initial static Lynx element tree as one well-formed XML fragment, then call html_fragment_to_main_thread_script exactly once with that fragment. Give every node needed by event handlers or dynamic updates a unique id attribute.
+- The tool returns an opaque placeholder comment and a bindings map from XML ids to generated node variable names. It does not return the generated JavaScript.
+- Copy the placeholder exactly, without quoting or rewriting it, onto its own line inside renderPage() after page and pageId exist. The server replaces it with the generated Element PAPI statements after model generation.
+- Write event handlers and dynamic updates after the placeholder. Refer to generated nodes only through the returned bindings and do not redeclare those node variable names.
 - The tool handles element creation, literal text, classes, IDs, inline styles, datasets, attributes, and child order. Write state, event handlers, dynamic updates, lifecycle registration, and cleanup yourself.
 - Do not put style, script, lynx, page, or raw-text elements in the fragment. Keep CSS in the artifact's style block and bind events in main-thread JavaScript.`;
 

--- a/packages/genui/lynx-xml/src/prompt.ts
+++ b/packages/genui/lynx-xml/src/prompt.ts
@@ -18,6 +18,14 @@ export interface BuildLynxXmlSystemPromptOptions {
 
 const ENGINE_VERSION_PATTERN = /^\d+(?:\.\d+)*$/u;
 
+/** Tool-specific guidance for converting initial XML element fragments. */
+export const LYNX_XML_HTML_FRAGMENT_TOOL_INSTRUCTIONS =
+  `Initial tree conversion tool:
+- Draft the initial static Lynx element tree as one well-formed XML fragment, then call html_fragment_to_main_thread_script with that fragment.
+- Use the returned JavaScript inside renderPage(). It assumes page and pageId already exist and appends every top-level fragment node to page.
+- The tool handles element creation, literal text, classes, IDs, inline styles, datasets, attributes, and child order. Write state, event handlers, dynamic updates, lifecycle registration, and cleanup yourself.
+- Do not put style, script, lynx, page, or raw-text elements in the fragment. Keep CSS in the artifact's style block and bind events in main-thread JavaScript.`;
+
 /** Build a system prompt for producing complete, zero-build `.lynxml` files. */
 export function buildLynxXmlSystemPrompt(
   options: BuildLynxXmlSystemPromptOptions = {},
@@ -30,6 +38,7 @@ export function buildLynxXmlSystemPrompt(
   return appendix ? `${prompt}\n\n${appendix}` : prompt;
 }
 
+/** Normalize and validate a requested Lynx engine version. */
 function normalizeEngineVersion(engineVersion: string): string {
   const normalized = engineVersion.trim();
   if (!ENGINE_VERSION_PATTERN.test(normalized)) {
@@ -40,6 +49,7 @@ function normalizeEngineVersion(engineVersion: string): string {
   return normalized;
 }
 
+/** Build the provider-neutral Lynx XML prompt for one engine version. */
 function buildBasePrompt(engineVersion: string): string {
   return `
 You are the Lynx XML generation agent for Lynx GenUI. Turn the user's request
@@ -106,3 +116,9 @@ Product and safety requirements:
 
 /** The default Lynx XML generation system prompt. */
 export const LYNX_XML_SYSTEM_PROMPT: string = buildLynxXmlSystemPrompt();
+
+/** The Lynx XML prompt for agents with the fragment conversion tool. */
+export const LYNX_XML_HTML_FRAGMENT_TOOL_SYSTEM_PROMPT: string =
+  buildLynxXmlSystemPrompt({
+    appendix: LYNX_XML_HTML_FRAGMENT_TOOL_INSTRUCTIONS,
+  });

--- a/packages/genui/lynx-xml/test/html-fragment.test.ts
+++ b/packages/genui/lynx-xml/test/html-fragment.test.ts
@@ -1,0 +1,99 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { describe, expect, test } from '@rstest/core';
+
+import {
+  generateMainThreadScript,
+  generateMainThreadScriptResult,
+} from '../src/index.js';
+
+describe('Lynx XML HTML fragment utilities', () => {
+  test('generates ordered Element PAPI calls and id bindings', () => {
+    const result = generateMainThreadScriptResult(`
+      <scroll-view class="feed" id="root" style="height: 100vh;" scroll-orientation="vertical">
+        <view class="card" data-kind="featured">
+          <text id="greeting" aria-label="Greeting">Hello &amp; welcome</text>
+          <image src="https://example.com/cover.png" />
+        </view>
+      </scroll-view>
+    `);
+
+    expect(result.bindings).toEqual({ root: 'node0', greeting: 'node2' });
+    expect(result.javascript).toBe(`const node0 = __CreateScrollView(pageId);
+__SetClasses(node0, "feed");
+__SetID(node0, "root");
+__SetInlineStyles(node0, "height: 100vh;");
+__SetAttribute(node0, "scroll-orientation", "vertical");
+const node1 = __CreateView(pageId);
+__SetClasses(node1, "card");
+__AddDataset(node1, "kind", "featured");
+const node2 = __CreateText(pageId);
+__SetID(node2, "greeting");
+__SetAttribute(node2, "aria-label", "Greeting");
+__AppendElement(node2, __CreateRawText("Hello & welcome"));
+__AppendElement(node1, node2);
+const node3 = __CreateImage(pageId);
+__SetAttribute(node3, "src", "https://example.com/cover.png");
+__AppendElement(node1, node3);
+__AppendElement(node0, node1);
+__AppendElement(page, node0);`);
+  });
+
+  test('supports multiple roots, text content, and generic element tags', () => {
+    expect(
+      generateMainThreadScript(
+        '<view>Before<text>inside</text>after</view><input value="42" />',
+      ),
+    ).toBe(`const node0 = __CreateView(pageId);
+const node1 = __CreateText(pageId);
+__AppendElement(node1, __CreateRawText("Before"));
+__AppendElement(node0, node1);
+const node2 = __CreateText(pageId);
+__AppendElement(node2, __CreateRawText("inside"));
+__AppendElement(node0, node2);
+const node3 = __CreateText(pageId);
+__AppendElement(node3, __CreateRawText("after"));
+__AppendElement(node0, node3);
+__AppendElement(page, node0);
+const node4 = __CreateElement("input", pageId);
+__SetAttribute(node4, "value", "42");
+__AppendElement(page, node4);`);
+  });
+
+  test('preserves meaningful text whitespace and ignores whitespace-only nodes', () => {
+    const javascript = generateMainThreadScript(
+      '<text>  spaced text  </text><view>   </view>',
+    );
+
+    expect(javascript).toContain('__CreateRawText("  spaced text  ")');
+    expect(javascript).not.toContain('__CreateRawText("   ")');
+  });
+
+  test('escapes closing script sequences in generated JavaScript', () => {
+    expect(generateMainThreadScript('<text>&lt;/script&gt;</text>')).toContain(
+      '__CreateRawText("<\\/script>")',
+    );
+  });
+
+  test('rejects empty, malformed, unsafe, and overly deep fragments', () => {
+    expect(() => generateMainThreadScript('   ')).toThrow(
+      'XML fragment must not be empty',
+    );
+    expect(() => generateMainThreadScript('<view><text></view>')).toThrow(
+      'Invalid XML fragment',
+    );
+    expect(() => generateMainThreadScript('<script />')).toThrow(
+      'Element <script> is not allowed',
+    );
+    expect(() =>
+      generateMainThreadScript('<view id="duplicate"/><text id="duplicate"/>')
+    ).toThrow('Duplicate XML id: duplicate');
+
+    const overlyDeepFragment = `${'<view>'.repeat(65)}${'</view>'.repeat(65)}`;
+    expect(() => generateMainThreadScript(overlyDeepFragment)).toThrow(
+      'XML fragment must not exceed 64 levels of element nesting',
+    );
+  });
+});

--- a/packages/genui/lynx-xml/test/prompt.test.ts
+++ b/packages/genui/lynx-xml/test/prompt.test.ts
@@ -31,6 +31,15 @@ describe('buildLynxXmlSystemPrompt', () => {
     expect(LYNX_XML_HTML_FRAGMENT_TOOL_SYSTEM_PROMPT).toContain(
       'html_fragment_to_main_thread_script',
     );
+    expect(LYNX_XML_HTML_FRAGMENT_TOOL_SYSTEM_PROMPT).toContain(
+      'opaque placeholder comment',
+    );
+    expect(LYNX_XML_HTML_FRAGMENT_TOOL_SYSTEM_PROMPT).toContain(
+      'bindings map',
+    );
+    expect(LYNX_XML_HTML_FRAGMENT_TOOL_SYSTEM_PROMPT).toContain(
+      'It does not return the generated JavaScript',
+    );
   });
 
   test('composes guidance from the Vanilla Lynx skill dependency', () => {

--- a/packages/genui/lynx-xml/test/prompt.test.ts
+++ b/packages/genui/lynx-xml/test/prompt.test.ts
@@ -6,6 +6,8 @@ import { describe, expect, test } from '@rstest/core';
 
 import {
   LYNX_XML_ENGINE_VERSION,
+  LYNX_XML_HTML_FRAGMENT_TOOL_INSTRUCTIONS,
+  LYNX_XML_HTML_FRAGMENT_TOOL_SYSTEM_PROMPT,
   LYNX_XML_SYSTEM_PROMPT,
   buildLynxXmlSystemPrompt,
 } from '../src/index.js';
@@ -15,6 +17,20 @@ describe('buildLynxXmlSystemPrompt', () => {
   test('builds the exported default prompt', () => {
     expect(LYNX_XML_ENGINE_VERSION).toBe('4.2');
     expect(LYNX_XML_SYSTEM_PROMPT).toBe(buildLynxXmlSystemPrompt());
+  });
+
+  test('builds the prompt for agents with the fragment conversion tool', () => {
+    expect(LYNX_XML_HTML_FRAGMENT_TOOL_SYSTEM_PROMPT).toBe(
+      buildLynxXmlSystemPrompt({
+        appendix: LYNX_XML_HTML_FRAGMENT_TOOL_INSTRUCTIONS,
+      }),
+    );
+    expect(LYNX_XML_SYSTEM_PROMPT).not.toContain(
+      'html_fragment_to_main_thread_script',
+    );
+    expect(LYNX_XML_HTML_FRAGMENT_TOOL_SYSTEM_PROMPT).toContain(
+      'html_fragment_to_main_thread_script',
+    );
   });
 
   test('composes guidance from the Vanilla Lynx skill dependency', () => {

--- a/packages/genui/server/agent/html-fragment-to-main-thread-script-tool.ts
+++ b/packages/genui/server/agent/html-fragment-to-main-thread-script-tool.ts
@@ -7,6 +7,7 @@ import { XMLParser, XMLValidator } from 'fast-xml-parser';
 import { z } from 'zod';
 
 const FRAGMENT_ROOT = 'genui-fragment';
+const MAX_XML_FRAGMENT_DEPTH = 64;
 const MAX_XML_FRAGMENT_LENGTH = 100_000;
 const TEXT_NODE_NAME = '#text';
 const ATTRIBUTE_NODE_NAME = ':@';
@@ -43,6 +44,7 @@ interface GeneratorState {
 
 type OrderedXmlNode = Record<string, unknown>;
 
+/** Escape a value for safe inclusion in an inline main-thread script. */
 function javascriptString(value: string): string {
   return JSON.stringify(value).replace(
     /<\/script/giu,
@@ -50,6 +52,7 @@ function javascriptString(value: string): string {
   );
 }
 
+/** Return the Element PAPI expression that creates one XML element. */
 function createElementExpression(tagName: string): string {
   const factory = ELEMENT_FACTORIES[tagName];
   return factory
@@ -57,20 +60,18 @@ function createElementExpression(tagName: string): string {
     : `__CreateElement(${javascriptString(tagName)}, pageId)`;
 }
 
+/** Emit a non-empty text node while preserving its original whitespace. */
 function appendText(
   text: string,
   parent: string,
   parentTagName: string | undefined,
   state: GeneratorState,
 ): void {
-  const value = text.trim();
-  if (!value) return;
+  if (!text.trim()) return;
 
   if (parentTagName === 'text') {
     state.lines.push(
-      `__AppendElement(${parent}, __CreateRawText(${
-        javascriptString(value)
-      }));`,
+      `__AppendElement(${parent}, __CreateRawText(${javascriptString(text)}));`,
     );
     return;
   }
@@ -78,11 +79,12 @@ function appendText(
   const node = `node${state.nextNodeIndex++}`;
   state.lines.push(
     `const ${node} = __CreateText(pageId);`,
-    `__AppendElement(${node}, __CreateRawText(${javascriptString(value)}));`,
+    `__AppendElement(${node}, __CreateRawText(${javascriptString(text)}));`,
     `__AppendElement(${parent}, ${node});`,
   );
 }
 
+/** Emit the Element PAPI call for one literal XML attribute. */
 function appendAttribute(
   node: string,
   name: string,
@@ -107,11 +109,13 @@ function appendAttribute(
   }
 }
 
+/** Emit one parsed XML node and its depth-bounded descendants. */
 function appendParsedNode(
   parsedNode: OrderedXmlNode,
   parent: string,
   parentTagName: string | undefined,
   state: GeneratorState,
+  depth: number,
 ): void {
   const entries = Object.entries(parsedNode).filter(
     ([name]) => name !== ATTRIBUTE_NODE_NAME,
@@ -124,6 +128,11 @@ function appendParsedNode(
   if (tagName === TEXT_NODE_NAME) {
     appendText(String(children), parent, parentTagName, state);
     return;
+  }
+  if (depth > MAX_XML_FRAGMENT_DEPTH) {
+    throw new Error(
+      `XML fragment must not exceed ${MAX_XML_FRAGMENT_DEPTH} levels of element nesting`,
+    );
   }
   if (!/^[a-z][a-z0-9-]*$/u.test(tagName)) {
     throw new Error(`Unsupported XML element: ${tagName}`);
@@ -149,7 +158,7 @@ function appendParsedNode(
     if (!child || typeof child !== 'object' || Array.isArray(child)) {
       throw new Error(`Invalid parsed child in <${tagName}>`);
     }
-    appendParsedNode(child as OrderedXmlNode, node, tagName, state);
+    appendParsedNode(child as OrderedXmlNode, node, tagName, state, depth + 1);
   }
   state.lines.push(`__AppendElement(${parent}, ${node});`);
 }
@@ -184,7 +193,7 @@ export function generateMainThreadScript(xmlFragment: string): string {
     if (!child || typeof child !== 'object' || Array.isArray(child)) {
       throw new Error('XML fragment contains an unsupported node');
     }
-    appendParsedNode(child as OrderedXmlNode, 'page', undefined, state);
+    appendParsedNode(child as OrderedXmlNode, 'page', undefined, state, 1);
   }
   if (state.lines.length === 0) {
     throw new Error('XML fragment must contain visible content');
@@ -204,6 +213,7 @@ const outputSchema = z.object({
   ),
 });
 
+/** Create the Mastra tool that converts XML fragments into Element PAPI code. */
 export function createHtmlFragmentToMainThreadScriptTool() {
   return createTool({
     id: 'html_fragment_to_main_thread_script',

--- a/packages/genui/server/agent/html-fragment-to-main-thread-script-tool.ts
+++ b/packages/genui/server/agent/html-fragment-to-main-thread-script-tool.ts
@@ -1,0 +1,218 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { createTool } from '@mastra/core/tools';
+import { XMLParser, XMLValidator } from 'fast-xml-parser';
+import { z } from 'zod';
+
+const FRAGMENT_ROOT = 'genui-fragment';
+const MAX_XML_FRAGMENT_LENGTH = 100_000;
+const TEXT_NODE_NAME = '#text';
+const ATTRIBUTE_NODE_NAME = ':@';
+
+const ELEMENT_FACTORIES: Readonly<Record<string, string>> = {
+  frame: '__CreateFrame',
+  image: '__CreateImage',
+  'scroll-view': '__CreateScrollView',
+  text: '__CreateText',
+  view: '__CreateView',
+  wrapper: '__CreateWrapperElement',
+};
+const FORBIDDEN_FRAGMENT_ELEMENTS = new Set([
+  'lynx',
+  'page',
+  'raw-text',
+  'script',
+  'style',
+]);
+
+const parser = new XMLParser({
+  preserveOrder: true,
+  ignoreAttributes: false,
+  attributeNamePrefix: '',
+  parseAttributeValue: false,
+  parseTagValue: false,
+  trimValues: false,
+});
+
+interface GeneratorState {
+  lines: string[];
+  nextNodeIndex: number;
+}
+
+type OrderedXmlNode = Record<string, unknown>;
+
+function javascriptString(value: string): string {
+  return JSON.stringify(value).replace(
+    /<\/script/giu,
+    (match) => `<\\/${match.slice(2)}`,
+  );
+}
+
+function createElementExpression(tagName: string): string {
+  const factory = ELEMENT_FACTORIES[tagName];
+  return factory
+    ? `${factory}(pageId)`
+    : `__CreateElement(${javascriptString(tagName)}, pageId)`;
+}
+
+function appendText(
+  text: string,
+  parent: string,
+  parentTagName: string | undefined,
+  state: GeneratorState,
+): void {
+  const value = text.trim();
+  if (!value) return;
+
+  if (parentTagName === 'text') {
+    state.lines.push(
+      `__AppendElement(${parent}, __CreateRawText(${
+        javascriptString(value)
+      }));`,
+    );
+    return;
+  }
+
+  const node = `node${state.nextNodeIndex++}`;
+  state.lines.push(
+    `const ${node} = __CreateText(pageId);`,
+    `__AppendElement(${node}, __CreateRawText(${javascriptString(value)}));`,
+    `__AppendElement(${parent}, ${node});`,
+  );
+}
+
+function appendAttribute(
+  node: string,
+  name: string,
+  rawValue: unknown,
+  state: GeneratorState,
+): void {
+  const value = javascriptString(String(rawValue));
+  if (name === 'class') {
+    state.lines.push(`__SetClasses(${node}, ${value});`);
+  } else if (name === 'id') {
+    state.lines.push(`__SetID(${node}, ${value});`);
+  } else if (name === 'style') {
+    state.lines.push(`__SetInlineStyles(${node}, ${value});`);
+  } else if (name.startsWith('data-') && name.length > 5) {
+    state.lines.push(
+      `__AddDataset(${node}, ${javascriptString(name.slice(5))}, ${value});`,
+    );
+  } else {
+    state.lines.push(
+      `__SetAttribute(${node}, ${javascriptString(name)}, ${value});`,
+    );
+  }
+}
+
+function appendParsedNode(
+  parsedNode: OrderedXmlNode,
+  parent: string,
+  parentTagName: string | undefined,
+  state: GeneratorState,
+): void {
+  const entries = Object.entries(parsedNode).filter(
+    ([name]) => name !== ATTRIBUTE_NODE_NAME,
+  );
+  if (entries.length !== 1) {
+    throw new Error('XML fragment contains an unsupported node');
+  }
+
+  const [tagName, children] = entries[0]!;
+  if (tagName === TEXT_NODE_NAME) {
+    appendText(String(children), parent, parentTagName, state);
+    return;
+  }
+  if (!/^[a-z][a-z0-9-]*$/u.test(tagName)) {
+    throw new Error(`Unsupported XML element: ${tagName}`);
+  }
+  if (FORBIDDEN_FRAGMENT_ELEMENTS.has(tagName)) {
+    throw new Error(`Element <${tagName}> is not allowed in the XML fragment`);
+  }
+  if (!Array.isArray(children)) {
+    throw new Error(`Invalid parsed children for <${tagName}>`);
+  }
+
+  const node = `node${state.nextNodeIndex++}`;
+  state.lines.push(`const ${node} = ${createElementExpression(tagName)};`);
+
+  const attributes = parsedNode[ATTRIBUTE_NODE_NAME];
+  if (attributes && typeof attributes === 'object') {
+    for (const [name, value] of Object.entries(attributes)) {
+      appendAttribute(node, name, value, state);
+    }
+  }
+
+  for (const child of children) {
+    if (!child || typeof child !== 'object' || Array.isArray(child)) {
+      throw new Error(`Invalid parsed child in <${tagName}>`);
+    }
+    appendParsedNode(child as OrderedXmlNode, node, tagName, state);
+  }
+  state.lines.push(`__AppendElement(${parent}, ${node});`);
+}
+
+/** Convert an XML element fragment into Element PAPI calls for renderPage(). */
+export function generateMainThreadScript(xmlFragment: string): string {
+  if (!xmlFragment.trim()) throw new Error('XML fragment must not be empty');
+  if (xmlFragment.length > MAX_XML_FRAGMENT_LENGTH) {
+    throw new Error(
+      `XML fragment must not exceed ${MAX_XML_FRAGMENT_LENGTH} characters`,
+    );
+  }
+
+  const wrappedFragment = `<${FRAGMENT_ROOT}>${xmlFragment}</${FRAGMENT_ROOT}>`;
+  const validation = XMLValidator.validate(wrappedFragment);
+  if (validation !== true) {
+    throw new Error(`Invalid XML fragment: ${validation.err.msg}`);
+  }
+
+  const parsed = parser.parse(wrappedFragment) as unknown;
+  if (!Array.isArray(parsed) || parsed.length !== 1) {
+    throw new Error('XML fragment could not be parsed');
+  }
+  const root = parsed[0] as OrderedXmlNode;
+  const children = root[FRAGMENT_ROOT];
+  if (!Array.isArray(children)) {
+    throw new Error('XML fragment could not be parsed');
+  }
+
+  const state: GeneratorState = { lines: [], nextNodeIndex: 0 };
+  for (const child of children) {
+    if (!child || typeof child !== 'object' || Array.isArray(child)) {
+      throw new Error('XML fragment contains an unsupported node');
+    }
+    appendParsedNode(child as OrderedXmlNode, 'page', undefined, state);
+  }
+  if (state.lines.length === 0) {
+    throw new Error('XML fragment must contain visible content');
+  }
+  return state.lines.join('\n');
+}
+
+const inputSchema = z.object({
+  xmlFragment: z.string().min(1).max(MAX_XML_FRAGMENT_LENGTH).describe(
+    'A well-formed XML fragment containing the Lynx elements to create.',
+  ),
+});
+
+const outputSchema = z.object({
+  javascript: z.string().min(1).describe(
+    'Element PAPI JavaScript statements to place inside renderPage().',
+  ),
+});
+
+export function createHtmlFragmentToMainThreadScriptTool() {
+  return createTool({
+    id: 'html_fragment_to_main_thread_script',
+    description:
+      'Convert an HTML-like, well-formed XML fragment into deterministic Element PAPI JavaScript for the Lynx main-thread renderPage function. The result assumes page and pageId already exist. It creates and appends elements, text, classes, IDs, inline styles, datasets, and attributes; event handlers and lifecycle code remain the agent\'s responsibility.',
+    inputSchema,
+    outputSchema,
+    execute: async ({ xmlFragment }) => ({
+      javascript: generateMainThreadScript(xmlFragment),
+    }),
+  });
+}

--- a/packages/genui/server/agent/html-fragment-to-main-thread-script-tool.ts
+++ b/packages/genui/server/agent/html-fragment-to-main-thread-script-tool.ts
@@ -2,11 +2,18 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
+import { RequestContext } from '@mastra/core/request-context';
 import { createTool } from '@mastra/core/tools';
 import { XMLParser, XMLValidator } from 'fast-xml-parser';
 import { z } from 'zod';
 
 const FRAGMENT_ROOT = 'genui-fragment';
+const FRAGMENT_SCRIPT_RUN_STATE_KEY =
+  'lynx-xml:html-fragment-script-run-state' as const;
+const FRAGMENT_SCRIPT_PLACEHOLDER_PATTERN =
+  /^\/\*__GENUI_HTML_FRAGMENT_[0-9a-f-]{36}__\*\/$/u;
+const FRAGMENT_SCRIPT_PLACEHOLDER_IN_SOURCE_PATTERN =
+  /\/\*__GENUI_HTML_FRAGMENT_[0-9a-f-]{36}__\*\//gu;
 const MAX_XML_FRAGMENT_DEPTH = 64;
 const MAX_XML_FRAGMENT_LENGTH = 100_000;
 const TEXT_NODE_NAME = '#text';
@@ -38,11 +45,108 @@ const parser = new XMLParser({
 });
 
 interface GeneratorState {
+  bindings: Map<string, string>;
   lines: string[];
   nextNodeIndex: number;
 }
 
+interface GeneratedMainThreadScript {
+  bindings: Record<string, string>;
+  javascript: string;
+}
+
+interface FragmentScriptReplacement {
+  javascript: string;
+  placeholder: string;
+}
+
+interface FragmentScriptRunState {
+  replacements: FragmentScriptReplacement[];
+}
+
+type FragmentScriptRequestContextValues = Record<
+  typeof FRAGMENT_SCRIPT_RUN_STATE_KEY,
+  FragmentScriptRunState
+>;
+
+export interface HtmlFragmentScriptRunScope {
+  requestContext: RequestContext<FragmentScriptRequestContextValues>;
+}
+
 type OrderedXmlNode = Record<string, unknown>;
+
+/** Create isolated storage for fragment scripts generated during one run. */
+export function createHtmlFragmentScriptRunScope(): HtmlFragmentScriptRunScope {
+  const requestContext = new RequestContext<
+    FragmentScriptRequestContextValues
+  >();
+  requestContext.set(FRAGMENT_SCRIPT_RUN_STATE_KEY, { replacements: [] });
+  return { requestContext };
+}
+
+/** Count exact, non-overlapping occurrences of a value. */
+function countOccurrences(source: string, value: string): number {
+  let count = 0;
+  let offset = 0;
+  while (offset < source.length) {
+    const next = source.indexOf(value, offset);
+    if (next === -1) break;
+    count++;
+    offset = next + value.length;
+  }
+  return count;
+}
+
+/** Escape a literal string for use in a regular expression. */
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, '\\$&');
+}
+
+/** Replace registered fragment placeholders before final artifact delivery. */
+export function resolveHtmlFragmentScriptPlaceholders(
+  scope: HtmlFragmentScriptRunScope,
+  source: string,
+): string {
+  const state = scope.requestContext.get(FRAGMENT_SCRIPT_RUN_STATE_KEY);
+  if (!state) {
+    throw new Error('HTML fragment script run scope is not initialized');
+  }
+
+  const knownPlaceholders = new Set(
+    state.replacements.map((replacement) => replacement.placeholder),
+  );
+  const unknownPlaceholder = source.match(
+    FRAGMENT_SCRIPT_PLACEHOLDER_IN_SOURCE_PATTERN,
+  )?.find((placeholder) => !knownPlaceholders.has(placeholder));
+  if (unknownPlaceholder) {
+    throw new Error(
+      'Lynx XML artifact contains an unknown fragment placeholder',
+    );
+  }
+
+  let resolved = source;
+  for (const replacement of state.replacements) {
+    if (countOccurrences(resolved, replacement.placeholder) !== 1) {
+      throw new Error(
+        'Each generated fragment placeholder must appear exactly once',
+      );
+    }
+    const standalonePlaceholder = new RegExp(
+      `^[\\t ]*${escapeRegExp(replacement.placeholder)}[\\t ]*\\r?$`,
+      'mu',
+    );
+    if (!standalonePlaceholder.test(resolved)) {
+      throw new Error(
+        'Each generated fragment placeholder must appear on its own line',
+      );
+    }
+    resolved = resolved.replace(
+      replacement.placeholder,
+      replacement.javascript,
+    );
+  }
+  return resolved;
+}
 
 /** Escape a value for safe inclusion in an inline main-thread script. */
 function javascriptString(value: string): string {
@@ -95,6 +199,11 @@ function appendAttribute(
   if (name === 'class') {
     state.lines.push(`__SetClasses(${node}, ${value});`);
   } else if (name === 'id') {
+    const bindingName = String(rawValue);
+    if (state.bindings.has(bindingName)) {
+      throw new Error(`Duplicate XML id: ${bindingName}`);
+    }
+    state.bindings.set(bindingName, node);
     state.lines.push(`__SetID(${node}, ${value});`);
   } else if (name === 'style') {
     state.lines.push(`__SetInlineStyles(${node}, ${value});`);
@@ -163,8 +272,10 @@ function appendParsedNode(
   state.lines.push(`__AppendElement(${parent}, ${node});`);
 }
 
-/** Convert an XML element fragment into Element PAPI calls for renderPage(). */
-export function generateMainThreadScript(xmlFragment: string): string {
+/** Generate Element PAPI calls and stable id-to-node bindings. */
+function generateMainThreadScriptResult(
+  xmlFragment: string,
+): GeneratedMainThreadScript {
   if (!xmlFragment.trim()) throw new Error('XML fragment must not be empty');
   if (xmlFragment.length > MAX_XML_FRAGMENT_LENGTH) {
     throw new Error(
@@ -188,7 +299,11 @@ export function generateMainThreadScript(xmlFragment: string): string {
     throw new Error('XML fragment could not be parsed');
   }
 
-  const state: GeneratorState = { lines: [], nextNodeIndex: 0 };
+  const state: GeneratorState = {
+    bindings: new Map(),
+    lines: [],
+    nextNodeIndex: 0,
+  };
   for (const child of children) {
     if (!child || typeof child !== 'object' || Array.isArray(child)) {
       throw new Error('XML fragment contains an unsupported node');
@@ -198,7 +313,40 @@ export function generateMainThreadScript(xmlFragment: string): string {
   if (state.lines.length === 0) {
     throw new Error('XML fragment must contain visible content');
   }
-  return state.lines.join('\n');
+  return {
+    bindings: Object.fromEntries(state.bindings),
+    javascript: state.lines.join('\n'),
+  };
+}
+
+/** Convert an XML element fragment into Element PAPI calls for renderPage(). */
+export function generateMainThreadScript(xmlFragment: string): string {
+  return generateMainThreadScriptResult(xmlFragment).javascript;
+}
+
+/** Store one generated script and return its model-visible indirection data. */
+function registerHtmlFragmentScript(
+  requestContext: RequestContext<FragmentScriptRequestContextValues>,
+  generated: GeneratedMainThreadScript,
+): { bindings: Record<string, string>; placeholder: string } {
+  const state = requestContext.get(FRAGMENT_SCRIPT_RUN_STATE_KEY);
+  if (!state) {
+    throw new Error('HTML fragment script run scope is not initialized');
+  }
+  if (state.replacements.length > 0) {
+    throw new Error(
+      'HTML fragment conversion may only be called once per agent run',
+    );
+  }
+
+  const placeholder = `/*__GENUI_HTML_FRAGMENT_${crypto.randomUUID()}__*/`;
+  requestContext.set(FRAGMENT_SCRIPT_RUN_STATE_KEY, {
+    replacements: [...state.replacements, {
+      javascript: generated.javascript,
+      placeholder,
+    }],
+  });
+  return { bindings: generated.bindings, placeholder };
 }
 
 const inputSchema = z.object({
@@ -208,9 +356,21 @@ const inputSchema = z.object({
 });
 
 const outputSchema = z.object({
-  javascript: z.string().min(1).describe(
-    'Element PAPI JavaScript statements to place inside renderPage().',
+  placeholder: z.string().regex(FRAGMENT_SCRIPT_PLACEHOLDER_PATTERN).describe(
+    'An opaque comment marker to copy exactly once onto its own line inside renderPage(). The server replaces it with generated Element PAPI JavaScript after model generation.',
   ),
+  bindings: z.record(z.string(), z.string().regex(/^node\d+$/u)).describe(
+    'A map from XML id attributes to generated JavaScript node variable names for event handlers and updates.',
+  ),
+});
+
+const requestContextSchema = z.object({
+  [FRAGMENT_SCRIPT_RUN_STATE_KEY]: z.object({
+    replacements: z.array(z.object({
+      javascript: z.string().min(1),
+      placeholder: z.string().regex(FRAGMENT_SCRIPT_PLACEHOLDER_PATTERN),
+    })).max(1),
+  }),
 });
 
 /** Create the Mastra tool that converts XML fragments into Element PAPI code. */
@@ -218,11 +378,16 @@ export function createHtmlFragmentToMainThreadScriptTool() {
   return createTool({
     id: 'html_fragment_to_main_thread_script',
     description:
-      'Convert an HTML-like, well-formed XML fragment into deterministic Element PAPI JavaScript for the Lynx main-thread renderPage function. The result assumes page and pageId already exist. It creates and appends elements, text, classes, IDs, inline styles, datasets, and attributes; event handlers and lifecycle code remain the agent\'s responsibility.',
+      'Convert one HTML-like, well-formed XML fragment into server-held Element PAPI JavaScript. Returns only an opaque placeholder to copy exactly once onto its own line inside renderPage(), plus bindings from XML id attributes to generated node variables. The server replaces the placeholder after model generation, so never expand or rewrite it. Event handlers and lifecycle code remain the agent\'s responsibility.',
     inputSchema,
     outputSchema,
-    execute: async ({ xmlFragment }) => ({
-      javascript: generateMainThreadScript(xmlFragment),
-    }),
+    requestContextSchema,
+    execute: async ({ xmlFragment }, context) =>
+      registerHtmlFragmentScript(
+        context.requestContext as RequestContext<
+          FragmentScriptRequestContextValues
+        >,
+        generateMainThreadScriptResult(xmlFragment),
+      ),
   });
 }

--- a/packages/genui/server/agent/html-fragment-to-main-thread-script-tool.ts
+++ b/packages/genui/server/agent/html-fragment-to-main-thread-script-tool.ts
@@ -4,56 +4,20 @@
 
 import { RequestContext } from '@mastra/core/request-context';
 import { createTool } from '@mastra/core/tools';
-import { XMLParser, XMLValidator } from 'fast-xml-parser';
 import { z } from 'zod';
 
-const FRAGMENT_ROOT = 'genui-fragment';
+import {
+  MAX_XML_FRAGMENT_LENGTH,
+  generateMainThreadScriptResult,
+} from '@lynx-js/genui-lynx-xml';
+import type { GeneratedMainThreadScript } from '@lynx-js/genui-lynx-xml';
+
 const FRAGMENT_SCRIPT_RUN_STATE_KEY =
   'lynx-xml:html-fragment-script-run-state' as const;
 const FRAGMENT_SCRIPT_PLACEHOLDER_PATTERN =
   /^\/\*__GENUI_HTML_FRAGMENT_[0-9a-f-]{36}__\*\/$/u;
 const FRAGMENT_SCRIPT_PLACEHOLDER_IN_SOURCE_PATTERN =
   /\/\*__GENUI_HTML_FRAGMENT_[0-9a-f-]{36}__\*\//gu;
-const MAX_XML_FRAGMENT_DEPTH = 64;
-const MAX_XML_FRAGMENT_LENGTH = 100_000;
-const TEXT_NODE_NAME = '#text';
-const ATTRIBUTE_NODE_NAME = ':@';
-
-const ELEMENT_FACTORIES: Readonly<Record<string, string>> = {
-  frame: '__CreateFrame',
-  image: '__CreateImage',
-  'scroll-view': '__CreateScrollView',
-  text: '__CreateText',
-  view: '__CreateView',
-  wrapper: '__CreateWrapperElement',
-};
-const FORBIDDEN_FRAGMENT_ELEMENTS = new Set([
-  'lynx',
-  'page',
-  'raw-text',
-  'script',
-  'style',
-]);
-
-const parser = new XMLParser({
-  preserveOrder: true,
-  ignoreAttributes: false,
-  attributeNamePrefix: '',
-  parseAttributeValue: false,
-  parseTagValue: false,
-  trimValues: false,
-});
-
-interface GeneratorState {
-  bindings: Map<string, string>;
-  lines: string[];
-  nextNodeIndex: number;
-}
-
-interface GeneratedMainThreadScript {
-  bindings: Record<string, string>;
-  javascript: string;
-}
 
 interface FragmentScriptReplacement {
   javascript: string;
@@ -72,8 +36,6 @@ type FragmentScriptRequestContextValues = Record<
 export interface HtmlFragmentScriptRunScope {
   requestContext: RequestContext<FragmentScriptRequestContextValues>;
 }
-
-type OrderedXmlNode = Record<string, unknown>;
 
 /** Create isolated storage for fragment scripts generated during one run. */
 export function createHtmlFragmentScriptRunScope(): HtmlFragmentScriptRunScope {
@@ -146,182 +108,6 @@ export function resolveHtmlFragmentScriptPlaceholders(
     );
   }
   return resolved;
-}
-
-/** Escape a value for safe inclusion in an inline main-thread script. */
-function javascriptString(value: string): string {
-  return JSON.stringify(value).replace(
-    /<\/script/giu,
-    (match) => `<\\/${match.slice(2)}`,
-  );
-}
-
-/** Return the Element PAPI expression that creates one XML element. */
-function createElementExpression(tagName: string): string {
-  const factory = ELEMENT_FACTORIES[tagName];
-  return factory
-    ? `${factory}(pageId)`
-    : `__CreateElement(${javascriptString(tagName)}, pageId)`;
-}
-
-/** Emit a non-empty text node while preserving its original whitespace. */
-function appendText(
-  text: string,
-  parent: string,
-  parentTagName: string | undefined,
-  state: GeneratorState,
-): void {
-  if (!text.trim()) return;
-
-  if (parentTagName === 'text') {
-    state.lines.push(
-      `__AppendElement(${parent}, __CreateRawText(${javascriptString(text)}));`,
-    );
-    return;
-  }
-
-  const node = `node${state.nextNodeIndex++}`;
-  state.lines.push(
-    `const ${node} = __CreateText(pageId);`,
-    `__AppendElement(${node}, __CreateRawText(${javascriptString(text)}));`,
-    `__AppendElement(${parent}, ${node});`,
-  );
-}
-
-/** Emit the Element PAPI call for one literal XML attribute. */
-function appendAttribute(
-  node: string,
-  name: string,
-  rawValue: unknown,
-  state: GeneratorState,
-): void {
-  const value = javascriptString(String(rawValue));
-  if (name === 'class') {
-    state.lines.push(`__SetClasses(${node}, ${value});`);
-  } else if (name === 'id') {
-    const bindingName = String(rawValue);
-    if (state.bindings.has(bindingName)) {
-      throw new Error(`Duplicate XML id: ${bindingName}`);
-    }
-    state.bindings.set(bindingName, node);
-    state.lines.push(`__SetID(${node}, ${value});`);
-  } else if (name === 'style') {
-    state.lines.push(`__SetInlineStyles(${node}, ${value});`);
-  } else if (name.startsWith('data-') && name.length > 5) {
-    state.lines.push(
-      `__AddDataset(${node}, ${javascriptString(name.slice(5))}, ${value});`,
-    );
-  } else {
-    state.lines.push(
-      `__SetAttribute(${node}, ${javascriptString(name)}, ${value});`,
-    );
-  }
-}
-
-/** Emit one parsed XML node and its depth-bounded descendants. */
-function appendParsedNode(
-  parsedNode: OrderedXmlNode,
-  parent: string,
-  parentTagName: string | undefined,
-  state: GeneratorState,
-  depth: number,
-): void {
-  const entries = Object.entries(parsedNode).filter(
-    ([name]) => name !== ATTRIBUTE_NODE_NAME,
-  );
-  if (entries.length !== 1) {
-    throw new Error('XML fragment contains an unsupported node');
-  }
-
-  const [tagName, children] = entries[0]!;
-  if (tagName === TEXT_NODE_NAME) {
-    appendText(String(children), parent, parentTagName, state);
-    return;
-  }
-  if (depth > MAX_XML_FRAGMENT_DEPTH) {
-    throw new Error(
-      `XML fragment must not exceed ${MAX_XML_FRAGMENT_DEPTH} levels of element nesting`,
-    );
-  }
-  if (!/^[a-z][a-z0-9-]*$/u.test(tagName)) {
-    throw new Error(`Unsupported XML element: ${tagName}`);
-  }
-  if (FORBIDDEN_FRAGMENT_ELEMENTS.has(tagName)) {
-    throw new Error(`Element <${tagName}> is not allowed in the XML fragment`);
-  }
-  if (!Array.isArray(children)) {
-    throw new Error(`Invalid parsed children for <${tagName}>`);
-  }
-
-  const node = `node${state.nextNodeIndex++}`;
-  state.lines.push(`const ${node} = ${createElementExpression(tagName)};`);
-
-  const attributes = parsedNode[ATTRIBUTE_NODE_NAME];
-  if (attributes && typeof attributes === 'object') {
-    for (const [name, value] of Object.entries(attributes)) {
-      appendAttribute(node, name, value, state);
-    }
-  }
-
-  for (const child of children) {
-    if (!child || typeof child !== 'object' || Array.isArray(child)) {
-      throw new Error(`Invalid parsed child in <${tagName}>`);
-    }
-    appendParsedNode(child as OrderedXmlNode, node, tagName, state, depth + 1);
-  }
-  state.lines.push(`__AppendElement(${parent}, ${node});`);
-}
-
-/** Generate Element PAPI calls and stable id-to-node bindings. */
-function generateMainThreadScriptResult(
-  xmlFragment: string,
-): GeneratedMainThreadScript {
-  if (!xmlFragment.trim()) throw new Error('XML fragment must not be empty');
-  if (xmlFragment.length > MAX_XML_FRAGMENT_LENGTH) {
-    throw new Error(
-      `XML fragment must not exceed ${MAX_XML_FRAGMENT_LENGTH} characters`,
-    );
-  }
-
-  const wrappedFragment = `<${FRAGMENT_ROOT}>${xmlFragment}</${FRAGMENT_ROOT}>`;
-  const validation = XMLValidator.validate(wrappedFragment);
-  if (validation !== true) {
-    throw new Error(`Invalid XML fragment: ${validation.err.msg}`);
-  }
-
-  const parsed = parser.parse(wrappedFragment) as unknown;
-  if (!Array.isArray(parsed) || parsed.length !== 1) {
-    throw new Error('XML fragment could not be parsed');
-  }
-  const root = parsed[0] as OrderedXmlNode;
-  const children = root[FRAGMENT_ROOT];
-  if (!Array.isArray(children)) {
-    throw new Error('XML fragment could not be parsed');
-  }
-
-  const state: GeneratorState = {
-    bindings: new Map(),
-    lines: [],
-    nextNodeIndex: 0,
-  };
-  for (const child of children) {
-    if (!child || typeof child !== 'object' || Array.isArray(child)) {
-      throw new Error('XML fragment contains an unsupported node');
-    }
-    appendParsedNode(child as OrderedXmlNode, 'page', undefined, state, 1);
-  }
-  if (state.lines.length === 0) {
-    throw new Error('XML fragment must contain visible content');
-  }
-  return {
-    bindings: Object.fromEntries(state.bindings),
-    javascript: state.lines.join('\n'),
-  };
-}
-
-/** Convert an XML element fragment into Element PAPI calls for renderPage(). */
-export function generateMainThreadScript(xmlFragment: string): string {
-  return generateMainThreadScriptResult(xmlFragment).javascript;
 }
 
 /** Store one generated script and return its model-visible indirection data. */

--- a/packages/genui/server/agent/lynx-xml-agent.ts
+++ b/packages/genui/server/agent/lynx-xml-agent.ts
@@ -4,21 +4,11 @@
 
 import { Agent } from '@mastra/core/agent';
 
-import { buildLynxXmlSystemPrompt } from '@lynx-js/genui-lynx-xml';
+import { LYNX_XML_HTML_FRAGMENT_TOOL_SYSTEM_PROMPT } from '@lynx-js/genui-lynx-xml';
 
 import { createHtmlFragmentToMainThreadScriptTool } from './html-fragment-to-main-thread-script-tool.js';
 import { createLLMProvider } from './openai-provider.js';
 import type { OpenAIProviderOptions } from './openai-provider.js';
-
-const HTML_FRAGMENT_TOOL_INSTRUCTIONS = `Initial tree conversion tool:
-- Draft the initial static Lynx element tree as one well-formed XML fragment, then call html_fragment_to_main_thread_script with that fragment.
-- Use the returned JavaScript inside renderPage(). It assumes page and pageId already exist and appends every top-level fragment node to page.
-- The tool handles element creation, literal text, classes, IDs, inline styles, datasets, attributes, and child order. Write state, event handlers, dynamic updates, lifecycle registration, and cleanup yourself.
-- Do not put style, script, lynx, page, or raw-text elements in the fragment. Keep CSS in the artifact's style block and bind events in main-thread JavaScript.`;
-
-export const LYNX_XML_AGENT_INSTRUCTIONS = buildLynxXmlSystemPrompt({
-  appendix: HTML_FRAGMENT_TOOL_INSTRUCTIONS,
-});
 
 interface LynxXmlAgentRunOptions {
   abortSignal?: AbortSignal | undefined;
@@ -39,6 +29,7 @@ export interface LynxXmlAgent {
   ) => unknown;
 }
 
+/** Create the provider-backed Lynx XML agent and its fragment conversion tool. */
 export function createLynxXmlAgent(opts: OpenAIProviderOptions = {}) {
   const { buildModel, model } = createLLMProvider(opts);
   const htmlFragmentToMainThreadScript =
@@ -46,7 +37,7 @@ export function createLynxXmlAgent(opts: OpenAIProviderOptions = {}) {
   const agent = new Agent({
     id: 'lynx-xml-agent',
     name: 'LynxXmlAgent',
-    instructions: LYNX_XML_AGENT_INSTRUCTIONS,
+    instructions: LYNX_XML_HTML_FRAGMENT_TOOL_SYSTEM_PROMPT,
     model: buildModel(model),
     tools: {
       html_fragment_to_main_thread_script: htmlFragmentToMainThreadScript,

--- a/packages/genui/server/agent/lynx-xml-agent.ts
+++ b/packages/genui/server/agent/lynx-xml-agent.ts
@@ -4,14 +4,21 @@
 
 import { Agent } from '@mastra/core/agent';
 
-import { LYNX_XML_SYSTEM_PROMPT } from '@lynx-js/genui-lynx-xml';
+import { buildLynxXmlSystemPrompt } from '@lynx-js/genui-lynx-xml';
 
+import { createHtmlFragmentToMainThreadScriptTool } from './html-fragment-to-main-thread-script-tool.js';
 import { createLLMProvider } from './openai-provider.js';
 import type { OpenAIProviderOptions } from './openai-provider.js';
 
-export {
-  LYNX_XML_SYSTEM_PROMPT as LYNX_XML_AGENT_INSTRUCTIONS,
-} from '@lynx-js/genui-lynx-xml';
+const HTML_FRAGMENT_TOOL_INSTRUCTIONS = `Initial tree conversion tool:
+- Draft the initial static Lynx element tree as one well-formed XML fragment, then call html_fragment_to_main_thread_script with that fragment.
+- Use the returned JavaScript inside renderPage(). It assumes page and pageId already exist and appends every top-level fragment node to page.
+- The tool handles element creation, literal text, classes, IDs, inline styles, datasets, attributes, and child order. Write state, event handlers, dynamic updates, lifecycle registration, and cleanup yourself.
+- Do not put style, script, lynx, page, or raw-text elements in the fragment. Keep CSS in the artifact's style block and bind events in main-thread JavaScript.`;
+
+export const LYNX_XML_AGENT_INSTRUCTIONS = buildLynxXmlSystemPrompt({
+  appendix: HTML_FRAGMENT_TOOL_INSTRUCTIONS,
+});
 
 interface LynxXmlAgentRunOptions {
   abortSignal?: AbortSignal | undefined;
@@ -34,11 +41,20 @@ export interface LynxXmlAgent {
 
 export function createLynxXmlAgent(opts: OpenAIProviderOptions = {}) {
   const { buildModel, model } = createLLMProvider(opts);
+  const htmlFragmentToMainThreadScript =
+    createHtmlFragmentToMainThreadScriptTool();
   const agent = new Agent({
     id: 'lynx-xml-agent',
     name: 'LynxXmlAgent',
-    instructions: LYNX_XML_SYSTEM_PROMPT,
+    instructions: LYNX_XML_AGENT_INSTRUCTIONS,
     model: buildModel(model),
+    tools: {
+      html_fragment_to_main_thread_script: htmlFragmentToMainThreadScript,
+    },
+    defaultOptions: {
+      maxSteps: 3,
+      toolCallConcurrency: 1,
+    },
   }) as unknown as LynxXmlAgent;
 
   return { agent, model };

--- a/packages/genui/server/agent/lynx-xml-agent.ts
+++ b/packages/genui/server/agent/lynx-xml-agent.ts
@@ -7,6 +7,7 @@ import { Agent } from '@mastra/core/agent';
 import { LYNX_XML_HTML_FRAGMENT_TOOL_SYSTEM_PROMPT } from '@lynx-js/genui-lynx-xml';
 
 import { createHtmlFragmentToMainThreadScriptTool } from './html-fragment-to-main-thread-script-tool.js';
+import type { HtmlFragmentScriptRunScope } from './html-fragment-to-main-thread-script-tool.js';
 import { createLLMProvider } from './openai-provider.js';
 import type { OpenAIProviderOptions } from './openai-provider.js';
 
@@ -15,6 +16,7 @@ interface LynxXmlAgentRunOptions {
   modelSettings?: {
     maxOutputTokens?: number | undefined;
   } | undefined;
+  requestContext: HtmlFragmentScriptRunScope['requestContext'];
   resourceId?: string | undefined;
 }
 

--- a/packages/genui/server/package.json
+++ b/packages/genui/server/package.json
@@ -21,6 +21,7 @@
     "@mastra/core": "1.56.0",
     "@openuidev/lang-core": "^0.2.11",
     "@volcengine/tos-sdk": "^2.9.1",
+    "fast-xml-parser": "^5.11.1",
     "hono": "4.13.0",
     "zod": "^4.4.3"
   },

--- a/packages/genui/server/package.json
+++ b/packages/genui/server/package.json
@@ -21,7 +21,6 @@
     "@mastra/core": "1.56.0",
     "@openuidev/lang-core": "^0.2.11",
     "@volcengine/tos-sdk": "^2.9.1",
-    "fast-xml-parser": "^5.11.1",
     "hono": "4.13.0",
     "zod": "^4.4.3"
   },

--- a/packages/genui/server/service/lynx-xml-agent.ts
+++ b/packages/genui/server/service/lynx-xml-agent.ts
@@ -2,6 +2,11 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
+import {
+  createHtmlFragmentScriptRunScope,
+  resolveHtmlFragmentScriptPlaceholders,
+} from '../agent/html-fragment-to-main-thread-script-tool.js';
+import type { HtmlFragmentScriptRunScope } from '../agent/html-fragment-to-main-thread-script-tool.js';
 import { createLynxXmlAgent } from '../agent/lynx-xml-agent.js';
 import type { LynxXmlAgent } from '../agent/lynx-xml-agent.js';
 import {
@@ -49,6 +54,33 @@ export function buildLynxXmlRunOptions(
   };
 }
 
+/** Add the request-scoped fragment registry to one agent invocation. */
+function buildLynxXmlScopedRunOptions(
+  opts: LynxXmlChatOptions,
+  abortSignal: AbortSignal | undefined,
+  scope: HtmlFragmentScriptRunScope,
+) {
+  return {
+    ...buildLynxXmlRunOptions(opts, abortSignal),
+    requestContext: scope.requestContext,
+  };
+}
+
+/** Track streamed text so final placeholder expansion has a fallback value. */
+function trackTextStream(
+  source: AsyncIterable<string>,
+  onChunk: (chunk: string) => void,
+): AsyncIterable<string> {
+  return {
+    [Symbol.asyncIterator]: async function*() {
+      for await (const chunk of source) {
+        onChunk(chunk);
+        yield chunk;
+      }
+    },
+  };
+}
+
 export default class LynxXmlAgentService {
   private readonly agentCache = new ProviderAgentCache<LynxXmlAgent>();
 
@@ -59,10 +91,11 @@ export default class LynxXmlAgentService {
     return this.agentCache.get(opts, createAgent);
   }
 
-  public async stream(
+  private async streamWithScope(
     messages: ChatMessage[],
-    opts: LynxXmlChatOptions = {},
-    abortSignal?: AbortSignal,
+    opts: LynxXmlChatOptions,
+    abortSignal: AbortSignal | undefined,
+    scope: HtmlFragmentScriptRunScope,
   ): Promise<MastraStreamResult> {
     abortSignal?.throwIfAborted();
     const agent = await this.getAgent(opts);
@@ -76,7 +109,11 @@ export default class LynxXmlAgentService {
     });
 
     const streamStartedAt = performance.now();
-    const runOptions = buildLynxXmlRunOptions(opts, abortSignal);
+    const runOptions = buildLynxXmlScopedRunOptions(
+      opts,
+      abortSignal,
+      scope,
+    );
     opts.onPerformanceEvent?.('agent.stream.invoke.started', {
       maxOutputTokens: runOptions.modelSettings.maxOutputTokens,
     });
@@ -89,6 +126,19 @@ export default class LynxXmlAgentService {
       hasTextStream: Boolean(result.textStream),
     });
     return result;
+  }
+
+  public stream(
+    messages: ChatMessage[],
+    opts: LynxXmlChatOptions = {},
+    abortSignal?: AbortSignal,
+  ): Promise<MastraStreamResult> {
+    return this.streamWithScope(
+      messages,
+      opts,
+      abortSignal,
+      createHtmlFragmentScriptRunScope(),
+    );
   }
 
   public async streamAsAsyncIterable(
@@ -114,14 +164,29 @@ export default class LynxXmlAgentService {
       preparedContentChars: sumContentChars(preparedMessages),
     });
 
-    const streamResult = await this.stream(
+    const scope = createHtmlFragmentScriptRunScope();
+    const streamResult = await this.streamWithScope(
       preparedMessages,
       opts,
       abortSignal,
+      scope,
     );
+    let streamedText = '';
     return {
-      textStream: toAsyncIterable(streamResult.textStream),
-      finalize: () => finalizeResult(streamResult),
+      textStream: trackTextStream(
+        toAsyncIterable(streamResult.textStream),
+        (chunk) => {
+          streamedText += chunk;
+        },
+      ),
+      finalize: async () => {
+        const result = await finalizeResult(streamResult);
+        const rawText = result.text ?? streamedText;
+        return {
+          ...result,
+          text: resolveHtmlFragmentScriptPlaceholders(scope, rawText),
+        };
+      },
     };
   }
 
@@ -134,11 +199,16 @@ export default class LynxXmlAgentService {
     abortSignal?.throwIfAborted();
     const agent = await this.getAgent(opts);
     abortSignal?.throwIfAborted();
+    const scope = createHtmlFragmentScriptRunScope();
     const result = await agent.generate(
       toModelMessages(buildConversationMessages(messages, conversation)),
-      buildLynxXmlRunOptions(opts, abortSignal),
+      buildLynxXmlScopedRunOptions(opts, abortSignal, scope),
     ) as MastraResult;
-    return extractGenerationResult(result);
+    const generated = await extractGenerationResult(result);
+    return {
+      ...generated,
+      text: resolveHtmlFragmentScriptPlaceholders(scope, generated.text),
+    };
   }
 }
 

--- a/packages/genui/server/test/html-fragment-to-main-thread-script-tool.test.ts
+++ b/packages/genui/server/test/html-fragment-to-main-thread-script-tool.test.ts
@@ -1,0 +1,86 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { describe, expect, test } from '@rstest/core';
+
+import {
+  createHtmlFragmentToMainThreadScriptTool,
+  generateMainThreadScript,
+} from '../agent/html-fragment-to-main-thread-script-tool.js';
+
+describe('HTML fragment to main-thread script tool', () => {
+  test('generates ordered Element PAPI calls for nested Lynx elements', () => {
+    const javascript = generateMainThreadScript(`
+      <scroll-view class="feed" id="root" style="height: 100vh;" scroll-orientation="vertical">
+        <view class="card" data-kind="featured">
+          <text aria-label="Greeting">Hello &amp; welcome</text>
+          <image src="https://example.com/cover.png" />
+        </view>
+      </scroll-view>
+    `);
+
+    expect(javascript).toBe(`const node0 = __CreateScrollView(pageId);
+__SetClasses(node0, "feed");
+__SetID(node0, "root");
+__SetInlineStyles(node0, "height: 100vh;");
+__SetAttribute(node0, "scroll-orientation", "vertical");
+const node1 = __CreateView(pageId);
+__SetClasses(node1, "card");
+__AddDataset(node1, "kind", "featured");
+const node2 = __CreateText(pageId);
+__SetAttribute(node2, "aria-label", "Greeting");
+__AppendElement(node2, __CreateRawText("Hello & welcome"));
+__AppendElement(node1, node2);
+const node3 = __CreateImage(pageId);
+__SetAttribute(node3, "src", "https://example.com/cover.png");
+__AppendElement(node1, node3);
+__AppendElement(node0, node1);
+__AppendElement(page, node0);`);
+  });
+
+  test('supports multiple roots, text content, and generic element tags', () => {
+    expect(
+      generateMainThreadScript(
+        '<view>Before<text>inside</text>after</view><input value="42" />',
+      ),
+    ).toBe(`const node0 = __CreateView(pageId);
+const node1 = __CreateText(pageId);
+__AppendElement(node1, __CreateRawText("Before"));
+__AppendElement(node0, node1);
+const node2 = __CreateText(pageId);
+__AppendElement(node2, __CreateRawText("inside"));
+__AppendElement(node0, node2);
+const node3 = __CreateText(pageId);
+__AppendElement(node3, __CreateRawText("after"));
+__AppendElement(node0, node3);
+__AppendElement(page, node0);
+const node4 = __CreateElement("input", pageId);
+__SetAttribute(node4, "value", "42");
+__AppendElement(page, node4);`);
+  });
+
+  test('escapes closing script sequences in generated JavaScript', () => {
+    expect(generateMainThreadScript('<text>&lt;/script&gt;</text>')).toContain(
+      '__CreateRawText("<\\/script>")',
+    );
+  });
+
+  test('rejects empty and malformed XML fragments', () => {
+    expect(() => generateMainThreadScript('   ')).toThrow(
+      'XML fragment must not be empty',
+    );
+    expect(() => generateMainThreadScript('<view><text></view>')).toThrow(
+      'Invalid XML fragment',
+    );
+    expect(() => generateMainThreadScript('<script />')).toThrow(
+      'Element <script> is not allowed',
+    );
+  });
+
+  test('exposes the converter as a Mastra tool', () => {
+    expect(createHtmlFragmentToMainThreadScriptTool().id).toBe(
+      'html_fragment_to_main_thread_script',
+    );
+  });
+});

--- a/packages/genui/server/test/html-fragment-to-main-thread-script-tool.test.ts
+++ b/packages/genui/server/test/html-fragment-to-main-thread-script-tool.test.ts
@@ -5,9 +5,29 @@
 import { describe, expect, test } from '@rstest/core';
 
 import {
+  createHtmlFragmentScriptRunScope,
   createHtmlFragmentToMainThreadScriptTool,
   generateMainThreadScript,
+  resolveHtmlFragmentScriptPlaceholders,
 } from '../agent/html-fragment-to-main-thread-script-tool.js';
+
+interface FragmentToolOutput {
+  bindings: Record<string, string>;
+  placeholder: string;
+}
+
+async function executeFragmentTool(
+  xmlFragment: string,
+  scope = createHtmlFragmentScriptRunScope(),
+): Promise<{ output: FragmentToolOutput; scope: typeof scope }> {
+  const tool = createHtmlFragmentToMainThreadScriptTool();
+  if (!tool.execute) throw new Error('fragment tool execute is missing');
+  const output = await tool.execute(
+    { xmlFragment },
+    { requestContext: scope.requestContext } as never,
+  );
+  return { output: output as FragmentToolOutput, scope };
+}
 
 describe('HTML fragment to main-thread script tool', () => {
   test('generates ordered Element PAPI calls for nested Lynx elements', () => {
@@ -85,11 +105,75 @@ __AppendElement(page, node4);`);
     expect(() => generateMainThreadScript('<script />')).toThrow(
       'Element <script> is not allowed',
     );
+    expect(() =>
+      generateMainThreadScript('<view id="duplicate"/><text id="duplicate"/>')
+    ).toThrow('Duplicate XML id: duplicate');
 
     const overlyDeepFragment = `${'<view>'.repeat(65)}${'</view>'.repeat(65)}`;
     expect(() => generateMainThreadScript(overlyDeepFragment)).toThrow(
       'XML fragment must not exceed 64 levels of element nesting',
     );
+  });
+
+  test('returns an opaque placeholder and id-to-node bindings', async () => {
+    const { output, scope } = await executeFragmentTool(
+      '<view id="root"><text id="label">Hello</text></view>',
+    );
+
+    expect(output.placeholder).toMatch(
+      /^\/\*__GENUI_HTML_FRAGMENT_[0-9a-f-]{36}__\*\/$/u,
+    );
+    expect(output.bindings).toEqual({ root: 'node0', label: 'node1' });
+    expect(Object.hasOwn(output, 'javascript')).toBe(false);
+
+    const artifact = `function renderPage() {
+  const page = __CreatePage("0", 0);
+  const pageId = __GetElementUniqueID(page);
+  ${output.placeholder}
+  __AddEventListener(node1, "tap", onTap, {});
+}`;
+    const resolved = resolveHtmlFragmentScriptPlaceholders(scope, artifact);
+    expect(resolved).toContain('const node0 = __CreateView(pageId);');
+    expect(resolved).toContain('__SetID(node1, "label");');
+    expect(resolved).toContain(
+      '__AddEventListener(node1, "tap", onTap, {});',
+    );
+    expect(resolved).not.toContain('__GENUI_HTML_FRAGMENT_');
+  });
+
+  test('isolates placeholders per run and rejects invalid placement', async () => {
+    const first = await executeFragmentTool('<view id="first"/>');
+    const second = await executeFragmentTool('<view id="second"/>');
+
+    expect(first.output.placeholder).not.toBe(second.output.placeholder);
+    expect(() =>
+      resolveHtmlFragmentScriptPlaceholders(
+        first.scope,
+        second.output.placeholder,
+      )
+    ).toThrow('unknown fragment placeholder');
+    expect(() =>
+      resolveHtmlFragmentScriptPlaceholders(first.scope, 'no placeholder')
+    ).toThrow('must appear exactly once');
+    expect(() =>
+      resolveHtmlFragmentScriptPlaceholders(
+        first.scope,
+        `${first.output.placeholder}\n${first.output.placeholder}`,
+      )
+    ).toThrow('must appear exactly once');
+    expect(() =>
+      resolveHtmlFragmentScriptPlaceholders(
+        first.scope,
+        `const marker = ${JSON.stringify(first.output.placeholder)};`,
+      )
+    ).toThrow('must appear on its own line');
+
+    const tool = createHtmlFragmentToMainThreadScriptTool();
+    if (!tool.execute) throw new Error('fragment tool execute is missing');
+    await expect(tool.execute(
+      { xmlFragment: '<view/>' },
+      { requestContext: first.scope.requestContext } as never,
+    )).rejects.toThrow('may only be called once per agent run');
   });
 
   test('exposes the converter as a Mastra tool', () => {

--- a/packages/genui/server/test/html-fragment-to-main-thread-script-tool.test.ts
+++ b/packages/genui/server/test/html-fragment-to-main-thread-script-tool.test.ts
@@ -60,6 +60,15 @@ __SetAttribute(node4, "value", "42");
 __AppendElement(page, node4);`);
   });
 
+  test('preserves meaningful text whitespace and ignores whitespace-only nodes', () => {
+    const javascript = generateMainThreadScript(
+      '<text>  spaced text  </text><view>   </view>',
+    );
+
+    expect(javascript).toContain('__CreateRawText("  spaced text  ")');
+    expect(javascript).not.toContain('__CreateRawText("   ")');
+  });
+
   test('escapes closing script sequences in generated JavaScript', () => {
     expect(generateMainThreadScript('<text>&lt;/script&gt;</text>')).toContain(
       '__CreateRawText("<\\/script>")',
@@ -75,6 +84,11 @@ __AppendElement(page, node4);`);
     );
     expect(() => generateMainThreadScript('<script />')).toThrow(
       'Element <script> is not allowed',
+    );
+
+    const overlyDeepFragment = `${'<view>'.repeat(65)}${'</view>'.repeat(65)}`;
+    expect(() => generateMainThreadScript(overlyDeepFragment)).toThrow(
+      'XML fragment must not exceed 64 levels of element nesting',
     );
   });
 

--- a/packages/genui/server/test/html-fragment-to-main-thread-script-tool.test.ts
+++ b/packages/genui/server/test/html-fragment-to-main-thread-script-tool.test.ts
@@ -7,7 +7,6 @@ import { describe, expect, test } from '@rstest/core';
 import {
   createHtmlFragmentScriptRunScope,
   createHtmlFragmentToMainThreadScriptTool,
-  generateMainThreadScript,
   resolveHtmlFragmentScriptPlaceholders,
 } from '../agent/html-fragment-to-main-thread-script-tool.js';
 
@@ -30,91 +29,6 @@ async function executeFragmentTool(
 }
 
 describe('HTML fragment to main-thread script tool', () => {
-  test('generates ordered Element PAPI calls for nested Lynx elements', () => {
-    const javascript = generateMainThreadScript(`
-      <scroll-view class="feed" id="root" style="height: 100vh;" scroll-orientation="vertical">
-        <view class="card" data-kind="featured">
-          <text aria-label="Greeting">Hello &amp; welcome</text>
-          <image src="https://example.com/cover.png" />
-        </view>
-      </scroll-view>
-    `);
-
-    expect(javascript).toBe(`const node0 = __CreateScrollView(pageId);
-__SetClasses(node0, "feed");
-__SetID(node0, "root");
-__SetInlineStyles(node0, "height: 100vh;");
-__SetAttribute(node0, "scroll-orientation", "vertical");
-const node1 = __CreateView(pageId);
-__SetClasses(node1, "card");
-__AddDataset(node1, "kind", "featured");
-const node2 = __CreateText(pageId);
-__SetAttribute(node2, "aria-label", "Greeting");
-__AppendElement(node2, __CreateRawText("Hello & welcome"));
-__AppendElement(node1, node2);
-const node3 = __CreateImage(pageId);
-__SetAttribute(node3, "src", "https://example.com/cover.png");
-__AppendElement(node1, node3);
-__AppendElement(node0, node1);
-__AppendElement(page, node0);`);
-  });
-
-  test('supports multiple roots, text content, and generic element tags', () => {
-    expect(
-      generateMainThreadScript(
-        '<view>Before<text>inside</text>after</view><input value="42" />',
-      ),
-    ).toBe(`const node0 = __CreateView(pageId);
-const node1 = __CreateText(pageId);
-__AppendElement(node1, __CreateRawText("Before"));
-__AppendElement(node0, node1);
-const node2 = __CreateText(pageId);
-__AppendElement(node2, __CreateRawText("inside"));
-__AppendElement(node0, node2);
-const node3 = __CreateText(pageId);
-__AppendElement(node3, __CreateRawText("after"));
-__AppendElement(node0, node3);
-__AppendElement(page, node0);
-const node4 = __CreateElement("input", pageId);
-__SetAttribute(node4, "value", "42");
-__AppendElement(page, node4);`);
-  });
-
-  test('preserves meaningful text whitespace and ignores whitespace-only nodes', () => {
-    const javascript = generateMainThreadScript(
-      '<text>  spaced text  </text><view>   </view>',
-    );
-
-    expect(javascript).toContain('__CreateRawText("  spaced text  ")');
-    expect(javascript).not.toContain('__CreateRawText("   ")');
-  });
-
-  test('escapes closing script sequences in generated JavaScript', () => {
-    expect(generateMainThreadScript('<text>&lt;/script&gt;</text>')).toContain(
-      '__CreateRawText("<\\/script>")',
-    );
-  });
-
-  test('rejects empty and malformed XML fragments', () => {
-    expect(() => generateMainThreadScript('   ')).toThrow(
-      'XML fragment must not be empty',
-    );
-    expect(() => generateMainThreadScript('<view><text></view>')).toThrow(
-      'Invalid XML fragment',
-    );
-    expect(() => generateMainThreadScript('<script />')).toThrow(
-      'Element <script> is not allowed',
-    );
-    expect(() =>
-      generateMainThreadScript('<view id="duplicate"/><text id="duplicate"/>')
-    ).toThrow('Duplicate XML id: duplicate');
-
-    const overlyDeepFragment = `${'<view>'.repeat(65)}${'</view>'.repeat(65)}`;
-    expect(() => generateMainThreadScript(overlyDeepFragment)).toThrow(
-      'XML fragment must not exceed 64 levels of element nesting',
-    );
-  });
-
   test('returns an opaque placeholder and id-to-node bindings', async () => {
     const { output, scope } = await executeFragmentTool(
       '<view id="root"><text id="label">Hello</text></view>',

--- a/packages/genui/server/test/lynx-xml-fragment-placeholder.test.ts
+++ b/packages/genui/server/test/lynx-xml-fragment-placeholder.test.ts
@@ -1,0 +1,104 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { Readable } from 'node:stream';
+
+import { beforeEach, describe, expect, rstest, test } from '@rstest/core';
+
+import {
+  createHtmlFragmentToMainThreadScriptTool,
+} from '../agent/html-fragment-to-main-thread-script-tool.js';
+import type { HtmlFragmentScriptRunScope } from '../agent/html-fragment-to-main-thread-script-tool.js';
+import { createLynxXmlAgent } from '../agent/lynx-xml-agent.js';
+import LynxXmlAgentService from '../service/lynx-xml-agent.js';
+
+rstest.mock('../agent/lynx-xml-agent.js', { mock: true });
+
+interface FragmentToolOutput {
+  bindings: Record<string, string>;
+  placeholder: string;
+}
+
+function modelArtifact(placeholder: string, binding: string): string {
+  return `<!doctype lynx>
+<lynx engine-version="4.2">
+<script thread="main">
+function renderPage() {
+  const page = __CreatePage("0", 0);
+  const pageId = __GetElementUniqueID(page);
+  ${placeholder}
+  __AddEventListener(${binding}, "tap", onTap, {});
+}
+</script>
+</lynx>`;
+}
+
+async function collect(source: AsyncIterable<string>): Promise<string> {
+  let value = '';
+  for await (const chunk of source) value += chunk;
+  return value;
+}
+
+beforeEach(() => {
+  rstest.mocked(createLynxXmlAgent).mockReset();
+});
+
+describe('Lynx XML fragment placeholder delivery', () => {
+  test('keeps scripts request-scoped and expands only the final text', async () => {
+    const placeholders: string[] = [];
+    const tool = createHtmlFragmentToMainThreadScriptTool();
+    const execute = tool.execute;
+    if (!execute) throw new Error('fragment tool execute is missing');
+
+    const agent = {
+      generate: () => Promise.resolve({ text: '' }),
+      stream: async (
+        _messages: unknown,
+        options: {
+          requestContext: HtmlFragmentScriptRunScope['requestContext'];
+        },
+      ) => {
+        const output = await execute(
+          { xmlFragment: '<view id="button"><text>Tap</text></view>' },
+          { requestContext: options.requestContext } as never,
+        ) as FragmentToolOutput;
+        const buttonBinding = output.bindings.button;
+        if (!buttonBinding) throw new Error('button binding is missing');
+        placeholders.push(output.placeholder);
+        const text = modelArtifact(output.placeholder, buttonBinding);
+        return {
+          textStream: Readable.from([text]) as AsyncIterable<string>,
+          text: undefined,
+          totalUsage: { inputTokens: 3, outputTokens: 5 },
+          finishReason: 'stop',
+        };
+      },
+    };
+    rstest.mocked(createLynxXmlAgent).mockReturnValue({
+      agent,
+      model: 'test-model',
+    } as never);
+
+    const service = new LynxXmlAgentService();
+    const first = await service.streamAsAsyncIterable([]);
+    const firstStreamedText = await collect(first.textStream);
+    const firstFinal = await first.finalize();
+    const second = await service.streamAsAsyncIterable([]);
+    const secondStreamedText = await collect(second.textStream);
+    const secondFinal = await second.finalize();
+
+    expect(createLynxXmlAgent).toHaveBeenCalledTimes(1);
+    expect(placeholders).toHaveLength(2);
+    expect(placeholders[0]).not.toBe(placeholders[1]);
+    expect(firstStreamedText).toContain(placeholders[0]);
+    expect(secondStreamedText).toContain(placeholders[1]);
+    expect(firstFinal.text).toContain('const node0 = __CreateView(pageId);');
+    expect(firstFinal.text).toContain(
+      '__AddEventListener(node0, "tap", onTap, {});',
+    );
+    expect(secondFinal.text).toContain('const node0 = __CreateView(pageId);');
+    expect(firstFinal.text).not.toContain('__GENUI_HTML_FRAGMENT_');
+    expect(secondFinal.text).not.toContain('__GENUI_HTML_FRAGMENT_');
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -998,6 +998,9 @@ importers:
       '@lynx-js/skill-vanilla-lynx':
         specifier: 0.2.0
         version: 0.2.0
+      fast-xml-parser:
+        specifier: ^5.11.1
+        version: 5.11.1
     devDependencies:
       '@rslib/core':
         specifier: catalog:rslib
@@ -1163,9 +1166,6 @@ importers:
       '@volcengine/tos-sdk':
         specifier: ^2.9.1
         version: 2.9.1(supports-color@10.2.2)
-      fast-xml-parser:
-        specifier: ^5.11.1
-        version: 5.11.1
       hono:
         specifier: 4.13.0
         version: 4.13.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1163,6 +1163,9 @@ importers:
       '@volcengine/tos-sdk':
         specifier: ^2.9.1
         version: 2.9.1(supports-color@10.2.2)
+      fast-xml-parser:
+        specifier: ^5.11.1
+        version: 5.11.1
       hono:
         specifier: 4.13.0
         version: 4.13.0
@@ -4689,6 +4692,9 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
+  '@nodable/entities@3.0.0':
+    resolution: {integrity: sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw==}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -7059,6 +7065,9 @@ packages:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
 
+  anynum@1.0.1:
+    resolution: {integrity: sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==}
+
   append-transform@2.0.0:
     resolution: {integrity: sha512-7yeyCEurROLQJFv5Xj4lEGTy0borxepjFv1g22oAdqFu//SrAlDl1O1Nxx15SH1RoliUml6p8dwJW9jvZughhg==}
     engines: {node: '>=8'}
@@ -8299,6 +8308,13 @@ packages:
   fast-wrap-ansi@0.2.0:
     resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
 
+  fast-xml-builder@1.3.1:
+    resolution: {integrity: sha512-pIM/1n3ntFXKYrUZwW7QCK0gAW7XY+wzj1YMIV3tLDvPj/V+zTGJK5e3/4WJfwj0qWw2ElNXiTixda/R+3YSug==}
+
+  fast-xml-parser@5.11.1:
+    resolution: {integrity: sha512-TBw6K/fxoQGGjCmZDw9w/ZwP3uDcnTM4YH/g+PFRWr8sbe5idXtxNN6vITh4+1ruCZaho6uBFurElsA7F0zzgw==}
+    hasBin: true
+
   fastest-stable-stringify@2.0.2:
     resolution: {integrity: sha512-bijHueCGd0LqqNK9b5oCMHc0MluJAx0cwqASgbWMvkO01lCYgIhacVRLcaDz3QnyYIRNJRDwMb41VuT6pHJ91Q==}
 
@@ -9040,6 +9056,9 @@ packages:
   is-unicode-supported@2.1.0:
     resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
     engines: {node: '>=18'}
+
+  is-unsafe@2.0.2:
+    resolution: {integrity: sha512-HgbIHPBH0KHHCcjLfGsCvhtPTVxjaAZlXjwdz7/GQC40SjSe4sfQsar8J5VFo8JOSbarkpV0OLG95bbaNd9aAQ==}
 
   is-weakmap@2.0.2:
     resolution: {integrity: sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==}
@@ -10254,6 +10273,10 @@ packages:
   path-exists@5.0.0:
     resolution: {integrity: sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  path-expression-matcher@1.6.2:
+    resolution: {integrity: sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==}
+    engines: {node: '>=14.0.0'}
 
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
@@ -11548,6 +11571,9 @@ packages:
     resolution: {integrity: sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==}
     engines: {node: '>=0.10.0'}
 
+  strnum@2.4.2:
+    resolution: {integrity: sha512-rDG3Ah4TV0k1hWvLSzkZtMmLN9+eS+h3knq4MP6A42Y3Yh5qGNnOUs1jJkoSr8FG5dsL28c7KgkIBzSEykqtuw==}
+
   style-mod@4.1.3:
     resolution: {integrity: sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==}
 
@@ -12399,6 +12425,10 @@ packages:
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
+
+  xml-naming@0.3.0:
+    resolution: {integrity: sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==}
+    engines: {node: '>=16.0.0'}
 
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
@@ -14875,6 +14905,8 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
+  '@nodable/entities@3.0.0': {}
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -17283,6 +17315,8 @@ snapshots:
       normalize-path: 3.0.0
       picomatch: 2.3.1
 
+  anynum@1.0.1: {}
+
   append-transform@2.0.0:
     dependencies:
       default-require-extensions: 3.0.1
@@ -18710,6 +18744,20 @@ snapshots:
     dependencies:
       fast-string-width: 3.0.2
 
+  fast-xml-builder@1.3.1:
+    dependencies:
+      path-expression-matcher: 1.6.2
+      xml-naming: 0.3.0
+
+  fast-xml-parser@5.11.1:
+    dependencies:
+      '@nodable/entities': 3.0.0
+      fast-xml-builder: 1.3.1
+      is-unsafe: 2.0.2
+      path-expression-matcher: 1.6.2
+      strnum: 2.4.2
+      xml-naming: 0.3.0
+
   fastest-stable-stringify@2.0.2: {}
 
   fastq@1.20.1:
@@ -19511,6 +19559,8 @@ snapshots:
   is-unicode-supported@0.1.0: {}
 
   is-unicode-supported@2.1.0: {}
+
+  is-unsafe@2.0.2: {}
 
   is-weakmap@2.0.2: {}
 
@@ -21029,6 +21079,8 @@ snapshots:
 
   path-exists@5.0.0: {}
 
+  path-expression-matcher@1.6.2: {}
+
   path-key@3.1.1: {}
 
   path-key@4.0.0: {}
@@ -22371,6 +22423,10 @@ snapshots:
     dependencies:
       escape-string-regexp: 1.0.5
 
+  strnum@2.4.2:
+    dependencies:
+      anynum: 1.0.1
+
   style-mod@4.1.3: {}
 
   style-to-js@1.1.16:
@@ -23304,6 +23360,8 @@ snapshots:
   ws@8.21.2: {}
 
   xml-name-validator@5.0.0: {}
+
+  xml-naming@0.3.0: {}
 
   xmlchars@2.2.0: {}
 


### PR DESCRIPTION
## Summary

- add a Mastra tool that accepts well-formed XML fragments and emits deterministic Element PAPI JavaScript for `renderPage`
- export the headless parser and generator utilities from `@lynx-js/genui-lynx-xml`, while keeping the server module limited to Mastra and request-scope wiring
- keep generated JavaScript in a request-scoped registry and return only an opaque placeholder plus id-to-node bindings to the model
- validate attributes, ordered text and children, multiple roots, escaping, malformed XML, forbidden elements, duplicate ids, and maximum nesting depth

## Architecture

```mermaid
flowchart TD
    subgraph AgentRun["One Lynx XML agent run"]
        Model["GenUI model"]
        Tool["html_fragment_to_main_thread_script tool<br/>server orchestration"]
        Registry[("Request-scoped RequestContext registry")]
        Draft["Model-authored Lynx XML with placeholder"]
    end

    subgraph Headless["@lynx-js/genui-lynx-xml<br/>headless package"]
        Parser["fast-xml-parser + validation"]
        Generator["Deterministic Element PAPI generator"]
    end

    subgraph Delivery["Streaming and final artifact delivery"]
        Delta["Streaming deltas may contain the placeholder"]
        Finalize["LynxXmlAgentService.finalize"]
        Resolver["Validate marker and replace exactly once"]
        Artifact["Final Lynx XML with generated main-thread JavaScript"]
        Validate["Artifact normalization, validation, and delivery"]
    end

    Model -->|"1. Well-formed XML fragment"| Tool
    Tool -->|"2. Parse"| Parser
    Parser --> Generator
    Generator -->|"3. JavaScript + id bindings"| Tool
    Tool -->|"4a. Store full JavaScript"| Registry
    Tool -->|"4b. Return placeholder + bindings"| Model
    Model --> Draft
    Draft --> Delta
    Draft --> Finalize
    Finalize --> Resolver
    Registry -->|"Resolve within the same agent run"| Resolver
    Resolver --> Artifact
    Artifact --> Validate
```

- The generated JavaScript is kept out of the model-visible tool result, reducing tool-result input tokens.
- The registry is isolated per agent run, so cached Agent instances cannot leak generated scripts across requests.
- Unknown, missing, duplicated, or inline placeholders are rejected before final artifact delivery.
- The XML parser and generator remain reusable and provider-neutral in the headless Lynx XML package.

## Testing

- `CI=1 pnpm install --frozen-lockfile`
- `pnpm turbo build` (73 tasks passed)
- `pnpm --filter @lynx-js/genui-lynx-xml exec rstest run` (2 files, 20 tests passed)
- `pnpm --filter a2ui-server exec rstest run` (34 files, 165 tests passed)
- `pnpm dprint check`
- `pnpm biome check` on PR files
- `pnpm eslint` on PR TypeScript files
- `pnpm turbo api-extractor -- --local`
- `pnpm changeset status --since=origin/main`

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required). The affected packages are private, so no changeset is required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for converting well-formed HTML/XML fragments into executable Lynx rendering scripts.
  * Supports nested elements, text, attributes, styles, classes, IDs, datasets, and multiple root elements.
  * Preserves meaningful whitespace while ignoring whitespace-only nodes.
  * Added request-scoped script delivery with node bindings and controlled placeholder expansion.
  * Integrated fragment conversion into Lynx XML generation with single-step tool execution.

* **Bug Fixes**
  * Added validation for malformed, empty, duplicate-ID, unsafe, and excessively deep fragments.

* **Tests**
  * Added coverage for conversion, escaping, validation, nesting limits, whitespace handling, placeholder delivery, and tool registration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
