### PR TITLE
fix(template-webpack-plugin): pick the lazy bundle of a shared chunk deterministically

### DIFF
--- a/.changeset/lazy-bundle-name-order.md
+++ b/.changeset/lazy-bundle-name-order.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/template-webpack-plugin": patch
+---
+
+Map an async chunk shared by an unnamed `import()` and a `webpackChunkName` import to the lazy bundle derived from its modules, regardless of build order.

--- a/packages/webpack/template-webpack-plugin/src/LynxTemplatePlugin.ts
+++ b/packages/webpack/template-webpack-plugin/src/LynxTemplatePlugin.ts
@@ -988,8 +988,14 @@ class LynxTemplatePluginImpl {
         LynxTemplatePluginImpl.#getAsyncChunkGroups(compilation),
       )
     ) {
+      const derived = chunkGroups.every(cg =>
+        cg.name === null || cg.name === undefined
+      );
       for (const chunk of chunkGroups.flatMap(cg => cg.chunks)) {
-        if (chunk.id !== null && chunk.id !== undefined) {
+        if (chunk.id === null || chunk.id === undefined) {
+          continue;
+        }
+        if (derived || !lazyBundleNames.has(chunk.id)) {
           lazyBundleNames.set(chunk.id, filename);
         }
       }


### PR DESCRIPTION
## Summary

`test-rstest-windows` fails on #3752 at `template > templateCases-cases/runtime-module/async-chunks-dedupe`: https://github.com/lynx-family/lynx-stack/actions/runs/33732438221/job/100579538069

```
should map both import paths to the same bundle failed:
expected [ Array(1) ] to strictly equal [ Array(1) ]
-   "lazy-bundle/dynamic.js.5e6edda74222496d.bundle",
+   "lazy-bundle/../dynamic.js.5e6edda74222496d.bundle",
```

The same case fails on macOS with the template plugin of `main`, so #3752 is not the cause. The Windows rstest job is only scheduled when `build-windows` runs, which is why `main` never showed it.

## Cause

The case imports `dynamic.js` twice: `index.js` does `import('./dynamic.js')`, and `subdir/importer.js` does `import(/* webpackChunkName: '../dynamic.js:background' */ '../dynamic.js')`. Rspack gives both dynamic imports one async chunk (id `0`) but two chunk groups, one unnamed and one named `../dynamic.js:background`.

`LynxTemplatePlugin` groups the async chunk groups by lazy bundle name: a named group is keyed by its `webpackChunkName` after the `asyncChunkName` hook (`../dynamic.js`), an unnamed one by the name derived from its resolved modules (`dynamic.js`). `#getLazyBundleNameByChunkId` then walks those groups and writes `chunk.id -> name` into a map, so a chunk that belongs to two groups gets whichever group is walked last. That order follows `compilation.chunkGroups`, which follows the order in which the two imports finished building. Instrumenting the map on macOS shows the same chunk written twice, `../dynamic.js` first and `dynamic.js` last on a passing run, and the other way around on a failing one. Ubuntu happens to finish in the passing order, Windows and macOS do not always.

`__webpack_require__.lynx_aci` is built from that map, so the runtime pointed the chunk at `lazy-bundle/../dynamic.js.<hash>.bundle`, a file outside `lazy-bundle/`, on the failing runs.

## Fix

For a chunk shared by several groups, the name derived from the resolved modules wins over a `webpackChunkName`: it is the one that never escapes `lazy-bundle/`, and it is what #2961 intended for a leftover injected name. A chunk that only has user-named groups keeps the user name, so `webpackChunkName` still controls placement.

## Test

`async-chunks-dedupe` no longer depends on the build order; the template-webpack-plugin suite passes locally on macOS, where it used to fail.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed lazy bundle mapping for asynchronous chunks shared by unnamed dynamic imports and explicitly named imports.
  - Lazy bundles are now consistently associated with the correct bundle derived from their modules, regardless of build order.
  - Preserved existing mappings for explicitly named chunk groups to prevent incorrect reassignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->