### PR TITLE
ci(renovate): install root dependencies before generating changesets

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -39,10 +39,16 @@
   "prConcurrentLimit": 20,
   "prHourlyLimit": 4,
 
-  // Auto-generate a changeset for the dependency bump (see the script). No-op
-  // unless the command is allow-listed in the self-hosted `allowedCommands`.
+  // Auto-generate a changeset for the dependency bump (see the script). Renovate
+  // only updates lockfiles and never installs the repo's dependencies, so install
+  // the root package first: the script needs `yaml` from the root devDependencies.
+  // No-op unless both commands are allow-listed in the self-hosted
+  // `allowedCommands`.
   "postUpgradeTasks": {
-    "commands": ["node .github/scripts/generate-renovate-changeset.cjs"],
+    "commands": [
+      "pnpm install --filter . --frozen-lockfile --ignore-scripts",
+      "node .github/scripts/generate-renovate-changeset.cjs",
+    ],
     "fileFilters": [".changeset/renovate-*.md"],
     "executionMode": "branch",
   },


### PR DESCRIPTION
Since 2026-08-12 every Renovate PR (e.g. #3374, #3415, #3428) carries an "Artifact update problem" comment with `Cannot find module 'yaml'` from `.github/scripts/generate-renovate-changeset.cjs`, and no changeset is generated.

The script requires `yaml` from the root devDependencies, but Renovate only runs `pnpm install --lockfile-only` and never installs the repo's node_modules. They used to exist only as a side effect of `pnpm dedupe --recursive` doing a full install; upstream renovate #45244 dropped `--recursive`, so `--lockfile-only` now applies to dedupe too and nothing is installed.

Add an explicit root-only install as the first `postUpgradeTasks` command. `--filter .` installs just the root package (measured: 469 MB, 3.4 s with a warm store), `--ignore-scripts` skips lifecycle hooks, and the install persists across branches within a Renovate run. The self-hosted pipeline allowlist gains the matching command in lynx-community/renovate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency maintenance to install required project packages before generating release changesets.
  * Improved configuration comments describing the automated update workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->