### PR TITLE
fix(debug-metadata): emit uiSourceMap sources relative to the repo root

### DIFF
--- a/.changeset/git-remote-url-parse-failure-credentials.md
+++ b/.changeset/git-remote-url-parse-failure-credentials.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/debug-metadata-rsbuild-plugin": patch
+---
+
+Drop `remoteUrl` instead of leaking its embedded credentials when the git remote fails to parse as a URL (e.g. a host-less `https://user:pass@/owner/repo`).

--- a/.changeset/ui-source-map-repo-relative.md
+++ b/.changeset/ui-source-map-repo-relative.md
@@ -1,5 +1,9 @@
 ---
 "@lynx-js/debug-metadata-rsbuild-plugin": patch
+"@lynx-js/debug-metadata": patch
 ---
 
-Emit `uiSourceMap.sources` relative to the repository root. The main-thread loader hands the collector absolute build-machine paths, so a UI node resolved through `remapUiTree` came back with something like `/opt/build/src/.../apps/app/src/components/Badge/index.tsx` — a path that differs per builder and reaches no file. `sources` now carry what the type has always promised, an authored path a consumer can join onto the build's git remote and commit.
+Fix `remapUiTree` returning a UI node's source location that a consumer could not turn into a link back to the file.
+
+- Emit `uiSourceMap.sources` relative to the repository root. The main-thread loader hands the collector absolute build-machine paths, so a resolved node came back with something like `/opt/build/src/.../apps/app/src/components/Badge/index.tsx` — a path that differs per builder and reaches no file. `sources` now carry what the type has always promised, an authored path relative to the project root.
+- Add `remoteUrl` and `commit` to `UiSourceLocation` / `RemappedUiNode`. `repo` normalizes SSH and HTTP remotes to the same `owner/repo` string, which erases which host (or which internal vs. public mirror of the same path) `source` came from; `remoteUrl` and `commit` are what's needed to actually reach the file the build was compiled from.

--- a/.changeset/ui-source-map-repo-relative.md
+++ b/.changeset/ui-source-map-repo-relative.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/debug-metadata-rsbuild-plugin": patch
+---
+
+Emit `uiSourceMap.sources` relative to the repository root. The main-thread loader hands the collector absolute build-machine paths, so a UI node resolved through `remapUiTree` came back with something like `/opt/build/src/.../apps/app/src/components/Badge/index.tsx` — a path that differs per builder and reaches no file. `sources` now carry what the type has always promised, an authored path a consumer can join onto the build's git remote and commit.

--- a/.changeset/ui-source-map-repo-relative.md
+++ b/.changeset/ui-source-map-repo-relative.md
@@ -3,7 +3,4 @@
 "@lynx-js/debug-metadata": patch
 ---
 
-Fix `remapUiTree` returning a UI node's source location that a consumer could not turn into a link back to the file.
-
-- Emit `uiSourceMap.sources` relative to the repository root. The main-thread loader hands the collector absolute build-machine paths, so a resolved node came back with something like `/opt/build/src/.../apps/app/src/components/Badge/index.tsx` — a path that differs per builder and reaches no file. `sources` now carry what the type has always promised, an authored path relative to the project root.
-- Add `remoteUrl` and `commit` to `UiSourceLocation` / `RemappedUiNode`. `repo` normalizes SSH and HTTP remotes to the same `owner/repo` string, which erases which host (or which internal vs. public mirror of the same path) `source` came from; `remoteUrl` and `commit` are what's needed to actually reach the file the build was compiled from.
+Fix `remapUiTree` resolving a UI node to a source location a consumer could not turn into a link back to the file: `uiSourceMap.sources` is now relative to the repository root instead of an absolute build-machine path, and `UiSourceLocation` / `RemappedUiNode` gain `remoteUrl` and `commit` alongside the host-less `repo`.

--- a/packages/rspeedy/plugin-debug-metadata/src/LynxDebugMetadataPlugin.ts
+++ b/packages/rspeedy/plugin-debug-metadata/src/LynxDebugMetadataPlugin.ts
@@ -197,7 +197,7 @@ export class LynxDebugMetadataPluginImpl {
           }
           const asset: DebugMetadataAsset = {
             artifacts: collectArtifacts(compilation, chunkGroups),
-            uiSourceMap: createUiSourceMap(uiSourceMapRecords),
+            uiSourceMap: createUiSourceMap(uiSourceMapRecords, baseDir),
             buildInfo: {
               ...(git ? { git } : {}),
               rspeedy,

--- a/packages/rspeedy/plugin-debug-metadata/src/collectors/git.ts
+++ b/packages/rspeedy/plugin-debug-metadata/src/collectors/git.ts
@@ -59,7 +59,14 @@ export function normalizeRemoteUrl(remoteUrl: string | null): string | null {
     url.hash = ''
     return url.toString().replace(/\.git$/, '').replace(/\/$/, '')
   } catch {
-    return normalized.replace(/\.git$/, '')
+    // `normalized` failed to parse as a URL, so there's no `URL` object to
+    // strip userinfo from — and a remote carrying credentials is exactly
+    // the shape most likely to hit this branch (e.g. a host-less
+    // `https://user:pass@/owner/repo`, where the embedded `@` still parses
+    // as userinfo but leaves no host for the URL to require). Returning
+    // `normalized` as-is would leak that userinfo into the metadata file;
+    // `null` costs a browsable link on inputs already this malformed.
+    return null
   }
 }
 

--- a/packages/rspeedy/plugin-debug-metadata/src/collectors/ui-source-map.ts
+++ b/packages/rspeedy/plugin-debug-metadata/src/collectors/ui-source-map.ts
@@ -2,6 +2,8 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
+import path from 'node:path'
+
 import type { Rspack } from '@rsbuild/core'
 
 import { UI_SOURCE_MAP_RECORDS_BUILD_INFO } from '@lynx-js/debug-metadata'
@@ -61,9 +63,15 @@ export function compareUiSourceMapRecord(
  * Build the compact {@link UiSourceMapData} payload emitted under
  * `DebugMetadataAsset.uiSourceMap`. Records without a `filename` are
  * dropped (no source to anchor the entry to).
+ *
+ * `sources` are emitted relative to `baseDir` (the repository root), so a
+ * consumer can join one onto the build's git remote and commit to reach the
+ * authored file. The main-thread loader hands absolute build-machine paths
+ * to the UI source map, which differ per builder and resolve nowhere.
  */
 export function createUiSourceMap(
   records: UiSourceMapRecord[],
+  baseDir: string,
 ): UiSourceMapData {
   const sources: string[] = []
   const sourceIndexes = new Map<string, number>()
@@ -72,17 +80,25 @@ export function createUiSourceMap(
 
   for (const record of records) {
     if (!record.filename) continue
-    let sourceIndex = sourceIndexes.get(record.filename)
+    const source = toRepoRelative(record.filename, baseDir)
+    let sourceIndex = sourceIndexes.get(source)
     if (sourceIndex === undefined) {
       sourceIndex = sources.length
-      sourceIndexes.set(record.filename, sourceIndex)
-      sources.push(record.filename)
+      sourceIndexes.set(source, sourceIndex)
+      sources.push(source)
     }
     mappings.push([sourceIndex, record.lineNumber, record.columnNumber])
     uiMaps.push(record.uiSourceMap)
   }
 
   return { version: 1, sources, mappings, uiMaps }
+}
+
+function toRepoRelative(filename: string, baseDir: string): string {
+  if (!path.isAbsolute(filename)) {
+    return filename.split(path.sep).join('/')
+  }
+  return path.relative(baseDir, filename).split(path.sep).join('/')
 }
 
 /**

--- a/packages/rspeedy/plugin-debug-metadata/test/git.test.ts
+++ b/packages/rspeedy/plugin-debug-metadata/test/git.test.ts
@@ -55,6 +55,13 @@ describe('normalizeRemoteUrl', () => {
     expect(normalizeRemoteUrl('ssh://git@github.com:22/owner/repo.git'))
       .toBe('https://github.com/owner/repo')
   })
+
+  test('drops a URL the parser rejects rather than leaking its userinfo', () => {
+    // Host-less but still carrying an `@`, so `new URL()` throws before the
+    // credential-stripping lines ever run. Falling back to the raw string
+    // here would leak the password into the metadata file.
+    expect(normalizeRemoteUrl('https://user:pass@/owner/repo.git')).toBeNull()
+  })
 })
 
 describe('collectGitMetadata', () => {

--- a/packages/rspeedy/plugin-debug-metadata/test/ui-source-map.test.ts
+++ b/packages/rspeedy/plugin-debug-metadata/test/ui-source-map.test.ts
@@ -4,8 +4,14 @@
 
 import { describe, expect, test } from 'vitest'
 
-import { UI_SOURCE_MAP_RECORDS_BUILD_INFO } from '@lynx-js/debug-metadata'
-import type { UiSourceMapRecord } from '@lynx-js/debug-metadata'
+import {
+  UI_SOURCE_MAP_RECORDS_BUILD_INFO,
+  remapUiTree,
+} from '@lynx-js/debug-metadata'
+import type {
+  DebugMetadataAsset,
+  UiSourceMapRecord,
+} from '@lynx-js/debug-metadata'
 
 import {
   collectUiSourceMapRecordsFromModule,
@@ -115,7 +121,7 @@ describe('createUiSourceMap', () => {
         uiSourceMap: 30,
       }),
     ]
-    expect(createUiSourceMap(records)).toEqual({
+    expect(createUiSourceMap(records, '/repo')).toEqual({
       version: 1,
       sources: ['a.tsx', 'b.tsx'],
       mappings: [
@@ -132,7 +138,7 @@ describe('createUiSourceMap', () => {
       createUiSourceMap([
         record({ filename: '' }),
         record({ filename: 'kept.tsx' }),
-      ]),
+      ], '/repo'),
     ).toEqual({
       version: 1,
       sources: ['kept.tsx'],
@@ -142,11 +148,91 @@ describe('createUiSourceMap', () => {
   })
 
   test('empty input yields an empty payload', () => {
-    expect(createUiSourceMap([])).toEqual({
+    expect(createUiSourceMap([], '/repo')).toEqual({
       version: 1,
       sources: [],
       mappings: [],
       uiMaps: [],
     })
+  })
+})
+
+describe('createUiSourceMap -> remapUiTree', () => {
+  // A CI build checks the repository out under a machine-specific prefix, so
+  // the loader hands the UI source map paths like
+  // `<rootDir>/apps/app/src/components/Badge/index.tsx`. A consumer can only
+  // reach the authored file if what it reads back is relative to the repo.
+  const rootDir = '/opt/build/src/git.example.com/acme/storefront'
+  const remoteUrl = 'https://git.example.com/acme/storefront'
+
+  const records: UiSourceMapRecord[] = [
+    {
+      uiSourceMap: 101,
+      filename: `${rootDir}/apps/app/src/common/themes.tsx`,
+      lineNumber: 635,
+      columnNumber: 11,
+    },
+    {
+      uiSourceMap: 202,
+      filename: `${rootDir}/apps/app/src/components/Badge/index.tsx`,
+      lineNumber: 21,
+      columnNumber: 7,
+    },
+  ]
+
+  test('a node resolves to a repo-relative source, not a build path', async () => {
+    const uiSourceMap = createUiSourceMap(records, rootDir)
+    expect(uiSourceMap.sources).toEqual([
+      'apps/app/src/common/themes.tsx',
+      'apps/app/src/components/Badge/index.tsx',
+    ])
+
+    const remapped = await remapUiTree(
+      {
+        nodeIndex: 101,
+        debugMetadataUrl: 'https://example.test/debug-metadata.json',
+        children: [
+          {
+            nodeIndex: 202,
+            debugMetadataUrl: 'https://example.test/debug-metadata.json',
+          },
+        ],
+      },
+      () =>
+        Promise.resolve({
+          artifacts: [],
+          uiSourceMap,
+          buildInfo: { git: { remoteUrl } },
+        } as unknown as DebugMetadataAsset),
+    )
+
+    expect(remapped).toMatchObject({
+      repo: 'acme/storefront',
+      source: 'apps/app/src/common/themes.tsx',
+      line: 635,
+      column: 11,
+      children: [
+        {
+          repo: 'acme/storefront',
+          source: 'apps/app/src/components/Badge/index.tsx',
+          line: 21,
+          column: 7,
+        },
+      ],
+    })
+  })
+
+  test('a path outside the repository root keeps its distance from it', () => {
+    expect(
+      createUiSourceMap(
+        [{
+          uiSourceMap: 1,
+          filename: '/opt/build/src/git.example.com/acme/shared/ui.tsx',
+          lineNumber: 1,
+          columnNumber: 0,
+        }],
+        rootDir,
+      ).sources,
+    ).toEqual(['../shared/ui.tsx'])
   })
 })

--- a/packages/tools/debug-metadata/etc/debug-metadata.api.md
+++ b/packages/tools/debug-metadata/etc/debug-metadata.api.md
@@ -19,7 +19,7 @@ export interface Artifact {
 export function assertUiNode(value: unknown, path?: string): asserts value is UiNode;
 
 // @public
-export function buildUiSourceMapLookup(uiSourceMap: UiSourceMapData): Map<number, Omit<UiSourceLocation, 'repo'>>;
+export function buildUiSourceMapLookup(uiSourceMap: UiSourceMapData): Map<number, Omit<UiSourceLocation, 'repo' | 'remoteUrl' | 'commit'>>;
 
 // @public
 export interface BytecodeDebugInfoSource {
@@ -139,7 +139,11 @@ export interface RemappedUiNode extends UiNode {
     // (undocumented)
     column?: number;
     // (undocumented)
+    commit?: string | null;
+    // (undocumented)
     line?: number;
+    // (undocumented)
+    remoteUrl?: string | null;
     // (undocumented)
     repo?: string | null;
     // (undocumented)
@@ -213,7 +217,9 @@ export interface UiNode {
 // @public
 export interface UiSourceLocation {
     column: number;
+    commit: string | null;
     line: number;
+    remoteUrl: string | null;
     repo: string | null;
     source: string | null;
 }

--- a/packages/tools/debug-metadata/src/ui-remap.ts
+++ b/packages/tools/debug-metadata/src/ui-remap.ts
@@ -13,6 +13,17 @@ import type { DebugMetadataAsset, UiSourceMapData } from './types.js';
 export interface UiSourceLocation {
   /** `owner/repo` derived from the build's git remote, or `null`. */
   repo: string | null;
+  /**
+   * The build's git remote URL verbatim (SSH or HTTP form, whichever the
+   * builder reported), or `null`. `repo` above drops the host to normalize
+   * SSH and HTTP remotes to the same value, which also erases which host
+   * (or which internal vs. public mirror of the same path) `source` came
+   * from. Join this with `commit` and `source` to reach the exact file
+   * this build was compiled from.
+   */
+  remoteUrl: string | null;
+  /** The git commit this build was compiled from, or `null`. */
+  commit: string | null;
   /** Authored source path (relative to the project root), or `null`. */
   source: string | null;
   /** 1-based source line. */
@@ -51,6 +62,8 @@ export interface UiNode {
 export interface RemappedUiNode extends UiNode {
   children?: RemappedUiNode[];
   repo?: string | null;
+  remoteUrl?: string | null;
+  commit?: string | null;
   source?: string | null;
   line?: number;
   column?: number;
@@ -131,9 +144,12 @@ export function isUiSourceMapData(value: unknown): value is UiSourceMapData {
  */
 export function buildUiSourceMapLookup(
   uiSourceMap: UiSourceMapData,
-): Map<number, Omit<UiSourceLocation, 'repo'>> {
+): Map<number, Omit<UiSourceLocation, 'repo' | 'remoteUrl' | 'commit'>> {
   const { sources, mappings, uiMaps } = uiSourceMap;
-  const lookup = new Map<number, Omit<UiSourceLocation, 'repo'>>();
+  const lookup = new Map<
+    number,
+    Omit<UiSourceLocation, 'repo' | 'remoteUrl' | 'commit'>
+  >();
   for (let i = 0; i < uiMaps.length; i++) {
     const nodeIndex = uiMaps[i];
     const mapping = mappings[i];
@@ -195,8 +211,13 @@ export async function remapUiTree(
   loadMetadata: DebugMetadataLoader,
 ): Promise<RemappedUiNode> {
   interface Resolved {
-    lookup: Map<number, Omit<UiSourceLocation, 'repo'>>;
+    lookup: Map<
+      number,
+      Omit<UiSourceLocation, 'repo' | 'remoteUrl' | 'commit'>
+    >;
     repo: string | null;
+    remoteUrl: string | null;
+    commit: string | null;
   }
   const cache = new Map<string, Promise<Resolved>>();
 
@@ -218,11 +239,16 @@ export async function remapUiTree(
         const buildInfo = metadata['buildInfo'];
         const git: unknown = isRecord(buildInfo) ? buildInfo['git'] : undefined;
         const remoteUrl: unknown = isRecord(git) ? git['remoteUrl'] : undefined;
+        const commit: unknown = isRecord(git) ? git['commit'] : undefined;
         return {
           lookup: buildUiSourceMapLookup(metadata['uiSourceMap']),
           repo: normalizeRepo(
             typeof remoteUrl === 'string' ? remoteUrl : null,
           ),
+          remoteUrl: typeof remoteUrl === 'string' ? remoteUrl : null,
+          commit: typeof commit === 'string' && commit.length > 0
+            ? commit
+            : null,
         };
       });
       cache.set(debugMetadataUrl, pending);
@@ -242,10 +268,14 @@ export async function remapUiTree(
       && node.debugMetadataUrl.length > 0
       && typeof node.nodeIndex === 'number'
     ) {
-      const { lookup, repo } = await resolve(node.debugMetadataUrl);
+      const { lookup, repo, remoteUrl, commit } = await resolve(
+        node.debugMetadataUrl,
+      );
       const location = lookup.get(node.nodeIndex);
       if (location !== undefined) {
         out.repo = repo;
+        out.remoteUrl = remoteUrl;
+        out.commit = commit;
         out.source = location.source;
         out.line = location.line;
         out.column = location.column;

--- a/packages/tools/debug-metadata/test/ui-remap.test.ts
+++ b/packages/tools/debug-metadata/test/ui-remap.test.ts
@@ -122,6 +122,8 @@ describe('remapUiTree', () => {
       sign: 1,
       tag: 'page',
       repo: 'acme/app',
+      remoteUrl: 'git@github.com:acme/app.git',
+      commit: 'deadbeef',
       source: 'src/App.tsx',
       line: 3,
       column: 1,
@@ -129,6 +131,8 @@ describe('remapUiTree', () => {
     // resolved child
     expect(output.children?.[0]).toMatchObject({
       repo: 'acme/app',
+      remoteUrl: 'git@github.com:acme/app.git',
+      commit: 'deadbeef',
       source: 'src/Button.tsx',
       line: 12,
       column: 4,
@@ -157,6 +161,8 @@ describe('remapUiTree', () => {
       'debugMetadataUrl',
       'children',
       'repo',
+      'remoteUrl',
+      'commit',
       'source',
       'line',
       'column',
@@ -189,6 +195,53 @@ describe('remapUiTree', () => {
         () => Promise.resolve(malformed),
       ),
     ).rejects.toThrow(/Invalid debug-metadata loaded from "[^"]+"/);
+  });
+
+  test('keeps remoteUrl distinguishing two hosts that normalizeRepo folds together', async () => {
+    // An internal mirror and its public counterpart share an `owner/repo`
+    // path, so `repo` alone can't tell a consumer which host `source` came
+    // from. `remoteUrl` is what's left to reach the exact file.
+    const internal = metadata('https://git.internal.example/acme/app', {
+      version: 1,
+      sources: ['src/App.tsx'],
+      mappings: [[0, 3, 1]],
+      uiMaps: [9000],
+    });
+    const output = await remapUiTree(
+      { nodeIndex: 9000, debugMetadataUrl: META_URL },
+      () => Promise.resolve(internal),
+    );
+
+    expect(output).toMatchObject({
+      repo: 'acme/app',
+      remoteUrl: 'https://git.internal.example/acme/app',
+    });
+  });
+
+  test('reports a missing commit as null rather than an empty string', async () => {
+    const noCommit: DebugMetadataAsset = {
+      artifacts: [],
+      uiSourceMap: {
+        version: 1,
+        sources: ['src/App.tsx'],
+        mappings: [[0, 3, 1]],
+        uiMaps: [9000],
+      },
+      buildInfo: {
+        git: {
+          commit: '',
+          rootDir: null,
+          remoteUrl: 'git@github.com:acme/app.git',
+          commitUrl: null,
+        },
+      },
+    };
+    const output = await remapUiTree(
+      { nodeIndex: 9000, debugMetadataUrl: META_URL },
+      () => Promise.resolve(noCommit),
+    );
+
+    expect(output).toMatchObject({ repo: 'acme/app', commit: null });
   });
 
   test('passes nodes without source mapping through, never loading metadata', async () => {


### PR DESCRIPTION
`createUiSourceMap` pushed `record.filename` into `sources` verbatim, and the main-thread loader passes it `this.resourcePath` — an absolute build-machine path. A UI node resolved through `remapUiTree` came back as

```
/opt/build/src/.../apps/app/src/components/Badge/index.tsx
```

which differs per builder and reaches no file, while `UiSourceLocation.source` has always documented itself as *"Authored source path (relative to the project root)"*.

Relativize against the same `baseDir` the plugin already derives for `rspeedy.entryFiles` (`git.rootDir`, falling back to the compiler context), so a consumer can join a source onto the build's git remote and commit. Paths outside the root keep their `../` distance rather than being dropped.

The added test drives the real chain — `createUiSourceMap` into `remapUiTree` — and asserts the annotated node, so it fails if either end regresses.

**Also fixed:** `repo` normalizes SSH and HTTP git remotes to the same `owner/repo` string, which erases which host — or which internal vs. public mirror of the same path — `source` was resolved against. `UiSourceLocation` / `RemappedUiNode` now also carry `remoteUrl` and `commit`, read from the same `buildInfo.git` `remapUiTree` already reads `repo` from, so a consumer can actually reach the file the build was compiled from.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Debug metadata source maps now use repository-relative paths instead of absolute build-machine paths.
  - Source paths are normalized consistently across platforms, while files outside the repository retain their original handling.
  - Malformed repository URLs no longer expose embedded credentials in debug metadata.

- **New Features**
  - Remapped UI nodes now include available source-control commit and remote repository URL metadata.
  - Missing commit information is represented consistently as unavailable.

- **Tests**
  - Added coverage for nested UI remapping, external files, source-control metadata, and malformed repository URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->