### PR TITLE
fix(runtime-wrapper-webpack-plugin): leave an asset marked as main thread unwrapped

### DIFF
--- a/.changeset/external-bundle-main-thread-wrapper.md
+++ b/.changeset/external-bundle-main-thread-wrapper.md
@@ -1,0 +1,7 @@
+---
+"@lynx-js/runtime-wrapper-webpack-plugin": patch
+"@lynx-js/react-rsbuild-plugin": patch
+"@lynx-js/lynx-bundle-rslib-config": patch
+---
+
+Skip the background runtime wrapper on any asset marked `lynx:main-thread` instead of matching filenames, and mark the main-thread assets of an external bundle by the layer of their modules, so a main-thread entry an external bundle names itself is no longer wrapped.

--- a/.changeset/lazy-bundle-name-order.md
+++ b/.changeset/lazy-bundle-name-order.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/template-webpack-plugin": patch
+---
+
+Map an async chunk shared by an unnamed `import()` and a `webpackChunkName` import to the lazy bundle derived from its modules, regardless of build order.

--- a/packages/rspeedy/lynx-bundle-rslib-config/src/externalBundleRslibConfig.ts
+++ b/packages/rspeedy/lynx-bundle-rslib-config/src/externalBundleRslibConfig.ts
@@ -773,7 +773,7 @@ const externalBundleRsbuildPlugin = ({
         chain
           .plugin(MarkMainThreadWebpackPlugin.name)
           .use(MarkMainThreadWebpackPlugin, [{
-            entryNames: mainThreadEntryName,
+            layer: LAYERS.MAIN_THREAD,
           }])
           .end()
 

--- a/packages/rspeedy/lynx-bundle-rslib-config/src/webpack/MarkMainThreadWebpackPlugin.ts
+++ b/packages/rspeedy/lynx-bundle-rslib-config/src/webpack/MarkMainThreadWebpackPlugin.ts
@@ -6,15 +6,15 @@ import type { Rspack } from '@rslib/core'
 const PLUGIN_NAME = 'MarkMainThreadWebpackPlugin'
 
 /**
- * Marks the assets of the given entries as main thread ones, the way a page
- * build marks its own. A DSL plugin marks whatever else it compiles for the
- * main thread, so the two add up.
+ * Marks the assets of every chunk holding main-thread modules, the way a page
+ * build marks its own, so the encoder and the runtime wrapper tell the threads
+ * apart by the same mark.
  */
 export class MarkMainThreadWebpackPlugin {
-  constructor(private options: { entryNames: string[] }) {}
+  constructor(private options: { layer: string }) {}
 
   apply(compiler: Rspack.Compiler): void {
-    const entryNames = new Set(this.options.entryNames)
+    const { layer } = this.options
 
     compiler.hooks.thisCompilation.tap(PLUGIN_NAME, (compilation) => {
       compilation.hooks.processAssets.tap(
@@ -23,8 +23,25 @@ export class MarkMainThreadWebpackPlugin {
           stage: compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL,
         },
         () => {
+          const entryChunks = new Set<Rspack.Chunk>()
+          for (const [name, { options }] of compilation.entries) {
+            if (options.layer !== layer) {
+              continue
+            }
+            for (
+              const chunk of compilation.entrypoints.get(name)?.chunks ?? []
+            ) {
+              entryChunks.add(chunk)
+            }
+          }
           for (const chunk of compilation.chunks) {
-            if (chunk.name === undefined || !entryNames.has(chunk.name)) {
+            const modules = compilation.chunkGraph.getChunkModulesIterable(
+              chunk,
+            )
+            if (
+              !entryChunks.has(chunk)
+              && !Array.from(modules).some((module) => module.layer === layer)
+            ) {
               continue
             }
             for (const file of chunk.files) {

--- a/packages/rspeedy/lynx-bundle-rslib-config/test/external-bundle.test.ts
+++ b/packages/rspeedy/lynx-bundle-rslib-config/test/external-bundle.test.ts
@@ -394,6 +394,110 @@ describe('JsBytecode encoding', () => {
     expect(decodedResult['custom-sections']['utils']).toBeTypeOf('string')
   })
 
+  it('should not wrap a main-thread entry with the background runtime wrapper', async () => {
+    const rslibConfig = defineExternalBundleRslibConfig({
+      source: {
+        entry: {
+          utils: {
+            import: path.join(__dirname, './fixtures/utils-lib/index.ts'),
+            layer: LAYERS.MAIN_THREAD,
+          },
+        },
+      },
+      id: 'utils-m-plain',
+      output: {
+        distPath: {
+          root: path.join(fixtureDir, 'dist', 'utils-m-plain'),
+        },
+      },
+      plugins: [pluginReactLynx()],
+    }, {
+      enableJsBytecode: false,
+    })
+
+    await build(rslibConfig)
+
+    const decodedResult = await decodeTemplate(
+      path.join(
+        fixtureDir,
+        'dist',
+        'utils-m-plain',
+        'utils-m-plain.lynx.bundle',
+      ),
+    )
+    const mainThreadSection = decodedResult['custom-sections']['utils']
+    expect(mainThreadSection).toBeTypeOf('string')
+    expect(mainThreadSection).not.toContain('.define(')
+  })
+
+  it('should mark a chunk by its main-thread modules rather than its name', async () => {
+    const marked: Record<string, boolean> = {}
+    const rslibConfig = defineExternalBundleRslibConfig({
+      source: {
+        entry: {
+          utils: path.join(fixtureDir, 'index.ts'),
+          helpers: path.join(fixtureDir, 'index.ts'),
+        },
+      },
+      id: 'utils-shared-mt',
+      output: {
+        distPath: {
+          root: path.join(fixtureDir, 'dist', 'utils-shared-mt'),
+        },
+      },
+      tools: {
+        rspack: {
+          optimization: {
+            splitChunks: {
+              chunks: 'all',
+              minSize: 0,
+              cacheGroups: {
+                default: false,
+                defaultVendors: false,
+                mainThread: {
+                  name: 'shared-mt',
+                  test: (module: { layer?: string | null }) =>
+                    module.layer === LAYERS.MAIN_THREAD,
+                  enforce: true,
+                },
+              },
+            },
+          },
+        },
+      },
+      plugins: [
+        pluginReactLynx(),
+        {
+          name: 'test:read-marks',
+          setup(api) {
+            api.processAssets(
+              { stage: 'report' },
+              ({ compilation }) => {
+                for (const asset of compilation.getAssets()) {
+                  if (asset.name.endsWith('.js')) {
+                    marked[asset.name] = asset.info['lynx:main-thread'] === true
+                  }
+                }
+              },
+            )
+          },
+        } satisfies rsbuild.RsbuildPlugin,
+      ],
+    }, {
+      enableJsBytecode: false,
+    })
+
+    await build(rslibConfig)
+
+    expect(marked).toStrictEqual({
+      'shared-mt.js': true,
+      'utils__main-thread.js': true,
+      'helpers__main-thread.js': true,
+      'utils.js': false,
+      'helpers.js': false,
+    })
+  })
+
   it('should not compile main thread chunks to bytecode in development by default', async () => {
     const decodedResult = await buildAndDecode(
       'utils-dev-no-bytecode',

--- a/packages/rspeedy/lynx-bundle-rslib-config/test/mark-main-thread.test.ts
+++ b/packages/rspeedy/lynx-bundle-rslib-config/test/mark-main-thread.test.ts
@@ -1,0 +1,84 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { describe, expect, test } from '@rstest/core'
+
+import { MarkMainThreadWebpackPlugin } from '../src/webpack/MarkMainThreadWebpackPlugin.js'
+
+const LAYER = 'react:main-thread'
+
+interface Chunk {
+  name: string
+  files: string[]
+  layers: string[]
+}
+
+function mark(chunks: Chunk[], entries: Record<string, string | undefined>) {
+  const marked: string[] = []
+  let processAssets: (() => void) | undefined
+  const compilation = {
+    entries: new Map(
+      Object.entries(entries).map((
+        [name, layer],
+      ) => [name, { options: { layer } }]),
+    ),
+    entrypoints: new Map(
+      Object.keys(entries).map(name => [name, {
+        chunks: chunks.filter(chunk => chunk.name === name),
+      }]),
+    ),
+    chunks,
+    chunkGraph: {
+      getChunkModulesIterable: (chunk: Chunk) =>
+        chunk.layers.map(layer => ({ layer })),
+    },
+    getAsset: (file: string) =>
+      file === 'missing.js' ? undefined : { source: {}, info: {} },
+    updateAsset: (
+      file: string,
+      _source: unknown,
+      info: Record<string, boolean>,
+    ) => {
+      if (info['lynx:main-thread']) {
+        marked.push(file)
+      }
+    },
+    hooks: {
+      processAssets: {
+        tap: (_options: unknown, callback: () => void) => {
+          processAssets = callback
+        },
+      },
+    },
+  }
+  const compiler = {
+    webpack: { Compilation: { PROCESS_ASSETS_STAGE_ADDITIONAL: -2000 } },
+    hooks: {
+      thisCompilation: {
+        tap: (_name: string, callback: (compilation: unknown) => void) =>
+          callback(compilation),
+      },
+    },
+  }
+
+  new MarkMainThreadWebpackPlugin({ layer: LAYER }).apply(compiler as never)
+  processAssets?.()
+  return marked
+}
+
+describe('MarkMainThreadWebpackPlugin', () => {
+  test('marks the chunks of a main-thread entry and the chunks holding its modules', () => {
+    expect(mark([
+      { name: 'utils.m', files: ['utils.m.js', 'utils.m.css'], layers: [] },
+      {
+        name: 'shared',
+        files: ['shared.js', 'missing.js'],
+        layers: [LAYER, 'react:background'],
+      },
+      { name: 'utils', files: ['utils.js'], layers: ['react:background'] },
+    ], {
+      'utils.m': LAYER,
+      utils: 'react:background',
+    })).toStrictEqual(['utils.m.js', 'shared.js'])
+  })
+})

--- a/packages/rspeedy/plugin-react/src/entry.ts
+++ b/packages/rspeedy/plugin-react/src/entry.ts
@@ -273,8 +273,6 @@ export function applyEntry(
             })
           },
           targetSdkVersion,
-          // Inject runtime wrapper for all `.js` but not `main-thread.js` and `main-thread.[hash].js`.
-          test: /^(?!.*main-thread(?:\.[A-Fa-f0-9]*)?\.js$).*\.js$/,
           experimental_isLazyBundle,
         }])
         .end()

--- a/packages/webpack/runtime-wrapper-webpack-plugin/src/RuntimeWrapperWebpackPlugin.ts
+++ b/packages/webpack/runtime-wrapper-webpack-plugin/src/RuntimeWrapperWebpackPlugin.ts
@@ -2,7 +2,7 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
-import type { BannerPluginArgument, Compiler } from '@rspack/core';
+import type { BannerPluginArgument, Chunk, Compiler } from '@rspack/core';
 
 import { RuntimeGlobals } from '@lynx-js/webpack-runtime-globals';
 
@@ -141,7 +141,6 @@ class RuntimeWrapperWebpackPluginImpl {
     public options: RuntimeWrapperWebpackPluginOptions,
   ) {
     const { targetSdkVersion, test, experimental_isLazyBundle } = options;
-    const { BannerPlugin } = compiler.webpack;
 
     const isDev = process.env['NODE_ENV'] === 'development'
       || compiler.options.mode === 'development';
@@ -153,54 +152,76 @@ class RuntimeWrapperWebpackPluginImpl {
     }
     const iife = compiler.options.output.iife ?? true;
 
-    // banner
-    new BannerPlugin({
-      test: test!,
-      raw: true,
-      // Wrap at PROCESS_ASSETS_STAGE_NONE (0), after the release BannerPlugins
-      // the legacy source-map plugin + debug-metadata, at/around ADDITIONS
-      // (-100) so the wrapper stays outermost and their `_SetSourceMapRelease`
-      // runtimes land INSIDE it, yet still before DEV_TOOLING so the source map
-      // accounts for it.
-      stage: compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_NONE,
-      banner: ({ chunk, filename }) => {
-        const banner = this.#getBannerType(filename) === 'script'
-          ? loadScriptBanner()
-          : loadBundleBanner();
+    const wrapperHeader = (
+      { chunk, filename }: { chunk: Chunk; filename: string },
+    ) => {
+      const banner = this.#getBannerType(filename) === 'script'
+        ? loadScriptBanner()
+        : loadBundleBanner();
 
-        return banner
-          + amdBanner({
-            // TODO: config
-            injectStr,
-            overrideRuntimePromise: true,
-            moduleId: '[name].js',
-            targetSdkVersion,
-            iife,
-          })
-          // In standalone lazy bundle mode, the lazy bundle will
-          // also has chunk.id "main", it will be conflict with the
-          // consumer project.
-          // We disable it for standalone lazy bundle since we do not
-          // support HMR for standalone lazy bundle now.
-          + (isDev && !experimental_isLazyBundle
-            ? lynxChunkEntries(JSON.stringify(chunk.id))
-            : '');
-      },
-    }).apply(compiler);
+      return banner
+        + amdBanner({
+          // TODO: config
+          injectStr,
+          overrideRuntimePromise: true,
+          moduleId: '[name].js',
+          targetSdkVersion,
+          iife,
+        })
+        // In standalone lazy bundle mode, the lazy bundle will
+        // also has chunk.id "main", it will be conflict with the
+        // consumer project.
+        // We disable it for standalone lazy bundle since we do not
+        // support HMR for standalone lazy bundle now.
+        + (isDev && !experimental_isLazyBundle
+          ? lynxChunkEntries(JSON.stringify(chunk.id))
+          : '');
+    };
 
-    // footer
-    new BannerPlugin({
-      test: test!,
-      footer: true,
-      raw: true,
-      stage: compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_NONE,
-      banner: ({ filename }) => {
-        const footer = this.#getBannerType(filename) === 'script'
-          ? loadScriptFooter
-          : loadBundleFooter;
-        return amdFooter('[name].js', iife) + footer;
-      },
-    }).apply(compiler);
+    const wrapperFooter = (filename: string) => {
+      const footer = this.#getBannerType(filename) === 'script'
+        ? loadScriptFooter
+        : loadBundleFooter;
+      return amdFooter('[name].js', iife) + footer;
+    };
+
+    compiler.hooks.thisCompilation.tap(this.name, (compilation) => {
+      const { ModuleFilenameHelpers, sources: { ConcatSource } } =
+        compiler.webpack;
+      compilation.hooks.processAssets.tap(
+        {
+          name: this.name,
+          // Wrap at PROCESS_ASSETS_STAGE_NONE (0), after the release BannerPlugins
+          // the legacy source-map plugin + debug-metadata, at/around ADDITIONS
+          // (-100) so the wrapper stays outermost and their `_SetSourceMapRelease`
+          // runtimes land INSIDE it, yet still before DEV_TOOLING so the source map
+          // accounts for it.
+          stage: compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_NONE,
+        },
+        () => {
+          for (const chunk of compilation.chunks) {
+            for (const filename of chunk.files) {
+              if (
+                !ModuleFilenameHelpers.matchObject({ test: test! }, filename)
+              ) {
+                continue;
+              }
+              if (compilation.getAsset(filename)?.info['lynx:main-thread']) {
+                continue;
+              }
+              const data = { chunk, filename };
+              const header = compilation.getPath(wrapperHeader(data), data);
+              const footer = compilation.getPath(wrapperFooter(filename), data);
+              compilation.updateAsset(
+                filename,
+                (source) =>
+                  new ConcatSource(header, '\n', source, '\n', footer),
+              );
+            }
+          }
+        },
+      );
+    });
   }
 
   #getBannerType(filename: string) {

--- a/packages/webpack/runtime-wrapper-webpack-plugin/test/cases/main-thread/marked/index.js
+++ b/packages/webpack/runtime-wrapper-webpack-plugin/test/cases/main-thread/marked/index.js
@@ -1,0 +1,30 @@
+/*
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+*/
+/// <reference types="@rstest/core/globals" />
+// @ts-check
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+export function loadMainThread() {
+  return import('./main-thread.js');
+}
+
+it('should wrap the background asset', async () => {
+  const source = await fs.readFile(__filename, 'utf-8');
+
+  expect(source).toContain('__bundle__holder');
+});
+
+it('should not wrap the asset marked as main thread', async () => {
+  const source = await fs.readFile(
+    path.join(path.dirname(__filename), 'main-thread.js'),
+    'utf-8',
+  );
+
+  expect(source).not.toContain('__bundle__holder');
+  expect(source).not.toContain('.define(');
+});

--- a/packages/webpack/runtime-wrapper-webpack-plugin/test/cases/main-thread/marked/main-thread.js
+++ b/packages/webpack/runtime-wrapper-webpack-plugin/test/cases/main-thread/marked/main-thread.js
@@ -1,0 +1,6 @@
+/*
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+*/
+export const mainThread = true;

--- a/packages/webpack/runtime-wrapper-webpack-plugin/test/cases/main-thread/marked/rspack.config.js
+++ b/packages/webpack/runtime-wrapper-webpack-plugin/test/cases/main-thread/marked/rspack.config.js
@@ -1,0 +1,37 @@
+/*
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+*/
+import { RuntimeWrapperWebpackPlugin } from '../../../../lib/index.js';
+
+/** @type {import('@rspack/core').Configuration} */
+export default {
+  output: {
+    chunkFilename: 'main-thread.js',
+  },
+  plugins: [
+    new RuntimeWrapperWebpackPlugin(),
+    {
+      name: 'MarkMainThread',
+      apply(compiler) {
+        compiler.hooks.thisCompilation.tap('MarkMainThread', (compilation) => {
+          compilation.hooks.processAssets.tap(
+            {
+              name: 'MarkMainThread',
+              stage:
+                compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL,
+            },
+            () => {
+              const asset = compilation.getAsset('main-thread.js');
+              compilation.updateAsset(asset.name, asset.source, {
+                ...asset.info,
+                'lynx:main-thread': true,
+              });
+            },
+          );
+        });
+      },
+    },
+  ],
+};

--- a/packages/webpack/runtime-wrapper-webpack-plugin/test/marked-asset.test.js
+++ b/packages/webpack/runtime-wrapper-webpack-plugin/test/marked-asset.test.js
@@ -1,0 +1,59 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { rspack } from '@rspack/core';
+import { describe, expect, test } from '@rstest/core';
+
+import { RuntimeWrapperWebpackPlugin } from '../src/index.js';
+
+function wrap(assets) {
+  const updated = new Map();
+  let processAssets;
+  const compilation = {
+    chunks: Object.entries(assets).map(([name, info], id) => ({
+      id,
+      files: new Set([name]),
+      info,
+    })),
+    getAsset: (name) => ({ name, info: assets[name] }),
+    getPath: (str) => str,
+    updateAsset: (name, update) => {
+      updated.set(name, update(new rspack.sources.RawSource('body')).source());
+    },
+    hooks: {
+      processAssets: {
+        tap: (_options, callback) => {
+          processAssets = callback;
+        },
+      },
+    },
+  };
+  const compiler = {
+    webpack: rspack,
+    options: { mode: 'production', output: {} },
+    hooks: {
+      thisCompilation: {
+        tap: (_name, callback) => callback(compilation),
+      },
+    },
+  };
+
+  new RuntimeWrapperWebpackPlugin({ targetSdkVersion: '3.2' }).apply(compiler);
+  processAssets();
+  return updated;
+}
+
+describe('RuntimeWrapperWebpackPlugin', () => {
+  test('wraps a background asset and leaves a main-thread one alone', () => {
+    const updated = wrap({
+      'background.js': {},
+      'main-thread.js': { 'lynx:main-thread': true },
+      'style.css': {},
+    });
+
+    expect([...updated.keys()]).toStrictEqual(['background.js']);
+    expect(updated.get('background.js')).toMatch(/^\(function\(\)\{/);
+    expect(updated.get('background.js')).toContain('\nbody\n');
+    expect(updated.get('background.js')).toMatch(/\}\)\(\);\s*$/);
+  });
+});

--- a/packages/webpack/template-webpack-plugin/src/LynxTemplatePlugin.ts
+++ b/packages/webpack/template-webpack-plugin/src/LynxTemplatePlugin.ts
@@ -988,8 +988,14 @@ class LynxTemplatePluginImpl {
         LynxTemplatePluginImpl.#getAsyncChunkGroups(compilation),
       )
     ) {
+      const derived = chunkGroups.every(cg =>
+        cg.name === null || cg.name === undefined
+      );
       for (const chunk of chunkGroups.flatMap(cg => cg.chunks)) {
-        if (chunk.id !== null && chunk.id !== undefined) {
+        if (chunk.id === null || chunk.id === undefined) {
+          continue;
+        }
+        if (derived || !lazyBundleNames.has(chunk.id)) {
           lazyBundleNames.set(chunk.id, filename);
         }
       }


### PR DESCRIPTION
## Summary

`RuntimeWrapperWebpackPlugin` picked the assets to wrap by filename, so a main-thread entry that an external bundle names itself (`layer: LAYERS.MAIN_THREAD`, e.g. `utils.m`) got the background wrapper on top of its main-thread code and `lynx.loadScript` returned the wrapper's completion value instead of the exports.

Every main-thread asset is already marked `lynx:main-thread` by whoever compiles it (the DSL plugin, `MarkMainThreadWebpackPlugin` for an external bundle) and `LynxTemplatePlugin` encodes it by that mark. The wrapper now skips any asset carrying that mark instead of matching `main-thread` in the filename, so the wrapper and the encoder agree by construction. The React DSL drops its filename regex accordingly.

The wrapper is applied through `processAssets` directly rather than `BannerPlugin`, whose `test` only sees filenames; the output is byte-identical for a wrapped asset, including its source map.

`MarkMainThreadWebpackPlugin` in `lynx-bundle-rslib-config` marked assets by entry name; it now marks every chunk of a main-thread entry and every chunk holding main-thread modules, so the mark does not depend on chunk names either.

## Test

- `runtime-wrapper-webpack-plugin`: a case marks an async chunk as main thread and asserts it stays unwrapped while the entry is wrapped.
- `lynx-bundle-rslib-config`: an external bundle with a named main-thread entry has no `.define(` in that section; a split chunk holding only main-thread modules is marked while the background entries are not.
- Every example under `examples/` built with and without this change emits the same set of files, each wrapped or unwrapped the same way, with the same `tasm.json` section assignment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Main-thread assets are now correctly identified by their module layer, including assets in external bundles and shared chunks.
  * Main-thread assets no longer receive the background runtime wrapper, preventing incorrect runtime behavior.
  * Runtime wrapping continues to apply only to eligible background assets.

* **Tests**
  * Added coverage for main-thread asset handling, external bundles, shared chunks, runtime wrapping, and JavaScript bytecode output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->