### PR TITLE
fix(lynx-bundle-rslib-config): route an external bundle's intermediate files into .lynx/<id>

### DIFF
--- a/.changeset/external-bundle-intermediate-dir.md
+++ b/.changeset/external-bundle-intermediate-dir.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/lynx-bundle-rslib-config": patch
+---
+
+Route the raw per-thread chunks and debug intermediates of an external bundle into `.lynx/<id>/`, the way a page build's are routed into `.lynx/<entry>/`, instead of the flat `[name].js` default. A `development` build (or `DEBUG` set) used to leave them next to the bundle at the root of `dist`.

--- a/packages/rspeedy/lynx-bundle-rslib-config/src/externalBundleRslibConfig.ts
+++ b/packages/rspeedy/lynx-bundle-rslib-config/src/externalBundleRslibConfig.ts
@@ -2,9 +2,12 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
+import path from 'node:path'
+
 import { rsbuild } from '@rslib/core'
 import type { LibConfig, RslibConfig, Rspack } from '@rslib/core'
 
+import type { LynxConfig } from '@lynx-js/rsbuild-plugin'
 import type {
   CustomSectionNaming,
   LynxTemplatePlugin as LynxTemplatePluginClass,
@@ -682,6 +685,22 @@ const externalBundleRsbuildPlugin = ({
 
     const { LynxTemplatePlugin } = exposed
 
+    const lynxConfig = api.useExposed<LynxConfig>(
+      Symbol.for('@lynx-js/rsbuild-plugin:config'),
+    )
+
+    if (!lynxConfig) {
+      throw new Error(
+        'lynx-bundle-rslib-config requires an exposed Lynx config. Please apply `pluginLynx` from `@lynx-js/rsbuild-plugin`, which a DSL plugin such as `pluginReactLynx` does for you.',
+      )
+    }
+
+    // The raw per-thread chunks are only ingredients for the encoded bundle,
+    // the way a page's are — keep them out of `dist` alongside it.
+    const intermediateDir = lynxConfig.resolveIntermediateDir({
+      entryName: bundleName,
+    })
+
     api.modifyBundlerChain(
       async (chain, { CHAIN_ID }) => {
         // Mark the react loaders as building an external bundle.
@@ -716,7 +735,10 @@ const externalBundleRsbuildPlugin = ({
         ) => {
           chain
             .entry(entryName)
-            .add(entryValue)
+            .add({
+              ...entryValue,
+              filename: path.posix.join(intermediateDir, `${entryName}.js`),
+            })
             .end()
         }
 
@@ -799,6 +821,7 @@ const externalBundleRsbuildPlugin = ({
           .use(LynxTemplatePlugin, [{
             ...LynxTemplatePlugin.defaultOptions,
             filename: `${bundleName}.${isWeb ? 'web' : 'lynx'}.bundle`,
+            intermediate: intermediateDir,
             chunks: [...mainThreadEntryName, ...backgroundEntryName],
             customSectionNaming: sectionNaming,
             appType: 'DynamicComponent',

--- a/packages/rspeedy/lynx-bundle-rslib-config/test/external-bundle.test.ts
+++ b/packages/rspeedy/lynx-bundle-rslib-config/test/external-bundle.test.ts
@@ -522,10 +522,10 @@ describe('JsBytecode encoding', () => {
 
     expect(marked).toStrictEqual({
       'shared-mt.js': true,
-      'utils__main-thread.js': true,
-      'helpers__main-thread.js': true,
-      'utils.js': false,
-      'helpers.js': false,
+      '.lynx/utils-shared-mt/utils__main-thread.js': true,
+      '.lynx/utils-shared-mt/helpers__main-thread.js': true,
+      '.lynx/utils-shared-mt/utils.js': false,
+      '.lynx/utils-shared-mt/helpers.js': false,
     })
   })
 
@@ -616,7 +616,7 @@ describe('debug mode artifacts', () => {
   // The template intermediates go into the `.lynx` directory, the same way an
   // application build emits them.
   const getFiles = () => {
-    const intermediate = path.join(distRoot, '.lynx')
+    const intermediate = path.join(distRoot, '.lynx', bundleId)
     return fs.existsSync(intermediate) ? fs.readdirSync(intermediate) : []
   }
 
@@ -1219,13 +1219,25 @@ describe('debug metadata', () => {
     }
 
     expect(
-      fs.existsSync(path.join(distRoot, '.lynx', 'debug-metadata.json')),
+      fs.existsSync(
+        path.join(
+          distRoot,
+          '.lynx',
+          'utils-debug-metadata',
+          'debug-metadata.json',
+        ),
+      ),
     ).toBe(true)
 
     // The release banner has to sit inside the module wrapper, which is what
     // `lynx.loadScript` takes the section's value from.
     const mainThread = await fs.promises.readFile(
-      path.join(distRoot, 'utils__main-thread.js'),
+      path.join(
+        distRoot,
+        '.lynx',
+        'utils-debug-metadata',
+        'utils__main-thread.js',
+      ),
       'utf-8',
     )
     expect(mainThread).toMatch(/^\(function\s*\(\)\s*\{/)
@@ -1273,7 +1285,10 @@ describe('debug info outside', () => {
         plugins: [pluginReactLynx()],
       }))
       const tasmJson = JSON.parse(
-        fs.readFileSync(path.join(distRoot, '.lynx', 'tasm.json'), 'utf-8'),
+        fs.readFileSync(
+          path.join(distRoot, '.lynx', 'utils-dbg-outside', 'tasm.json'),
+          'utf-8',
+        ),
       ) as {
         compilerOptions: Record<string, unknown>
         sourceContent: Record<string, unknown>
@@ -1286,5 +1301,47 @@ describe('debug info outside', () => {
     } finally {
       rstest.unstubAllEnvs()
     }
+  })
+})
+
+describe('intermediate directory', () => {
+  const fixtureDir = path.join(__dirname, './fixtures/utils-lib')
+
+  // A `development` build (`DEBUG` unset — `lynxRstestConfig` otherwise sets
+  // `DEBUG=rspeedy`) is the case that used to leak: `LynxEncodePlugin` skips
+  // its own cleanup for `NODE_ENV=development`, so the raw entry chunks stay
+  // on disk. Their directory is what this test checks.
+  it('keeps the raw entry chunks out of dist root, the way a page build does', async () => {
+    const debug = process.env['DEBUG']
+    const nodeEnv = process.env['NODE_ENV']
+    delete process.env['DEBUG']
+    process.env['NODE_ENV'] = 'development'
+    const distRoot = path.join(fixtureDir, 'dist', 'utils-intermediate-dir')
+    try {
+      await build(defineExternalBundleRslibConfig({
+        source: { entry: { utils: path.join(fixtureDir, 'index.ts') } },
+        id: 'utils-intermediate-dir',
+        output: { distPath: { root: distRoot } },
+        plugins: [pluginReactLynx()],
+      }))
+    } finally {
+      if (debug === undefined) delete process.env['DEBUG']
+      else process.env['DEBUG'] = debug
+      if (nodeEnv === undefined) delete process.env['NODE_ENV']
+      else process.env['NODE_ENV'] = nodeEnv
+    }
+
+    const rootEntries = await fs.promises.readdir(distRoot)
+    expect(rootEntries.sort()).toStrictEqual([
+      '.lynx',
+      'utils-intermediate-dir.lynx.bundle',
+    ])
+    expect(
+      await fs.promises.readdir(
+        path.join(distRoot, '.lynx', 'utils-intermediate-dir'),
+      ),
+    ).toStrictEqual(
+      expect.arrayContaining(['utils.js', 'utils__main-thread.js']),
+    )
   })
 })


### PR DESCRIPTION
## Summary

An external bundle's raw per-thread entry chunks (`<entry>.js`, `<entry>__main-thread.js`) and debug intermediates (`tasm.json`, `debug-metadata.json`) were emitted at the flat `[name].js` default and the flat `.lynx/` root, never routed through `LynxConfig.resolveIntermediateDir()` the way a page build's own are (`packages/rspeedy/plugin-react/src/entry.ts`). A `development` build (or `DEBUG` set) leaves these on disk next to the delivered bundle, so they landed loose at the root of `dist` instead of tucked under `.lynx/<entry>/` like a page build's.

`externalBundleRslibConfig.ts` now resolves the same intermediate directory (keyed by the bundle `id`) and passes it to both the entry `filename`s and `LynxTemplatePlugin`'s `intermediate` option:

```
dist/demo.lynx.bundle                 # unchanged: the deliverable
dist/.lynx/demo/a.js                  # was dist/a.js
dist/.lynx/demo/a__main-thread.js     # was dist/a__main-thread.js
dist/.lynx/demo/tasm.json             # was dist/.lynx/tasm.json
```

The encoded bundle is unaffected: section names come from the chunk's logical name, not its output path, verified by decoding a built example.

This does not change whether a `development` build cleans up these files — that already matches a page build's own behavior (also keeps them, for the dev server to serve) and is out of scope here.

## Test

- `lynx-bundle-rslib-config`: a new test asserts `dist` only holds `.lynx` and the bundle for a `development` build, with the raw chunks inside `.lynx/<id>/`; four existing tests updated to the new paths.
- Decoded `examples/react-externals`'s external bundle after a `development` build: sections (`./App.js`, `./App.js__main-thread`, `./App.js:CSS`) are unchanged, only the intermediates' location moved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * External bundle intermediate files are now kept in per-bundle `.lynx/<id>/` directories instead of appearing at the root of `dist`.
  * Development and debug builds no longer expose raw thread chunks alongside final bundle files.
  * Template intermediates and metadata now use a consistent per-bundle output location.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->