### PR TITLE
perf(react): skip ET attribute diff before materialization

### DIFF
--- a/packages/react/runtime/__test__/element-template/runtime/background/instance.test.ts
+++ b/packages/react/runtime/__test__/element-template/runtime/background/instance.test.ts
@@ -2024,6 +2024,43 @@ describe('BackgroundElementTemplateInstance Shadow State', () => {
     expect(instance.attributeSlots).toEqual(slots);
   });
 
+  it.each([false, true])('does not serialize attributes before materialization (hydrated=%s)', (isHydrated) => {
+    const instance = new BackgroundElementTemplateInstance('view', [{ id: 'before' }]);
+    if (isHydrated) {
+      markElementTemplateHydrated();
+    }
+    const nextSlots = [{ id: 'after' }];
+    const stringify = vi.spyOn(JSON, 'stringify');
+    try {
+      instance.setAttribute('attributeSlots', nextSlots);
+
+      expect(stringify).not.toHaveBeenCalled();
+    } finally {
+      stringify.mockRestore();
+    }
+    expect(instance.attributeSlots).toEqual(nextSlots);
+    expect(globalCommitContext.ops).toEqual([]);
+
+    const root = new BackgroundPageRootInstance();
+    markElementTemplateHydrated();
+    root.appendChild(instance);
+
+    expect(globalCommitContext.ops).toEqual([
+      ElementTemplateUpdateOps.createTemplate,
+      instance.instanceId,
+      'view',
+      null,
+      nextSlots,
+      [],
+      ElementTemplateUpdateOps.insertNode,
+      root.instanceId,
+      0,
+      instance.instanceId,
+      0,
+      null,
+    ]);
+  });
+
   it('keeps raw initial planned attribute slots for later native prepare', () => {
     __etAttrPlanMap.view = [0, adaptEventAttrSlot];
     const instance = new BackgroundElementTemplateInstance('view', [true]);

--- a/packages/react/runtime/src/element-template/background/instance.ts
+++ b/packages/react/runtime/src/element-template/background/instance.ts
@@ -491,15 +491,15 @@ export class BackgroundElementTemplateInstance {
         );
       }
       this.rawAttributeSlots = nextSlots === value ? undefined : value;
-      const maxLength = Math.max(previousSlots.length, nextSlots.length);
       this.attributeSlots = nextSlots;
+      if (!canEmitUpdatePatch) {
+        return;
+      }
+      const maxLength = Math.max(previousSlots.length, nextSlots.length);
       for (let slotIndex = 0; slotIndex < maxLength; slotIndex += 1) {
         const previousValue = previousSlots[slotIndex];
         const nextValue = nextSlots[slotIndex];
         if (isDirectOrDeepEqual(previousValue, nextValue)) {
-          continue;
-        }
-        if (!canEmitUpdatePatch) {
           continue;
         }
         pushOp(


### PR DESCRIPTION
Attribute slot updates compare previous and next values even when hydration has not completed or the instance has not been materialized. Object-valued slots can be serialized just to discard the comparison result.

Return after preparing attributes, queuing eligible ref effects, and saving the latest shadow state when no update patch can be emitted. Later creation still uses the latest values, and materialized instances keep the existing attribute diff behavior.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
