### PR TITLE
perf(react): prune ET create checks for materialized subtrees

### DIFF
--- a/packages/react/runtime/__test__/element-template/runtime/background/instance.test.ts
+++ b/packages/react/runtime/__test__/element-template/runtime/background/instance.test.ts
@@ -883,6 +883,123 @@ describe('BackgroundElementTemplateInstance', () => {
       expect(ref).not.toHaveBeenCalled();
     });
 
+    it.each(['compiled', 'list'])('checks only the moved subtree root for creation under a %s parent', (parentKind) => {
+      __etAttrPlanMap._et_leaf = [0, adaptMTRefAttrSlot];
+      const root = new BackgroundPageRootInstance();
+      const parent = parentKind === 'list'
+        ? new BackgroundListElementTemplateInstance()
+        : new BackgroundElementTemplateInstance('_et_parent');
+      const anchor = new BackgroundElementTemplateInstance('_et_anchor');
+      const owner = new BackgroundElementTemplateInstance('_et_owner');
+      const nested = new BackgroundElementTemplateInstance('_et_nested');
+      const leaf = new BackgroundElementTemplateInstance('_et_leaf');
+      nested.appendChild(leaf);
+      owner.appendChild(nested);
+      markElementTemplateHydrated();
+      root.appendChild(parent);
+      parent.appendChild(anchor);
+      parent.appendChild(owner);
+      globalCommitContext.ops = [];
+
+      const createCheck = vi.spyOn(BackgroundElementTemplateInstance.prototype, 'emitMainThreadCreateIfNeeded');
+      try {
+        parent.insertBefore(owner, anchor);
+
+        expect(createCheck).toHaveBeenCalledTimes(1);
+      } finally {
+        createCheck.mockRestore();
+      }
+      expect(parent.childNodes).toEqual([owner, anchor]);
+      expect(owner.firstChild).toBe(nested);
+      expect(nested.firstChild).toBe(leaf);
+      expect(globalCommitContext.ops).toEqual(
+        parentKind === 'list'
+          ? [
+            ElementTemplateUpdateOps.removeTypedListItem,
+            parent.instanceId,
+            owner.instanceId,
+            [],
+            ElementTemplateUpdateOps.insertTypedListItem,
+            parent.instanceId,
+            {
+              __etHandleRef: owner.instanceId,
+              type: '_et_owner',
+              platformInfo: {},
+              subtreeHandleIds: [leaf.instanceId],
+            },
+            anchor.instanceId,
+          ]
+          : [
+            ElementTemplateUpdateOps.insertNode,
+            parent.instanceId,
+            0,
+            owner.instanceId,
+            anchor.instanceId,
+            [leaf.instanceId],
+          ],
+      );
+    });
+
+    it('creates new descendants once when moving their materialized owner', () => {
+      const ref = vi.fn();
+      __etAttrPlanMap._et_ref_leaf = [0, adaptRefAttrSlot];
+      const root = new BackgroundPageRootInstance();
+      const parent = new BackgroundElementTemplateInstance('_et_parent');
+      const anchor = new BackgroundElementTemplateInstance('_et_anchor');
+      const owner = new BackgroundElementTemplateInstance('_et_owner');
+      markElementTemplateHydrated();
+      root.appendChild(parent);
+      parent.appendChild(anchor);
+      parent.appendChild(owner);
+      globalCommitContext.ops = [];
+
+      const nested = new BackgroundElementTemplateInstance('_et_nested');
+      const leaf = new BackgroundElementTemplateInstance('_et_ref_leaf');
+      leaf.setAttribute('attributeSlots', [ref]);
+      nested.appendChild(leaf);
+      flushPendingRefs();
+      expect(ref).not.toHaveBeenCalled();
+      expect(globalCommitContext.ops).toEqual([]);
+
+      owner.appendChild(nested);
+      parent.insertBefore(owner, anchor);
+      flushPendingRefs();
+
+      expect(globalCommitContext.ops).toEqual([
+        ElementTemplateUpdateOps.createTemplate,
+        leaf.instanceId,
+        '_et_ref_leaf',
+        null,
+        [`${leaf.instanceId}-0`],
+        [],
+        ElementTemplateUpdateOps.createTemplate,
+        nested.instanceId,
+        '_et_nested',
+        null,
+        [],
+        [[leaf.instanceId]],
+        ElementTemplateUpdateOps.insertNode,
+        owner.instanceId,
+        0,
+        nested.instanceId,
+        0,
+        null,
+        ElementTemplateUpdateOps.insertNode,
+        parent.instanceId,
+        0,
+        owner.instanceId,
+        anchor.instanceId,
+        null,
+      ]);
+      expect(ref).toHaveBeenCalledTimes(1);
+      expect(ref).toHaveBeenCalledWith(expect.objectContaining({
+        selector: `[ref=${leaf.instanceId}-0]`,
+      }));
+      expect(parent.childNodes).toEqual([owner, anchor]);
+      expect(owner.firstChild).toBe(nested);
+      expect(nested.firstChild).toBe(leaf);
+    });
+
     it('defers nested slot inserts until the owner template is created', () => {
       const parent = new BackgroundElementTemplateInstance('view');
       parent.emitCreate();

--- a/packages/react/runtime/src/element-template/background/instance.ts
+++ b/packages/react/runtime/src/element-template/background/instance.ts
@@ -207,6 +207,13 @@ export class BackgroundElementTemplateInstance {
     if (!this.needsMainThreadCreate()) {
       return;
     }
+    // New descendants materialize at their own insert boundary, and lifetime
+    // removal clears this flag recursively before a subtree is reattached.
+    let child = this.firstChild;
+    while (child) {
+      child.emitMainThreadCreateIfNeeded();
+      child = child.nextSibling;
+    }
     // An unmaterialized subtree may receive attr updates before it is inserted;
     // prepare here so its materializing insert attaches the latest ref value.
     this.prepareAttributeSlotsForNative();
@@ -301,7 +308,7 @@ export class BackgroundElementTemplateInstance {
     const beforeId = (beforeChild && beforeChild.__slotIndex === child.__slotIndex) ? beforeChild.instanceId : 0;
     const containingListItem = getContainingListItem(child);
     const movedMainThreadRefHandleIds = collectMainThreadRefSubtreeHandleIds(child);
-    emitMainThreadCreateRecursive(child);
+    child.emitMainThreadCreateIfNeeded();
     pushOp(
       ElementTemplateUpdateOps.insertNode,
       this.instanceId,
@@ -718,7 +725,7 @@ export class BackgroundListElementTemplateInstance extends BackgroundTypedElemen
       return;
     }
 
-    emitMainThreadCreateRecursive(child);
+    child.emitMainThreadCreateIfNeeded();
     pushOp(
       ElementTemplateUpdateOps.insertTypedListItem,
       this.instanceId,
@@ -809,22 +816,4 @@ function collectElementTemplateSubtreeHandleIdsImpl(
     collectElementTemplateSubtreeHandleIdsImpl(child, handles);
     child = child.nextSibling;
   }
-}
-
-function emitMainThreadCreateRecursive(instance: BackgroundElementTemplateInstance): void {
-  if (
-    !isElementTemplateHydrated()
-    || instance.instanceId === ELEMENT_TEMPLATE_PAGE_HANDLE_ID
-  ) {
-    return;
-  }
-
-  // Walk children in linked-list order; the slot-grouped view would just be
-  // discarded here since we recurse into every child regardless of slot.
-  let child = instance.firstChild;
-  while (child) {
-    emitMainThreadCreateRecursive(child);
-    child = child.nextSibling;
-  }
-  instance.emitMainThreadCreateIfNeeded();
 }


### PR DESCRIPTION
Moving an existing Element Template subtree recursively checks every descendant for creation even though its handles already exist. Each node only exits after the traversal reaches its individual create check.

Check whether the subtree root needs creation before descending. Newly inserted descendants are created at their own insertion boundary, while lifetime removal clears materialization throughout the subtree so reattachment still recreates children before parents. This removes one redundant traversal from moves; MTRef subtree collection, move payloads, and ref lifecycle ordering remain intact.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
