### PR TITLE
fix(web-core): tolerate unsupported gesture detectors

### DIFF
--- a/.changeset/web-gesture-noop.md
+++ b/.changeset/web-gesture-noop.md
@@ -1,0 +1,5 @@
+---
+'@lynx-js/web-core': patch
+---
+
+Allow Lynx-for-Web pages that use `main-thread:gesture` to render by providing no-op gesture detector element APIs.

--- a/.github/web-core-gesture-compat.instructions.md
+++ b/.github/web-core-gesture-compat.instructions.md
@@ -1,0 +1,5 @@
+---
+applyTo: "packages/web-platform/web-core/**"
+---
+
+Keep `__SetGestureDetector` and `__RemoveGestureDetector` available in both client and server Element PAPIs even while Lynx-for-Web gesture recognition is unsupported, so `main-thread:gesture` bundles degrade to no gesture instead of throwing during evaluation.

--- a/packages/web-platform/web-core/tests/element-apis.spec.ts
+++ b/packages/web-platform/web-core/tests/element-apis.spec.ts
@@ -2151,6 +2151,36 @@ describe('Element APIs', () => {
   });
 
   describe('Server Element APIs SSR Propagation', () => {
+    test('gesture detector PAPIs are supported as no-ops in SSR', () => {
+      const binding: SSRBinding = { ssrResult: '' };
+      const config = {
+        enableCSSSelector: true,
+        defaultOverflowVisible: false,
+        defaultDisplayLinear: true,
+        transformVW: false,
+        transformVH: false,
+        transformREM: false,
+      };
+      const { globalThisAPIs: api } = createServerElementAPI(
+        binding,
+        undefined,
+        '',
+        config,
+      );
+      const element = api.__CreateElement('view', 0);
+
+      expect(() => {
+        api.__SetGestureDetector(
+          element,
+          1,
+          0,
+          { callbacks: [] },
+          { waitFor: [], simultaneous: [], continueWith: [] },
+        );
+        api.__RemoveGestureDetector(element, 1);
+      }).not.toThrow();
+    });
+
     test('ssr __SetInlineStyles and __SetAttribute style transformations', () => {
       const binding: SSRBinding = { ssrResult: '' };
       const config = {

--- a/packages/web-platform/web-core/tests/element-apis.spec.ts
+++ b/packages/web-platform/web-core/tests/element-apis.spec.ts
@@ -139,6 +139,21 @@ describe('Element APIs', () => {
     expect(mtsGlobalThis.__GetTag(element)).toBe('view');
   });
 
+  test('gesture detector PAPIs are supported as no-ops', () => {
+    const element = mtsGlobalThis.__CreateElement('view', 0);
+
+    expect(() => {
+      mtsGlobalThis.__SetGestureDetector(
+        element,
+        1,
+        0,
+        { callbacks: [] },
+        { waitFor: [], simultaneous: [], continueWith: [] },
+      );
+      mtsGlobalThis.__RemoveGestureDetector(element, 1);
+    }).not.toThrow();
+  });
+
   test('createElement maps input to x-input', () => {
     // `input` is created as the `x-input` custom element so Lynx event
     // forwarding wires up (matches native behavior on web).

--- a/packages/web-platform/web-core/ts/client/mainthread/elementAPIs/createElementAPI.ts
+++ b/packages/web-platform/web-core/ts/client/mainthread/elementAPIs/createElementAPI.ts
@@ -630,8 +630,8 @@ export function createElementAPI(
     __QuerySelectorAll,
     // Gesture recognition is not implemented on web yet. Keep these PAPIs as
     // no-ops so ReactLynx bundles using `main-thread:gesture` can still render.
-    __SetGestureDetector: () => {},
-    __RemoveGestureDetector: () => {},
+    __SetGestureDetector: () => undefined,
+    __RemoveGestureDetector: () => undefined,
     __FlushElementTree: (_, options) => {
       const pipelineId = options?.pipelineOptions?.pipelineID;
       const backgroundThread = mtsBinding.lynxViewInstance.backgroundThread;

--- a/packages/web-platform/web-core/ts/client/mainthread/elementAPIs/createElementAPI.ts
+++ b/packages/web-platform/web-core/ts/client/mainthread/elementAPIs/createElementAPI.ts
@@ -628,6 +628,10 @@ export function createElementAPI(
     __InvokeUIMethod: mtsBinding.lynxViewInstance.invokeUIMethod,
     __QuerySelector,
     __QuerySelectorAll,
+    // Gesture recognition is not implemented on web yet. Keep these PAPIs as
+    // no-ops so ReactLynx bundles using `main-thread:gesture` can still render.
+    __SetGestureDetector: () => {},
+    __RemoveGestureDetector: () => {},
     __FlushElementTree: (_, options) => {
       const pipelineId = options?.pipelineOptions?.pipelineID;
       const backgroundThread = mtsBinding.lynxViewInstance.backgroundThread;

--- a/packages/web-platform/web-core/ts/server/elementAPIs/createElementAPI.ts
+++ b/packages/web-platform/web-core/ts/server/elementAPIs/createElementAPI.ts
@@ -518,6 +518,10 @@ export function createElementAPI(
       __QuerySelectorAll: () => {
         throw new Error('Not yet Implemented');
       },
+      // SSR does not recognize gestures, but gesture-bearing bundles still
+      // need the PAPIs to exist while their main-thread code is evaluated.
+      __SetGestureDetector: () => {},
+      __RemoveGestureDetector: () => {},
     },
     wasmContext,
   };

--- a/packages/web-platform/web-core/ts/server/elementAPIs/createElementAPI.ts
+++ b/packages/web-platform/web-core/ts/server/elementAPIs/createElementAPI.ts
@@ -520,8 +520,8 @@ export function createElementAPI(
       },
       // SSR does not recognize gestures, but gesture-bearing bundles still
       // need the PAPIs to exist while their main-thread code is evaluated.
-      __SetGestureDetector: () => {},
-      __RemoveGestureDetector: () => {},
+      __SetGestureDetector: () => undefined,
+      __RemoveGestureDetector: () => undefined,
     },
     wasmContext,
   };

--- a/packages/web-platform/web-core/ts/types/IElementPAPI.ts
+++ b/packages/web-platform/web-core/ts/types/IElementPAPI.ts
@@ -406,6 +406,19 @@ export type QuerySelectorAllPAPI = (
   options?: unknown,
 ) => unknown[];
 
+export type SetGestureDetectorPAPI = (
+  element: HTMLElement,
+  id: number,
+  type: number,
+  config: unknown,
+  relationMap: Record<string, number[]>,
+) => void;
+
+export type RemoveGestureDetectorPAPI = (
+  element: HTMLElement,
+  id: number,
+) => void;
+
 export interface ElementPAPIs {
   // __GetTemplateParts currently only provided by the thread-strategy = "all-on-ui" (default)
   __GetTemplateParts: GetTemplatePartsPAPI;
@@ -473,6 +486,12 @@ export interface ElementPAPIs {
   __InvokeUIMethod: InvokeUIMethodPAPI;
   __QuerySelector: QuerySelectorPAPI;
   __QuerySelectorAll: QuerySelectorAllPAPI;
+  /**
+   * Gesture recognition is not implemented on the web platform yet. These
+   * PAPIs are still provided so bundles using `main-thread:gesture` can run.
+   */
+  __SetGestureDetector: SetGestureDetectorPAPI;
+  __RemoveGestureDetector: RemoveGestureDetectorPAPI;
   __FlushElementTree: (
     _subTree?: unknown,
     options?: FlushElementTreeOptions,


### PR DESCRIPTION
Fixes #3742

Lynx-for-Web now provides no-op `__SetGestureDetector` and `__RemoveGestureDetector` Element PAPIs in both client and SSR runtimes. Gesture-bearing bundles can mount and render when web gesture recognition is unavailable, while gesture callbacks remain inactive for now.

The change also adds the corresponding PAPI types and regression coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Compatibility**
  * Added no-op gesture detector APIs for web and server-rendered pages.
  * Pages using `main-thread:gesture` can now render and evaluate without errors; gesture recognition remains unavailable.

* **Tests**
  * Added coverage confirming gesture detector operations complete without throwing errors in web and server-rendered environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->