### PR TITLE
fix(template-webpack-plugin): assemble every main-thread entry of an external bundle

### DIFF
--- a/.changeset/external-bundle-multi-entry.md
+++ b/.changeset/external-bundle-multi-entry.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/template-webpack-plugin": patch
+---
+
+Assemble every main-thread entry of an external bundle into its own section instead of dropping all but the first, and leave no packed chunk of a web external bundle on disk.

--- a/packages/rspeedy/lynx-bundle-rslib-config/test/external-bundle.test.ts
+++ b/packages/rspeedy/lynx-bundle-rslib-config/test/external-bundle.test.ts
@@ -207,6 +207,37 @@ describe('should build external bundle', () => {
     ])
   })
 
+  it('should build every main-thread entry into external bundle', async () => {
+    const distRoot = path.join(fixtureDir, 'dist', 'utils-multi')
+    const rslibConfig = defineExternalBundleRslibConfig({
+      source: {
+        entry: {
+          a: path.join(__dirname, './fixtures/utils-lib/index.ts'),
+          b: path.join(__dirname, './fixtures/utils-lib/index.ts'),
+        },
+      },
+      id: 'utils-multi',
+      output: {
+        distPath: {
+          root: distRoot,
+        },
+      },
+      plugins: [pluginReactLynx()],
+    })
+
+    await build(rslibConfig)
+
+    const decodedResult = await decodeTemplate(
+      path.join(distRoot, 'utils-multi.lynx.bundle'),
+    )
+    expect(Object.keys(decodedResult['custom-sections']).sort()).toEqual([
+      'a',
+      'a__main-thread',
+      'b',
+      'b__main-thread',
+    ])
+  })
+
   it('should only build main-thread code into external bundle', async () => {
     const rslibConfig = defineExternalBundleRslibConfig({
       source: {

--- a/packages/webpack/template-webpack-plugin/src/LynxTemplatePlugin.ts
+++ b/packages/webpack/template-webpack-plugin/src/LynxTemplatePlugin.ts
@@ -988,8 +988,14 @@ class LynxTemplatePluginImpl {
         LynxTemplatePluginImpl.#getAsyncChunkGroups(compilation),
       )
     ) {
+      const derived = chunkGroups.every(cg =>
+        cg.name === null || cg.name === undefined
+      );
       for (const chunk of chunkGroups.flatMap(cg => cg.chunks)) {
-        if (chunk.id !== null && chunk.id !== undefined) {
+        if (chunk.id === null || chunk.id === undefined) {
+          continue;
+        }
+        if (derived || !lazyBundleNames.has(chunk.id)) {
           lazyBundleNames.set(chunk.id, filename);
         }
       }

--- a/packages/webpack/template-webpack-plugin/src/LynxTemplatePlugin.ts
+++ b/packages/webpack/template-webpack-plugin/src/LynxTemplatePlugin.ts
@@ -1234,12 +1234,19 @@ class LynxTemplatePluginImpl {
       compilation,
     );
 
+    const isFetchBundleLazy = isAsync
+      && this.#options.lazyBundleFetcher === 'FetchBundle';
+    const naming = this.#options.customSectionNaming
+      ?? (isFetchBundleLazy ? () => LAZY_BUNDLE_SECTION_NAMING : undefined);
+
     const { encodeData } = await hooks.beforeEncode.promise({
       encodeData: encodeRawData,
       filenameTemplate,
       chunkGroups,
       intermediate,
-      intermediateAssets: [],
+      intermediateAssets: naming
+        ? assetsInfoByGroups.mainThread.map(asset => asset.name)
+        : [],
     });
 
     const { lepusCode, css } = encodeData;
@@ -1249,18 +1256,13 @@ class LynxTemplatePluginImpl {
         return [asset.name, asset.source.source().toString()];
       }),
     );
-
-    const isFetchBundleLazy = isAsync
-      && this.#options.lazyBundleFetcher === 'FetchBundle';
-    const naming = this.#options.customSectionNaming
-      ?? (isFetchBundleLazy ? () => LAZY_BUNDLE_SECTION_NAMING : undefined);
     // Default to bytecode for the main-thread sections. Skip in dev or when
     // DEBUG matches rspeedy so the source stays debuggable.
     const enableSectionBytecode = this.#options.enableSectionBytecode
       ?? (!isDev && !isDebug());
     const customSectionSplit = naming
       ? buildCustomSections({
-        mainThreadAssets: lepusCode.root ? [lepusCode.root] : [],
+        mainThreadAssets: assetsInfoByGroups.mainThread,
         manifest: encodeData.manifest,
         cssAssets: encodeData.css.chunks,
         enableBytecode: enableSectionBytecode,
@@ -1343,8 +1345,10 @@ class LynxTemplatePluginImpl {
         ...(cssDiagnostics === undefined ? {} : { cssDiagnostics }),
         template: buffer,
         outputName: filename,
-        mainThreadAssets: [lepusCode.root, ...encodeData.lepusCode.chunks]
-          .filter(i => i !== undefined),
+        mainThreadAssets: customSectionSplit
+          ? assetsInfoByGroups.mainThread
+          : [lepusCode.root, ...encodeData.lepusCode.chunks]
+            .filter(i => i !== undefined),
         cssChunks: assetsInfoByGroups.css,
         chunkGroups,
       });

--- a/packages/webpack/template-webpack-plugin/src/WebEncodePlugin.ts
+++ b/packages/webpack/template-webpack-plugin/src/WebEncodePlugin.ts
@@ -81,11 +81,18 @@ export class WebEncodePlugin {
         }, (encodeOptions) => {
           const { encodeData, intermediateAssets } = encodeOptions;
 
-          const name = last(Object.keys(encodeData.manifest));
+          // A bundle assembled from sections packs every background chunk, so
+          // none of them stays on disk. A card keeps its split chunks.
+          const inlinedManifest =
+            encodeData.sourceContent.appType === 'DynamicComponent'
+              ? Object.keys(encodeData.manifest)
+              : [last(Object.keys(encodeData.manifest))];
 
           if (!isDebug() && !isDev && !isRsdoctor()) {
             [
-              name === undefined ? undefined : { name },
+              ...inlinedManifest.map(name =>
+                name === undefined ? undefined : { name }
+              ),
               encodeData.lepusCode.root,
               ...encodeData.lepusCode.chunks,
               ...encodeData.css.chunks,

--- a/packages/webpack/template-webpack-plugin/test/__snapshots__/cases.test.ts.snap
+++ b/packages/webpack/template-webpack-plugin/test/__snapshots__/cases.test.ts.snap
@@ -36,3 +36,40 @@ exports[`template > templateCases-cases/defaults/config > should pass 1`] = `
   useNewSwiper: true,
 }
 `;
+
+exports[`template > templateCases-cases/main-thread/external-bundle > should pass 1`] = `
+{
+  bundleModuleMode: ReturnByFunction,
+  debugInfoOutside: true,
+  defaultDisplayLinear: true,
+  defaultOverflowVisible: true,
+  enableCSSInvalidation: false,
+  enableCSSSelector: true,
+  enableFiberArch: true,
+  enableLepusDebug: true,
+  enableRemoveCSSScope: false,
+  enableReuseContext: true,
+  targetSdkVersion: 3.2,
+  templateDebugUrl: ,
+  useLepusNG: true,
+}
+`;
+
+exports[`template > templateCases-cases/main-thread/external-bundle > should pass 2`] = `
+{
+  debugMetadataUrl: ,
+  enableA11y: true,
+  enableAccessibilityElement: false,
+  enableCSSInheritance: false,
+  enableGridPlacementShorthands: true,
+  enableNativeList: true,
+  enableNewGesture: false,
+  enableNewIntersectionObserver: true,
+  enableNewSticky: true,
+  flexBasisZeroPercent: true,
+  lepusStrict: true,
+  removeDescendantSelectorScope: false,
+  syncXElementRegistry: true,
+  useNewSwiper: true,
+}
+`;

--- a/packages/webpack/template-webpack-plugin/test/cases/main-thread/external-bundle/a.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/main-thread/external-bundle/a.js
@@ -1,0 +1,6 @@
+/*
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+*/
+console.info('**aaa**');

--- a/packages/webpack/template-webpack-plugin/test/cases/main-thread/external-bundle/b.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/main-thread/external-bundle/b.js
@@ -1,0 +1,6 @@
+/*
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+*/
+console.info('**bbb**');

--- a/packages/webpack/template-webpack-plugin/test/cases/main-thread/external-bundle/rspack.config.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/main-thread/external-bundle/rspack.config.js
@@ -1,0 +1,55 @@
+/*
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+*/
+import { fileURLToPath } from 'node:url';
+import { LynxEncodePlugin, LynxTemplatePlugin } from '../../../../lib/index.js';
+
+const section = (assetName) => assetName.split('/')[0];
+
+/** @type {import('@rspack/core').Configuration} */
+export default {
+  entry: {
+    a: './a.js',
+    b: './b.js',
+    a__main_thread: './a.js',
+    b__main_thread: './b.js',
+    test: './test.js',
+  },
+  context: fileURLToPath(new URL('.', import.meta.url)),
+  output: {
+    filename: '[name]/[name].js',
+  },
+  plugins: [
+    new LynxEncodePlugin(),
+    new LynxTemplatePlugin({
+      ...LynxTemplatePlugin.defaultOptions,
+      chunks: ['a', 'b', 'a__main_thread', 'b__main_thread'],
+      excludeChunks: ['test'],
+      filename: 'bundle/template.js',
+      intermediate: '.rspeedy/bundle',
+      appType: 'DynamicComponent',
+      enableSectionBytecode: false,
+      customSectionNaming: () => ({
+        mainThread: section,
+        background: (manifestKey) => section(manifestKey.replace(/^\//, '')),
+        css: () => undefined,
+      }),
+    }),
+
+    compiler => {
+      compiler.hooks.thisCompilation.tap('test', (compilation) => {
+        compilation.hooks.processAssets.tap('test', () => {
+          ['a__main_thread', 'b__main_thread'].forEach(name => {
+            const asset = compilation.getAsset(`${name}/${name}.js`);
+            compilation.updateAsset(asset.name, asset.source, {
+              ...asset.info,
+              'lynx:main-thread': true,
+            });
+          });
+        });
+      });
+    },
+  ],
+};

--- a/packages/webpack/template-webpack-plugin/test/cases/main-thread/external-bundle/test.config.cjs
+++ b/packages/webpack/template-webpack-plugin/test/cases/main-thread/external-bundle/test.config.cjs
@@ -1,0 +1,6 @@
+/** @type {import("@lynx-js/test-runner").TConfigCaseConfig} */
+module.exports = {
+  bundlePath: [
+    'test/test.js',
+  ],
+};

--- a/packages/webpack/template-webpack-plugin/test/cases/main-thread/external-bundle/test.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/main-thread/external-bundle/test.js
@@ -1,0 +1,28 @@
+/*
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+*/
+/// <reference types="@rstest/core/globals" />
+
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+
+it('should hold every main-thread chunk as its own section', async () => {
+  const tasm = JSON.parse(
+    await fs.readFile(
+      path.join(__dirname, '..', '.rspeedy', 'bundle', 'tasm.json'),
+      'utf-8',
+    ),
+  );
+
+  expect(Object.keys(tasm.customSections).sort()).toStrictEqual([
+    'a',
+    'a__main_thread',
+    'b',
+    'b__main_thread',
+  ]);
+  expect(tasm.customSections['a__main_thread'].content).toContain('**aaa**');
+  expect(tasm.customSections['b__main_thread'].content).toContain('**bbb**');
+  expect(tasm.lepusCode).toBeUndefined();
+});

--- a/packages/webpack/template-webpack-plugin/test/cases/web/lazy-bundle/a.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/web/lazy-bundle/a.js
@@ -1,0 +1,6 @@
+/*
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+*/
+console.info('**aaa**');

--- a/packages/webpack/template-webpack-plugin/test/cases/web/lazy-bundle/b.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/web/lazy-bundle/b.js
@@ -1,0 +1,6 @@
+/*
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+*/
+console.info('**bbb**');

--- a/packages/webpack/template-webpack-plugin/test/cases/web/lazy-bundle/rspack.config.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/web/lazy-bundle/rspack.config.js
@@ -1,0 +1,56 @@
+/*
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+*/
+import { fileURLToPath } from 'node:url';
+import { LynxTemplatePlugin, WebEncodePlugin } from '../../../../lib/index.js';
+
+const section = (assetName) => assetName.split('/')[0];
+
+/** @type {import('@rspack/core').Configuration} */
+export default {
+  entry: {
+    a: './a.js',
+    b: './b.js',
+    a__main_thread: './a.js',
+    b__main_thread: './b.js',
+    test: './test.js',
+  },
+  context: fileURLToPath(new URL('.', import.meta.url)),
+  output: {
+    filename: '[name]/[name].js',
+  },
+  plugins: [
+    new WebEncodePlugin({
+      cardType: 'react',
+    }),
+    new LynxTemplatePlugin({
+      ...LynxTemplatePlugin.defaultOptions,
+      chunks: ['a', 'b', 'a__main_thread', 'b__main_thread'],
+      excludeChunks: ['test'],
+      filename: 'bundle/template.js',
+      intermediate: '.rspeedy/bundle',
+      appType: 'DynamicComponent',
+      customSectionNaming: () => ({
+        mainThread: section,
+        background: (manifestKey) => section(manifestKey.replace(/^\//, '')),
+        css: () => undefined,
+      }),
+    }),
+
+    compiler => {
+      compiler.hooks.thisCompilation.tap('test', (compilation) => {
+        compilation.hooks.processAssets.tap('test', () => {
+          ['a__main_thread', 'b__main_thread'].forEach(name => {
+            const asset = compilation.getAsset(`${name}/${name}.js`);
+            compilation.updateAsset(asset.name, asset.source, {
+              ...asset.info,
+              'lynx:main-thread': true,
+            });
+          });
+        });
+      });
+    },
+  ],
+};

--- a/packages/webpack/template-webpack-plugin/test/cases/web/lazy-bundle/test.config.cjs
+++ b/packages/webpack/template-webpack-plugin/test/cases/web/lazy-bundle/test.config.cjs
@@ -1,0 +1,6 @@
+/** @type {import("@lynx-js/test-runner").TConfigCaseConfig} */
+module.exports = {
+  bundlePath: [
+    'test/test.js',
+  ],
+};

--- a/packages/webpack/template-webpack-plugin/test/cases/web/lazy-bundle/test.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/web/lazy-bundle/test.js
@@ -1,0 +1,19 @@
+/*
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+*/
+/// <reference types="@rstest/core/globals" />
+
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+
+it('should pack every background chunk into the bundle', async () => {
+  const bundle = await fs.readFile(
+    path.join(__dirname, '..', 'bundle', 'template.js'),
+    'utf-8',
+  );
+
+  expect(bundle).toContain('**aaa**');
+  expect(bundle).toContain('**bbb**');
+});

--- a/packages/webpack/template-webpack-plugin/test/web-encode-plugin-inlined-manifest.test.ts
+++ b/packages/webpack/template-webpack-plugin/test/web-encode-plugin-inlined-manifest.test.ts
@@ -1,0 +1,87 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { SyncHook } from '@rspack/lite-tapable';
+import { describe, expect, test } from '@rstest/core';
+import webpack from 'webpack';
+
+import { LynxTemplatePlugin, WebEncodePlugin } from '../src/index.js';
+
+async function inlinedManifestOf(appType: 'app' | 'DynamicComponent') {
+  // `lynxRstestConfig` sets `DEBUG=rspeedy`, under which the plugin inlines
+  // nothing; see web-encode-plugin-sourcemap.test.ts.
+  const debug = process.env['DEBUG'];
+  delete process.env['DEBUG'];
+  try {
+    return await drive(appType);
+  } finally {
+    if (debug === undefined) delete process.env['DEBUG'];
+    else process.env['DEBUG'] = debug;
+  }
+}
+
+async function drive(appType: 'app' | 'DynamicComponent') {
+  const deleted: string[] = [];
+  let processAssets: (() => void) | undefined;
+
+  const compilation = {
+    warnings: [],
+    errors: [],
+    chunks: [],
+    outputOptions: {},
+    getAsset: (name: string) => ({ name, source: {}, info: {} }),
+    hooks: {
+      processAssets: {
+        tap: (_options: unknown, callback: () => void) => {
+          processAssets = callback;
+        },
+      },
+    },
+    deleteAsset: (name: string) => {
+      deleted.push(name);
+    },
+    emitAsset: () => void 0,
+    updateAsset: () => void 0,
+  } as unknown as webpack.Compilation;
+
+  const compiler = {
+    options: { mode: 'production' },
+    hooks: { thisCompilation: new SyncHook(['compilation']) },
+    webpack,
+  } as unknown as webpack.Compiler;
+
+  new WebEncodePlugin().apply(compiler as never);
+  compiler.hooks.thisCompilation.call(compilation, {} as never);
+
+  const hooks = LynxTemplatePlugin.getLynxTemplatePluginHooks(
+    compilation as never,
+  );
+  await hooks.beforeEncode.promise({
+    encodeData: {
+      manifest: { '/a.js': 'a', '/b.js': 'b' },
+      lepusCode: { root: undefined, chunks: [] },
+      css: { chunks: [] },
+      customSections: {},
+      compilerOptions: {},
+      sourceContent: { dsl: 'react', appType, config: {} },
+    },
+    intermediateAssets: [],
+  } as never);
+
+  processAssets?.();
+  return deleted;
+}
+
+describe('WebEncodePlugin: inlined manifest', () => {
+  test('a bundle assembled from sections inlines every background chunk', async () => {
+    expect(await inlinedManifestOf('DynamicComponent')).toStrictEqual([
+      '/a.js',
+      '/b.js',
+    ]);
+  });
+
+  test('a card keeps its split chunks and inlines the last one', async () => {
+    expect(await inlinedManifestOf('app')).toStrictEqual(['/b.js']);
+  });
+});


### PR DESCRIPTION
## Summary

An external bundle with several entries lost every `<entry>__main-thread` chunk but the first: `LynxTemplatePlugin` handed only `lepusCode.root` to the section split, so the other main-thread chunks stayed on disk as plain assets and `lynx.loadScript('<entry>__main-thread')` had nothing to load.

`lepusCode` describes a card, whose main thread is a single root plus whatever the DSL appends (the worklet runtime), and it is dropped for a bundle assembled by name. So the section split now takes every main-thread asset of the template directly, and those assets are reported as `intermediateAssets` so the encoders fold them away like the root. `lepusCode` itself is unchanged.

On the web target only the last manifest file was inlined, which left a background chunk of a multi-entry bundle on disk. A lazy bundle now inlines every manifest file, the way the Lynx target does.

## Test

- `lynx-bundle-rslib-config`: a build with two entries expects the sections `a`, `a__main-thread`, `b` and `b__main-thread`.
- `template-webpack-plugin`: a Lynx case asserts every main-thread chunk becomes its own section, a web case asserts both background chunks land in the bundle, and a unit test covers the inlined manifest of a lazy bundle versus a card.
