### PR TITLE
fix(rspeedy): enable CSS source maps by default only in Lynx environments

### DIFF
--- a/.changeset/css-source-map-lynx-only.md
+++ b/.changeset/css-source-map-lynx-only.md
@@ -1,0 +1,6 @@
+---
+"@lynx-js/rspeedy": patch
+"@lynx-js/rsbuild-plugin": patch
+---
+
+Enable `output.sourceMap.css` by default only in Lynx environments, so web builds no longer emit unused CSS `.map` files into the intermediate directory.

--- a/packages/rspeedy/core/src/config/defaults.ts
+++ b/packages/rspeedy/core/src/config/defaults.ts
@@ -28,10 +28,6 @@ export function applyDefaultRspeedyConfig(config: Config): Config {
       // from the `output.filename.bundle` field.
       filename: getFilename(config.output?.filename),
 
-      sourceMap: {
-        css: true,
-      },
-
       // inlineScripts defaults to false when chunk splitting is enabled, true otherwise
       inlineScripts: !enableChunkSplitting,
 

--- a/packages/rspeedy/core/src/config/output/source-map.ts
+++ b/packages/rspeedy/core/src/config/output/source-map.ts
@@ -73,11 +73,12 @@ export interface SourceMap {
   /**
    * Whether to generate CSS source maps.
    *
-   * @defaultValue `true`
+   * @defaultValue `true` in Lynx environments, `false` otherwise.
    *
    * @remarks
    *
-   * In Lynx builds, all `.map` assets are removed before emit.
+   * Lynx environments enable CSS source maps so that CSS diagnostics can be
+   * mapped back to the source; all `.map` assets are removed before emit.
    *
    * @example
    *

--- a/packages/rspeedy/core/test/config/output/source-map.test.ts
+++ b/packages/rspeedy/core/test/config/output/source-map.test.ts
@@ -6,14 +6,12 @@ import { describe, expect, test } from '@rstest/core'
 import { createRspeedy } from '../../../src/index.js'
 
 describe('output.sourceMap', () => {
-  test('defaults css source map to true', async () => {
+  test('does not set css source map by default', async () => {
     const rspeedy = await createRspeedy({
       rspeedyConfig: {},
     })
 
-    expect(rspeedy.getRspeedyConfig().output?.sourceMap).toEqual({
-      css: true,
-    })
+    expect(rspeedy.getRspeedyConfig().output?.sourceMap).toBeUndefined()
   })
 
   test('respects output.sourceMap false', async () => {
@@ -44,7 +42,7 @@ describe('output.sourceMap', () => {
     })
   })
 
-  test('merges css default with user js source map config', async () => {
+  test('keeps user js source map config', async () => {
     const rspeedy = await createRspeedy({
       rspeedyConfig: {
         output: {
@@ -56,7 +54,6 @@ describe('output.sourceMap', () => {
     })
 
     expect(rspeedy.getRspeedyConfig().output?.sourceMap).toEqual({
-      css: true,
       js: 'source-map',
     })
   })

--- a/packages/rspeedy/plugin-lynx/src/plugins/sourcemap.plugin.ts
+++ b/packages/rspeedy/plugin-lynx/src/plugins/sourcemap.plugin.ts
@@ -2,7 +2,12 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
-import type { RsbuildPlugin, Rspack, RspackChain } from '@rsbuild/core'
+import type {
+  RsbuildConfig,
+  RsbuildPlugin,
+  Rspack,
+  RspackChain,
+} from '@rsbuild/core'
 import invariant from 'tiny-invariant'
 import type { UndefinedOnPartialDeep } from 'type-fest'
 
@@ -15,6 +20,17 @@ export function pluginSourcemap(): RsbuildPlugin {
     name: 'lynx:rsbuild:sourcemap',
     pre: ['lynx:rsbuild:dev'],
     setup(api) {
+      api.modifyEnvironmentConfig((config, { name }) => {
+        if (
+          !isLynx(name)
+          || hasCSSSourceMapConfigured(api.getRsbuildConfig('original'), name)
+          || typeof config.output.sourceMap !== 'object'
+        ) {
+          return
+        }
+        config.output.sourceMap = { ...config.output.sourceMap, css: true }
+      })
+
       api.modifyBundlerChain((chain, { isDev, environment }) => {
         const { dev, output, server } = api.getRsbuildConfig('current')
 
@@ -70,6 +86,18 @@ export function pluginSourcemap(): RsbuildPlugin {
       })
     },
   }
+}
+
+function hasCSSSourceMapConfigured(
+  config: RsbuildConfig,
+  environment: string,
+): boolean {
+  return [
+    config.environments?.[environment]?.output?.sourceMap,
+    config.output?.sourceMap,
+  ].some(sourceMap =>
+    typeof sourceMap === 'boolean' || sourceMap?.css !== undefined
+  )
 }
 
 function applyDropSourceMapAssets(chain: RspackChain): void {

--- a/packages/rspeedy/plugin-lynx/test/sourcemap.plugin.test.ts
+++ b/packages/rspeedy/plugin-lynx/test/sourcemap.plugin.test.ts
@@ -24,6 +24,14 @@ const hasDropPlugin = (plugins: unknown[] | undefined) =>
         === 'DropSourceMapAssetsPlugin',
   )
 
+const hasCSSSourceMapPlugin = (plugins: unknown[] | undefined) =>
+  !!plugins?.some(
+    p =>
+      typeof p === 'object' && p !== null
+      && (p as { constructor?: { name?: string } }).constructor?.name
+        === 'SourceMapDevToolPlugin',
+  )
+
 describe('pluginSourcemap', () => {
   describe('production', () => {
     test('defaults', async () => {
@@ -650,6 +658,56 @@ describe('pluginSourcemap', () => {
       })
       const config = await rsbuild.unwrapConfig()
       expect(hasDropPlugin(config.plugins)).toBe(false)
+    })
+  })
+
+  describe('css source map', () => {
+    test('enables css source map for lynx environments', async () => {
+      const rsbuild = await createStubRsbuild({})
+      await rsbuild.unwrapConfig()
+      expect(
+        rsbuild.getNormalizedConfig({ environment: 'lynx' }).output.sourceMap,
+      ).toMatchObject({ css: true })
+    })
+
+    test('does not enable css source map for other environments', async () => {
+      rstest.stubEnv('NODE_ENV', 'production')
+      const rsbuild = await createStubRsbuild({ environments: { web: {} } })
+      const config = await rsbuild.unwrapConfig({ action: 'build' })
+      expect(
+        rsbuild.getNormalizedConfig({ environment: 'web' }).output.sourceMap,
+      ).toMatchObject({ css: false })
+      expect(hasCSSSourceMapPlugin(config.plugins)).toBe(false)
+    })
+
+    test('respects output.sourceMap.css: true for other environments', async () => {
+      rstest.stubEnv('NODE_ENV', 'production')
+      const rsbuild = await createStubRsbuild({
+        environments: { web: {} },
+        output: { sourceMap: { css: true } },
+      })
+      const config = await rsbuild.unwrapConfig({ action: 'build' })
+      expect(hasCSSSourceMapPlugin(config.plugins)).toBe(true)
+    })
+
+    test('respects output.sourceMap.css: false for lynx environments', async () => {
+      const rsbuild = await createStubRsbuild({
+        output: { sourceMap: { css: false } },
+      })
+      await rsbuild.unwrapConfig()
+      expect(
+        rsbuild.getNormalizedConfig({ environment: 'lynx' }).output.sourceMap,
+      ).toMatchObject({ css: false })
+    })
+
+    test('respects environment-level output.sourceMap.css: false', async () => {
+      const rsbuild = await createStubRsbuild({
+        environments: { lynx: { output: { sourceMap: { css: false } } } },
+      })
+      await rsbuild.unwrapConfig()
+      expect(
+        rsbuild.getNormalizedConfig({ environment: 'lynx' }).output.sourceMap,
+      ).toMatchObject({ css: false })
     })
   })
 })


### PR DESCRIPTION
## Summary

- Move the `output.sourceMap.css: true` default (added in #2483 for CSS diagnostics) from the rspeedy config defaults into `pluginSourcemap`, applied per environment only when `isLynx(name)` and the user has not set `sourceMap.css` (root or environment level).
- Web builds ran with `devtool: false` and `sourceMap.css: true`, which makes Rsbuild add its `source-map-css` `SourceMapDevToolPlugin`; since #3256 re-emits related `.map` assets in `WebEncodePlugin`, the CSS map survived as `dist/.lynx/main/main.css.map` even though nothing on web consumes it.
- Update the `output.sourceMap.css` TSDoc and add tests for the Lynx / non-Lynx defaults and the explicit overrides.

## Verification

- `examples/react` web production build: `find dist -name '*.map'` is empty (was `dist/.lynx/main/main.css.map`).
- `@lynx-js/react-rsbuild-plugin` `test/sourcemap.test.ts` still lists `.lynx/main/main.css.map` in the Lynx debug metadata.

https://claude.ai/code/session_01JJq2bS1Rngk8Uy5igpyyzv


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - CSS source maps are now enabled by default for Lynx builds, supporting source-level CSS diagnostics.
  - Explicit CSS source map settings continue to be respected across environments.

- **Bug Fixes**
  - Web builds no longer generate unused CSS `.map` files in intermediate output directories.
  - Environment-specific settings can now correctly enable or disable CSS source maps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->