### PR TITLE
chore(deps): update @lynx-js/type-config to 4.2.0

### DIFF
--- a/.changeset/type-config-4-2-0.md
+++ b/.changeset/type-config-4-2-0.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/config-rsbuild-plugin": patch
+---
+
+Updated dependency `@lynx-js/type-config` to `4.2.0`.

--- a/packages/rspeedy/plugin-config/package.json
+++ b/packages/rspeedy/plugin-config/package.json
@@ -38,7 +38,7 @@
     "test:type": "tsc6 --noEmit"
   },
   "dependencies": {
-    "@lynx-js/type-config": "4.1.3"
+    "@lynx-js/type-config": "4.2.0"
   },
   "devDependencies": {
     "@lynx-js/rspeedy": "workspace:*",

--- a/packages/rspeedy/plugin-config/test/config.test-d.ts
+++ b/packages/rspeedy/plugin-config/test/config.test-d.ts
@@ -29,10 +29,10 @@ describe('config length', () => {
   })
   it('type config config should have expected length', () => {
     expectTypeOf<UnionToTuple<keyof TypeConfig.Config>['length']>()
-      .toEqualTypeOf<33>()
+      .toEqualTypeOf<36>()
   })
   it('pluginLynxConfig config should have expected length', () => {
     expectTypeOf<UnionToTuple<keyof Config>['length']>()
-      .toEqualTypeOf<33>()
+      .toEqualTypeOf<36>()
   })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1702,8 +1702,8 @@ importers:
   packages/rspeedy/plugin-config:
     dependencies:
       '@lynx-js/type-config':
-        specifier: 4.1.3
-        version: 4.1.3
+        specifier: 4.2.0
+        version: 4.2.0
     devDependencies:
       '@lynx-js/rspeedy':
         specifier: workspace:*
@@ -4584,8 +4584,8 @@ packages:
     resolution: {integrity: sha512-Zyl74cKi+BDggeXroLQG4frbBuiQ0DB0yH0C3pMkUHWv17abWTdJ2mw/H9Cd1QiIr+aQHn1U2SRtsrbkmWMtJw==}
     engines: {node: '>=18'}
 
-  '@lynx-js/type-config@4.1.3':
-    resolution: {integrity: sha512-r5YZFwXMQ9DY7du7idsTocRfzAff86ktKLwZ6k/i6kmF0dCCo7+5/d/FvmPtcg3PDuXV5vUSmAd8GnJrbdA/1w==}
+  '@lynx-js/type-config@4.2.0':
+    resolution: {integrity: sha512-Nbgd/HdQeDLQhWDC7VYq12NgciRChN5alhEyLX8VxXdVHUZEq5sUVJ3IbyKR0muPtaOEQMtXhTpPoGn+oXsLKA==}
 
   '@lynx-js/type-element-api@0.0.9':
     resolution: {integrity: sha512-CXTLnUPYwGlkJVPKx7wYafY1AyOp4TlAfZtTPWLeAW48lUDKBdcN0/uAVULogK/P+E1OwBZ8kDaw1/iMh9WQbw==}
@@ -14661,7 +14661,7 @@ snapshots:
     dependencies:
       immer: 10.2.0
 
-  '@lynx-js/type-config@4.1.3': {}
+  '@lynx-js/type-config@4.2.0': {}
 
   '@lynx-js/type-element-api@0.0.9': {}
 


### PR DESCRIPTION
## Summary
- Bump `@lynx-js/type-config` in `packages/rspeedy/plugin-config` from `4.1.3` to `4.2.0`, purely additive per the 4.2.0 changelog (new `Config` entries for LynxSDK 4.2, no removals).
- Update the golden key-count literals in `config.test-d.ts` to match.

## Test plan
- [x] `pnpm --filter @lynx-js/config-rsbuild-plugin test:type`
- [x] `pnpm --filter @lynx-js/config-rsbuild-plugin test`
- [x] `pnpm --filter @lynx-js/config-rsbuild-plugin api-extractor` (no `.api.md` diff)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Updated configuration compatibility to align with the latest type configuration release.
  * Added support for three additional configuration options.

* **Tests**
  * Updated configuration validation to cover the expanded set of available options.

* **Chores**
  * Recorded the package update for the next patch release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->