### PR TITLE
fix(rsbuild-plugin): honor output, source map and chunk split options set on an environment

### DIFF
--- a/.changeset/environment-scoped-output.md
+++ b/.changeset/environment-scoped-output.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/rsbuild-plugin": patch
+---
+
+Honor `output.filename.css`, `output.distPath.css`, `output.legalComments`, `output.sourceMap.js` and `dev.assetPrefix` when they are set on an environment. `pluginLynx` used to read them from the root of the config only and silently replaced a per-environment value with its own default.

--- a/.changeset/environment-scoped-split-chunks.md
+++ b/.changeset/environment-scoped-split-chunks.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react-rsbuild-plugin": patch
+---
+
+Honor `splitChunks`, `performance.chunkSplit` and `output.sourceMap` when they are set on an environment. `pluginReactLynx` used to read them from the root of the config only when deciding whether to split chunks and whether to inline sources into source maps.

--- a/packages/rspeedy/plugin-lynx/src/plugins/output.plugin.ts
+++ b/packages/rspeedy/plugin-lynx/src/plugins/output.plugin.ts
@@ -2,24 +2,18 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
-import type { RsbuildPlugin } from '@rsbuild/core'
+import type { RsbuildConfig, RsbuildPlugin } from '@rsbuild/core'
 
 import { getLynxConfig } from '../config.js'
+
+type OutputConfig = NonNullable<RsbuildConfig['output']>
 
 export function pluginOutput(): RsbuildPlugin {
   return {
     name: 'lynx:rsbuild:output',
     setup(api) {
-      api.modifyRsbuildConfig((config, { mergeRsbuildConfig }) => {
-        const original = api.getRsbuildConfig('original')
-        const originalFilename = typeof original.output?.filename === 'object'
-          ? original.output.filename
-          : undefined
-        const originalDistPath = typeof original.output?.distPath === 'object'
-          ? original.output.distPath
-          : undefined
-
-        return mergeRsbuildConfig(
+      api.modifyRsbuildConfig((config, { mergeRsbuildConfig }) =>
+        mergeRsbuildConfig(
           {
             // Default bundler-generated runtime / wrapper code to `var`
             // (QuickJS parses it faster than `const`/`let`); the SWC
@@ -33,24 +27,53 @@ export function pluginOutput(): RsbuildPlugin {
             },
           },
           config,
-          {
+        )
+      )
+
+      api.modifyEnvironmentConfig(
+        (config, { name, mergeEnvironmentConfig }) => {
+          const original = api.getRsbuildConfig('original')
+          // A value set on the environment wins over the same value set at the
+          // root, which is how Rsbuild merges the two.
+          const outputs = [
+            original.environments?.[name]?.output,
+            original.output,
+          ]
+          return mergeEnvironmentConfig(config, {
             output: {
               distPath: {
                 // We override the default value of Rsbuild(`static/css`) here.
                 // Since all the CSS should be encoded into the template in
                 // Lynx.
-                css: originalDistPath?.css
-                  ?? getLynxConfig(api).resolveIntermediateDir(),
+                css: pick(outputs, (output) =>
+                  typeof output.distPath === 'object'
+                    ? output.distPath.css
+                    : undefined) ?? getLynxConfig(api).resolveIntermediateDir(),
               },
               filename: {
-                css: originalFilename?.css ?? '[name]/[name].css',
+                css: pick(outputs, (output) =>
+                  output.filename?.css)
+                  ?? '[name]/[name].css',
               },
               // A Lynx bundle has nowhere to link a separate license file to.
-              legalComments: original.output?.legalComments ?? 'none',
+              legalComments: pick(outputs, (output) =>
+                output.legalComments)
+                ?? 'none',
             },
-          },
-        )
-      })
+          })
+        },
+      )
     },
   }
+}
+
+function pick<T>(
+  outputs: (OutputConfig | undefined)[],
+  get: (output: OutputConfig) => T | undefined,
+): T | undefined {
+  for (const output of outputs) {
+    const value = output === undefined ? undefined : get(output)
+    if (value !== undefined) return value
+  }
+  return undefined
 }

--- a/packages/rspeedy/plugin-lynx/src/plugins/sourcemap.plugin.ts
+++ b/packages/rspeedy/plugin-lynx/src/plugins/sourcemap.plugin.ts
@@ -32,7 +32,8 @@ export function pluginSourcemap(): RsbuildPlugin {
       })
 
       api.modifyBundlerChain((chain, { isDev, environment }) => {
-        const { dev, output, server } = api.getRsbuildConfig('current')
+        const { dev, output } = environment.config
+        const { server } = api.getRsbuildConfig('current')
 
         const publicPath = isDev ? dev?.assetPrefix : output?.assetPrefix
 

--- a/packages/rspeedy/plugin-lynx/test/output.plugin.test.ts
+++ b/packages/rspeedy/plugin-lynx/test/output.plugin.test.ts
@@ -77,4 +77,51 @@ describe('pluginOutput', () => {
 
     expect(config.output?.environment?.const).toBe(true)
   })
+
+  test('honors output.filename.css set on an environment', async () => {
+    const rsbuild = await createStubRsbuild({
+      mode: 'production',
+      environments: {
+        lynx: { output: { filename: { css: 'lynx-[name].css' } } },
+        web: { output: { filename: { css: 'web-[name].css' } } },
+      },
+    })
+    const [lynx, web] = await rsbuild.initConfigs({ action: 'build' })
+    expect(findCssExtractFilename(lynx?.plugins)).toBe('.lynx/lynx-[name].css')
+    expect(findCssExtractFilename(web?.plugins)).toBe('.lynx/web-[name].css')
+  })
+
+  test('prefers output.distPath.css of the environment over the root', async () => {
+    const rsbuild = await createStubRsbuild({
+      mode: 'production',
+      output: { distPath: { css: 'root-css' } },
+      environments: {
+        lynx: { output: { distPath: { css: 'lynx-css' } } },
+        web: {},
+      },
+    })
+    const [lynx, web] = await rsbuild.initConfigs({ action: 'build' })
+    expect(findCssExtractFilename(lynx?.plugins)).toBe(
+      'lynx-css/[name]/[name].css',
+    )
+    expect(findCssExtractFilename(web?.plugins)).toBe(
+      'root-css/[name]/[name].css',
+    )
+  })
+
+  test('honors output.legalComments set on an environment', async () => {
+    const rsbuild = await createStubRsbuild({
+      environments: {
+        lynx: { output: { legalComments: 'inline' } },
+        web: {},
+      },
+    })
+    await rsbuild.initConfigs()
+    expect(
+      rsbuild.getNormalizedConfig({ environment: 'lynx' }).output.legalComments,
+    ).toBe('inline')
+    expect(
+      rsbuild.getNormalizedConfig({ environment: 'web' }).output.legalComments,
+    ).toBe('none')
+  })
 })

--- a/packages/rspeedy/plugin-lynx/test/sourcemap.plugin.test.ts
+++ b/packages/rspeedy/plugin-lynx/test/sourcemap.plugin.test.ts
@@ -710,4 +710,55 @@ describe('pluginSourcemap', () => {
       ).toMatchObject({ css: false })
     })
   })
+
+  describe('environment config', () => {
+    test('honors output.sourceMap.js: false set on an environment', async () => {
+      rstest.stubEnv('NODE_ENV', 'production')
+      const { SourceMapDevToolPlugin } = await import(
+        '../src/webpack/SourceMapDevToolPlugin.js'
+      )
+      const rsbuild = await createStubRsbuild({
+        environments: {
+          lynx: { output: { sourceMap: { js: false } } },
+        },
+      })
+      const config = await rsbuild.unwrapConfig()
+      expect(config.devtool).toBe(false)
+      expect(SourceMapDevToolPlugin).not.toBeCalled()
+    })
+
+    test('prefers output.sourceMap.js of the environment over the root', async () => {
+      rstest.stubEnv('NODE_ENV', 'production')
+      const { SourceMapDevToolPlugin } = await import(
+        '../src/webpack/SourceMapDevToolPlugin.js'
+      )
+      const rsbuild = await createStubRsbuild({
+        output: { sourceMap: { js: false } },
+        environments: {
+          lynx: { output: { sourceMap: { js: 'source-map' } } },
+        },
+      })
+      const config = await rsbuild.unwrapConfig()
+      expect(config.devtool).toBe(false)
+      expect(SourceMapDevToolPlugin).toBeCalledWith(
+        expect.objectContaining({ filename: '[file].map[query]' }),
+      )
+    })
+
+    test('honors dev.assetPrefix set on an environment', async () => {
+      rstest.stubEnv('NODE_ENV', 'development')
+      const { SourceMapDevToolPlugin } = await import(
+        '../src/webpack/SourceMapDevToolPlugin.js'
+      )
+      const rsbuild = await createStubRsbuild({
+        environments: {
+          lynx: { dev: { assetPrefix: 'https://lynx.example.com/' } },
+        },
+      })
+      await rsbuild.unwrapConfig()
+      expect(SourceMapDevToolPlugin).toBeCalledWith(
+        expect.objectContaining({ publicPath: 'https://lynx.example.com/' }),
+      )
+    })
+  })
 })

--- a/packages/rspeedy/plugin-react/src/entry.ts
+++ b/packages/rspeedy/plugin-react/src/entry.ts
@@ -25,6 +25,7 @@ import {
 
 import type { PluginReactLynxOptions } from './pluginReactLynx.js'
 import { resolveLazyBundleFetcher } from './resolveLazyBundleFetcher.js'
+import { getUserSplitChunks } from './splitChunks.js'
 
 const S_LYNX_CONFIG = Symbol.for('@lynx-js/rsbuild-plugin:config')
 
@@ -75,14 +76,15 @@ export function applyEntry(
     const mainThreadChunks: string[] = []
     const entryPairs: Array<{ mainThread: string, background: string }> = []
 
-    const rsbuildConfig = api.getRsbuildConfig()
-    const userConfig = api.getRsbuildConfig('original')
-    const chunkSplitStrategy = userConfig.performance?.chunkSplit?.strategy
-    const enableChunkSplitting = userConfig.splitChunks === undefined
+    const { splitChunks, chunkSplitStrategy } = getUserSplitChunks(
+      api.getRsbuildConfig('original'),
+      environment.name,
+    )
+    const enableChunkSplitting = splitChunks === undefined
       ? (chunkSplitStrategy
         ? chunkSplitStrategy !== 'all-in-one'
-        : rsbuildConfig.splitChunks !== false)
-      : rsbuildConfig.splitChunks !== false
+        : environment.config.splitChunks !== false)
+      : environment.config.splitChunks !== false
     const rspeedyConfig = api.context.callerName === 'rspeedy'
       // biome-ignore lint/correctness/useHookAtTopLevel: This is not a React hook.
       ? api.useExposed<ExposedAPI>(Symbol.for('rspeedy.api'))?.config

--- a/packages/rspeedy/plugin-react/src/loaders.ts
+++ b/packages/rspeedy/plugin-react/src/loaders.ts
@@ -1,7 +1,11 @@
 // Copyright 2024 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
-import type { RsbuildPluginAPI, Rspack } from '@rsbuild/core'
+import type {
+  EnvironmentContext,
+  RsbuildPluginAPI,
+  Rspack,
+} from '@rsbuild/core'
 
 import { LAYERS, ReactWebpackPlugin } from '@lynx-js/react-webpack-plugin'
 
@@ -29,12 +33,10 @@ const MAIN_THREAD_ENV_INCLUDE = [
 const MAIN_THREAD_ENV_TARGETS = { chrome: '120' }
 
 function getLoaderOptions(
-  api: RsbuildPluginAPI,
+  output: EnvironmentContext['config']['output'],
   options: Required<PluginReactLynxOptions>,
   isMainThread = false,
 ) {
-  const { output } = api.getRsbuildConfig()
-
   const inlineSourcesContent: boolean = output?.sourceMap === true || !(
     // `false`
     output?.sourceMap === false
@@ -80,7 +82,7 @@ export function applyTestingLoaders(
   api: RsbuildPluginAPI,
   options: Required<PluginReactLynxOptions>,
 ): void {
-  api.modifyBundlerChain((chain, { CHAIN_ID }) => {
+  api.modifyBundlerChain((chain, { CHAIN_ID, environment }) => {
     const rule = chain.module
       .rule(CHAIN_ID.RULE.JS)
       .oneOf(CHAIN_ID.ONE_OF.JS_MAIN)
@@ -88,7 +90,7 @@ export function applyTestingLoaders(
     rule
       .use(TESTING_RULE_NAME)
       .loader(ReactWebpackPlugin.loaders.TESTING)
-      .options(getLoaderOptions(api, options))
+      .options(getLoaderOptions(environment.config.output, options))
       .end()
   })
 }
@@ -97,7 +99,7 @@ export function applyLoaders(
   api: RsbuildPluginAPI,
   options: Required<PluginReactLynxOptions>,
 ): void {
-  api.modifyBundlerChain((chain, { CHAIN_ID }) => {
+  api.modifyBundlerChain((chain, { CHAIN_ID, environment }) => {
     const rule = chain.module.rule(CHAIN_ID.RULE.JS)
     const jsMainRule = rule.oneOf(CHAIN_ID.ONE_OF.JS_MAIN)
     const type = jsMainRule.get('type') as string | undefined
@@ -120,7 +122,7 @@ export function applyLoaders(
       .end()
       .use(LAYERS.BACKGROUND)
         .loader(ReactWebpackPlugin.loaders.BACKGROUND)
-        .options(getLoaderOptions(api, options))
+        .options(getLoaderOptions(environment.config.output, options))
       .end()
 
     const mainThreadRule = jsMainRule.oneOf(LAYERS.MAIN_THREAD)
@@ -167,7 +169,7 @@ export function applyLoaders(
       })
       .use(LAYERS.MAIN_THREAD)
         .loader(ReactWebpackPlugin.loaders.MAIN_THREAD)
-        .options(getLoaderOptions(api, options, true))
+        .options(getLoaderOptions(environment.config.output, options, true))
       .end()
   })
 }

--- a/packages/rspeedy/plugin-react/src/splitChunks.ts
+++ b/packages/rspeedy/plugin-react/src/splitChunks.ts
@@ -1,7 +1,7 @@
 // Copyright 2024 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
-import type { RsbuildPluginAPI, Rspack } from '@rsbuild/core'
+import type { RsbuildConfig, RsbuildPluginAPI, Rspack } from '@rsbuild/core'
 
 type CacheGroups = Rspack.Configuration extends {
   optimization?: {
@@ -27,18 +27,37 @@ const isPlainObject = (obj: unknown): obj is Record<string, unknown> =>
   && typeof obj === 'object'
   && Object.prototype.toString.call(obj) === '[object Object]'
 
+// A value set on the environment wins over the same value set at the root,
+// which is how Rsbuild merges the two.
+export function getUserSplitChunks(
+  config: RsbuildConfig,
+  environment: string,
+): {
+  splitChunks: RsbuildConfig['splitChunks']
+  chunkSplitStrategy: string | undefined
+} {
+  const scoped = config.environments?.[environment]
+  return {
+    splitChunks: scoped?.splitChunks ?? config.splitChunks,
+    chunkSplitStrategy: scoped?.performance?.chunkSplit?.strategy
+      ?? config.performance?.chunkSplit?.strategy,
+  }
+}
+
 export const applySplitChunksRule: (
   api: RsbuildPluginAPI,
 ) => void = (api): void => {
   // Defaults to `all-in-one`.
-  api.modifyRsbuildConfig((config, { mergeRsbuildConfig }) => {
-    const userConfig = api.getRsbuildConfig('original')
-    const chunkSplitStrategy = userConfig.performance?.chunkSplit?.strategy
+  api.modifyEnvironmentConfig((config, { name, mergeEnvironmentConfig }) => {
+    const { splitChunks, chunkSplitStrategy } = getUserSplitChunks(
+      api.getRsbuildConfig('original'),
+      name,
+    )
     if (
-      userConfig.splitChunks === undefined
+      splitChunks === undefined
       && (chunkSplitStrategy === 'all-in-one' || !chunkSplitStrategy)
     ) {
-      return mergeRsbuildConfig(config, {
+      return mergeEnvironmentConfig(config, {
         splitChunks: false,
       })
     }
@@ -47,9 +66,12 @@ export const applySplitChunksRule: (
 
   api.modifyBundlerChain((chain, { environment }) => {
     const { config } = environment
-    const userConfig = api.getRsbuildConfig('original')
-    const isSplitByExperience = userConfig.splitChunks === undefined
-      ? userConfig.performance?.chunkSplit?.strategy === 'split-by-experience'
+    const { splitChunks, chunkSplitStrategy } = getUserSplitChunks(
+      api.getRsbuildConfig('original'),
+      environment.name,
+    )
+    const isSplitByExperience = splitChunks === undefined
+      ? chunkSplitStrategy === 'split-by-experience'
       : (isPlainObject(config.splitChunks)
         && config.splitChunks.preset === 'default')
 

--- a/packages/rspeedy/plugin-react/test/config.test.ts
+++ b/packages/rspeedy/plugin-react/test/config.test.ts
@@ -1841,6 +1841,31 @@ describe('Config', () => {
 
       expect(backgroundConfig).toHaveProperty('inlineSourcesContent', false)
     })
+
+    test('with output.sourceMap.js: "nosources" set on an environment', async () => {
+      const { pluginReactLynx } = await import('../src/pluginReactLynx.js')
+      const rsbuild = await createRspeedy({
+        rspeedyConfig: {
+          environments: {
+            lynx: {
+              output: {
+                sourceMap: {
+                  js: 'nosources-source-map',
+                },
+              },
+            },
+          },
+          plugins: [
+            pluginReactLynx(),
+            pluginStubRspeedyAPI(),
+          ],
+        },
+      })
+
+      const backgroundConfig = await getBackgroundLayerOptions(rsbuild)
+
+      expect(backgroundConfig).toHaveProperty('inlineSourcesContent', false)
+    })
   })
 
   describe('Output IIFE', () => {
@@ -2049,6 +2074,67 @@ describe('Config', () => {
       expect(config.optimization.splitChunks.cacheGroups).toHaveProperty(
         'preact',
       )
+    })
+
+    test('splitChunks.preset: "default" set on an environment', async () => {
+      const { pluginReactLynx } = await import('../src/pluginReactLynx.js')
+      const rsbuild = await createRspeedy({
+        rspeedyConfig: {
+          environments: {
+            lynx: {
+              splitChunks: {
+                preset: 'default',
+              },
+            },
+          },
+          plugins: [
+            pluginReactLynx(),
+            pluginStubRspeedyAPI(),
+          ],
+        },
+      })
+
+      const [config] = await rsbuild.initConfigs()
+
+      if (config?.optimization?.splitChunks === undefined) {
+        expect.fail('should have config.optimization.splitChunks')
+      }
+      expect(config.optimization.splitChunks).not.toBe(false)
+      if (config.optimization.splitChunks === false) {
+        expect.unreachable('splitChunks is not false')
+      }
+      expect(config.optimization.splitChunks.cacheGroups).toHaveProperty(
+        'preact',
+      )
+    })
+
+    test('performance.chunkSplit.strategy set on an environment overrides the root', async () => {
+      const { pluginReactLynx } = await import('../src/pluginReactLynx.js')
+      const rsbuild = await createRspeedy({
+        rspeedyConfig: {
+          performance: {
+            chunkSplit: {
+              strategy: 'split-by-experience',
+            },
+          },
+          environments: {
+            lynx: {
+              performance: {
+                chunkSplit: {
+                  strategy: 'all-in-one',
+                },
+              },
+            },
+          },
+          plugins: [
+            pluginReactLynx(),
+            pluginStubRspeedyAPI(),
+          ],
+        },
+      })
+
+      const [config] = await rsbuild.initConfigs()
+      expect(config?.optimization?.splitChunks).toBe(false)
     })
 
     test('splitChunks overrides performance.chunkSplit', async () => {


### PR DESCRIPTION
Closes #3723.

`pluginOutput` read `output.filename.css`, `output.distPath.css` and `output.legalComments` from the root of the config only, so a value set on an environment was silently replaced by the plugin default. The same root-only lookup existed in `pluginSourcemap` (`output.sourceMap.js`, `dev.assetPrefix` for the source map public path) and in `pluginReactLynx` (`splitChunks` / `performance.chunkSplit` when deciding whether to split chunks, `output.sourceMap` for `inlineSourcesContent`).

All of them now resolve the value per environment: the plugins that decide inside `modifyBundlerChain` read `environment.config`, and the ones that need to know what the user set read the environment entry of the original config before the root one, which is the precedence Rsbuild itself applies when merging.

Tests cover each field set on an environment, and the environment value winning over the root one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Environment-specific settings now take precedence for output filenames, distribution paths, legal comments, source maps, asset prefixes, and chunk splitting.
  - CSS and JavaScript build behavior can be customized independently for each environment.
  - Environment-level chunk-splitting strategies and presets are now honored consistently.

- **Bug Fixes**
  - Corrected handling of environment-specific source map and output configurations that were previously overridden by root settings.

- **Tests**
  - Added coverage for environment-specific output, source map, asset prefix, and chunk-splitting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->