### PR TITLE
fix(react-rsbuild-plugin): apply the runtime config to an application build

### DIFF
--- a/packages/rspeedy/plugin-react/src/entry.ts
+++ b/packages/rspeedy/plugin-react/src/entry.ts
@@ -327,7 +327,7 @@ export function applyEntry(
     // Runtime config belongs to the page host. Standalone lazy bundles and
     // rslib products (including external bundles) reuse the host-injected
     // `lynx.__runtime_configs__` instead of contributing their own values.
-    const isHostEnvironment = emitTemplate && !experimental_isLazyBundle
+    const isHostEnvironment = isApplication && !experimental_isLazyBundle
     if (isHostEnvironment && Object.keys(runtimeConfig).length > 0) {
       chain
         .plugin(PLUGIN_NAME_RUNTIME_CONFIG)


### PR DESCRIPTION
## Summary

#3718 gates the runtime config on `emitTemplate`, which #3744 had already renamed to `isApplication`, so `main` no longer compiles:

```
packages/rspeedy/plugin-react/src/entry.ts(328,31): error TS2304: Cannot find name 'emitTemplate'.
```

`isApplication` is the same condition (not an `rslib` or `rstest` build), so the runtime config still goes to the page host only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Runtime configuration values are now sourced based on the application environment, improving consistency across application builds and tooling contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->