### PR TITLE
fix(vanilla-rsbuild-plugin): wrap the background chunk under the .lynx intermediate directory

### DIFF
--- a/.changeset/vanilla-runtime-wrapper-intermediate-dir.md
+++ b/.changeset/vanilla-runtime-wrapper-intermediate-dir.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/vanilla-rsbuild-plugin": patch
+---
+
+Wrap the background chunk again. The runtime wrapper only matched assets under `.rspeedy/`, so once the intermediate directory moved to `.lynx/` the background chunk shipped without the wrapper and failed on load with `ReferenceError: lynx is not defined`. The wrapper now targets the background asset the plugin emits, wherever the intermediate directory lives.

--- a/packages/rspeedy/plugin-vanilla/src/pluginVanillaLynx.ts
+++ b/packages/rspeedy/plugin-vanilla/src/pluginVanillaLynx.ts
@@ -165,6 +165,7 @@ interface VanillaEntryContext {
 }
 
 interface VanillaEntryArtifacts {
+  backgroundAsset: string | undefined
   hasBackground: boolean
   mainThreadAsset: string
 }
@@ -330,7 +331,11 @@ function addVanillaEntry(
     }],
   )
 
-  return { hasBackground, mainThreadAsset }
+  return {
+    backgroundAsset: hasBackground ? backgroundAsset : undefined,
+    hasBackground,
+    mainThreadAsset,
+  }
 }
 
 function addVanillaBundlerPlugins(
@@ -353,7 +358,11 @@ function addVanillaBundlerPlugins(
       RuntimeWrapperWebpackPlugin,
       [{
         targetSdkVersion: engineVersion,
-        test: /^\.rspeedy\/.+\/background\.js$/,
+        test: artifacts.flatMap(artifact =>
+          artifact.backgroundAsset === undefined
+            ? []
+            : [artifact.backgroundAsset]
+        ),
       }],
     )
   }

--- a/packages/rspeedy/plugin-vanilla/test/pluginVanillaLynx.test.ts
+++ b/packages/rspeedy/plugin-vanilla/test/pluginVanillaLynx.test.ts
@@ -18,6 +18,7 @@ import { afterAll, describe, expect, test } from '@rstest/core'
 import { pluginLynx } from '@lynx-js/rsbuild-plugin'
 import type { LynxConfig } from '@lynx-js/rsbuild-plugin'
 import { createRspeedy } from '@lynx-js/rspeedy'
+import { RuntimeWrapperWebpackPlugin } from '@lynx-js/runtime-wrapper-webpack-plugin'
 
 import * as vanilla from '../src/index.js'
 
@@ -609,5 +610,28 @@ describe('pluginVanillaLynx configuration', () => {
     expect(() => plugin.apply(compiler)).toThrow(
       '[pluginVanillaLynx] Main-thread asset was not emitted: .lynx/main/main-thread.js',
     )
+  })
+})
+
+describe('pluginVanillaLynx runtime wrapper', () => {
+  test('wraps exactly the background assets the plugin emits', async () => {
+    const result = await runPluginHarness({
+      rawEntries: {
+        card: { values: () => [fixturePath('main-thread.ts')] },
+        solo: { values: () => ['virtual-main-thread'] },
+      },
+    })
+
+    const backgroundEntry = result.entries.get('card__background') as {
+      filename: string
+    }
+    expect(backgroundEntry.filename).toBe('.lynx/card/background.js')
+    expect(result.entries.has('solo__background')).toBe(false)
+
+    const wrapper = result.plugins.get('lynx:vanilla:runtime-wrapper')
+    expect(wrapper?.plugin).toBe(RuntimeWrapperWebpackPlugin)
+    expect((wrapper?.args?.[0] as { test: unknown }).test).toEqual([
+      backgroundEntry.filename,
+    ])
   })
 })


### PR DESCRIPTION
`pluginVanillaLynx` applies the runtime wrapper with `test: /^\.rspeedy\/.+\/background\.js$/`. #3682 moved the intermediate directory to `.lynx/`, so the pattern stopped matching and the background chunk shipped unwrapped. On device it fails at load:

```
loadCard failed ReferenceError: lynx is not defined
    at <anonymous> (file://view3/.lynx/main/background.js:104:18)
```

The plugin already computes the exact background asset path; the wrapper now targets that instead of a hardcoded directory.

The existing test only checked that `RuntimeWrapperWebpackPlugin` was registered, which stayed true while it matched nothing. The new test asserts the wrapper's `test` matches the background asset the plugin emits; it fails on `main` and passes here.

https://claude.ai/code/session_01JJq2bS1Rngk8Uy5igpyyzv


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed vanilla runtime builds so background assets load correctly when intermediate files are stored in the `.lynx` directory.
  * Prevented `ReferenceError: lynx is not defined` errors when loading background chunks.
  * Improved runtime wrapper matching for emitted background assets across supported build configurations.

* **Tests**
  * Added coverage verifying runtime wrappers correctly match emitted background assets and exclude entries without background chunks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->