### PR TITLE
fix(react): declare @rstest/core dependency

### DIFF
--- a/packages/react/testing-library/package.json
+++ b/packages/react/testing-library/package.json
@@ -20,6 +20,7 @@
     "@lynx-js/testing-environment": "workspace:*",
     "@rsbuild/core": "catalog:rsbuild",
     "@rstest/adapter-rsbuild": "catalog:rstest",
+    "@rstest/core": "catalog:rstest",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^7.0.0",
     "preact": "catalog:lynxjs"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1438,6 +1438,9 @@ importers:
       '@rstest/adapter-rsbuild':
         specifier: catalog:rstest
         version: 0.11.6(@rsbuild/core@2.1.10(core-js@3.50.0))(@rstest/core@0.11.6(core-js@3.50.0)(jsdom@27.4.0(supports-color@10.2.2)))
+      '@rstest/core':
+        specifier: catalog:rstest
+        version: 0.11.6(core-js@3.50.0)(jsdom@27.4.0(supports-color@10.2.2))
       '@testing-library/dom':
         specifier: ^10.4.1
         version: 10.4.1


### PR DESCRIPTION
## Summary

`@lynx-js/reactlynx-testing-library` imports `ExtendConfig` and `ExtendConfigFn` directly from `@rstest/core`, but only declared `@rstest/adapter-rsbuild` as a dependency. As a result, `@rstest/core` could resolve from an ancestor workspace and differ from the version used by the adapter. Comparing the two recursive `ExtendConfig` types can then fail with `TS2321: Excessive stack depth comparing types`.

Declare `@rstest/core` as a direct development dependency through the existing `rstest` catalog so the package and adapter resolve the same Rstest type definitions.

No changeset is needed because `@lynx-js/reactlynx-testing-library` is private.

## Test

- `pnpm install --frozen-lockfile`
- `pnpm dprint check packages/react/testing-library/package.json pnpm-lock.yaml`
- `pnpm turbo build` (73/73 tasks passed)
- `pnpm --filter @lynx-js/reactlynx-testing-library test` (29 test files, 167 tests passed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added the Rstest testing tool as a development dependency for the testing-library package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->