### PR TITLE
test(vanilla-rsbuild-plugin): assert the emitted background chunk carries the runtime wrapper

### DIFF
--- a/packages/rspeedy/plugin-vanilla/test/pluginVanillaLynx.test.ts
+++ b/packages/rspeedy/plugin-vanilla/test/pluginVanillaLynx.test.ts
@@ -89,6 +89,46 @@ function fixturePath(name: string): string {
   return fileURLToPath(new URL(`./fixtures/basic/${name}`, import.meta.url))
 }
 
+type TemplateEncodeArgs = Parameters<
+  Parameters<vanilla.TemplateHooks['beforeEncode']['tap']>[1]
+>[0]
+
+// Taps the template hook the encoders run on, which is the only place the
+// final source of every emitted chunk is visible at once.
+function observeTemplateEncodeData(): {
+  getEncodeData: () => TemplateEncodeArgs['encodeData'] | undefined
+  observeTemplate: RsbuildPlugin
+} {
+  let captured: TemplateEncodeArgs | undefined
+  const name = 'test:observe-vanilla-encode-data'
+
+  const observeTemplate: RsbuildPlugin = {
+    name,
+    setup(api) {
+      api.modifyBundlerChain(chain => {
+        const exposed = api.useExposed<{
+          LynxTemplatePlugin: vanilla.LynxTemplatePlugin
+        }>(Symbol.for('LynxTemplatePlugin'))
+        const plugin: Rspack.RspackPluginInstance = {
+          apply(compiler) {
+            compiler.hooks.thisCompilation.tap(name, compilation => {
+              const hooks = exposed!.LynxTemplatePlugin
+                .getLynxTemplatePluginHooks(compilation)
+              hooks.beforeEncode.tap(name, args => {
+                captured = args
+                return args
+              })
+            })
+          },
+        }
+        chain.plugin(name).use(plugin)
+      })
+    },
+  }
+
+  return { getEncodeData: () => captured?.encodeData, observeTemplate }
+}
+
 async function runPluginHarness(
   options: HarnessOptions = {},
 ): Promise<HarnessResult> {
@@ -633,5 +673,55 @@ describe('pluginVanillaLynx runtime wrapper', () => {
     expect((wrapper?.args?.[0] as { test: unknown }).test).toEqual([
       backgroundEntry.filename,
     ])
+  })
+
+  // The `test` above only states which asset the wrapper is aimed at. A path
+  // that stops matching what the build emits leaves the background chunk bare,
+  // and Lynx then evaluates it without `lynx` in scope: the card dies with
+  // `ReferenceError: lynx is not defined` on the device while every unit test
+  // still passes. Assert the emitted source itself.
+  test('emits a background chunk the Lynx runtime can evaluate', async () => {
+    const outputRoot = await mkdtemp(
+      path.join(tmpdir(), 'rspeedy-vanilla-wrapper-test-'),
+    )
+    tempDirs.push(outputRoot)
+
+    const { getEncodeData, observeTemplate } = observeTemplateEncodeData()
+
+    const rspeedy = await createRspeedy({
+      rspeedyConfig: {
+        output: {
+          distPath: { root: outputRoot },
+          filename: '[name].bundle',
+        },
+        plugins: [
+          vanilla.pluginVanillaLynx({
+            entries: {
+              card: {
+                mainThread: fixturePath('main-thread.ts'),
+              },
+            },
+          }),
+          observeTemplate,
+        ],
+      },
+    })
+
+    await rspeedy.build()
+
+    const manifest = getEncodeData()?.manifest ?? {}
+    const background = manifest['/.lynx/card/background.js']
+
+    expect(background).toBeTypeOf('string')
+    // `bundleSupportLoadScript` and `__bundle__holder` are the globals the
+    // wrapper talks to, so they survive minification and say the banner is
+    // really there.
+    expect(background).toContain('bundleSupportLoadScript')
+    expect(background).toContain('__bundle__holder')
+
+    // The main thread runs outside that runtime and must stay unwrapped.
+    expect(
+      getEncodeData()?.lepusCode.root?.source.source().toString(),
+    ).not.toContain('__bundle__holder')
   })
 })


### PR DESCRIPTION
The vanilla example crashes on a device with `ReferenceError: lynx is not defined` whenever the background chunk ships without the runtime wrapper, because Lynx then evaluates it outside the runtime that provides `lynx`. That is what #3745 fixed, and nothing in CI would have caught it: the tests assert the `test` option the wrapper is configured with, never the source that is emitted.

Add a build-level test that runs a real `rspeedy.build()`, reads the background chunk out of the template manifest, and asserts it carries the wrapper globals `bundleSupportLoadScript` and `__bundle__holder`. It also asserts the main-thread chunk stays unwrapped, since that one runs outside the same runtime.

Verified the test fails for the exact regression it targets: restoring the pre-#3745 `test: /^\.rspeedy\/.+\/background\.js$/` makes it fail with `expected '…' to contain 'bundleSupportLoadScript'`.

No production code changes. Current `main` builds and runs the vanilla example correctly, which I checked on a Pixel 5 running Lynx Explorer for both the production bundle and the dev server, and in the web preview.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration coverage to verify that background output includes the required runtime wrappers while main-thread output remains unchanged.
  * Added reusable test support for observing encoded template data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->