### PR TITLE
fix(debug-metadata): file each main thread chunk's debug info under its own artifact

### DIFF
--- a/.changeset/custom-section-tasm-location.md
+++ b/.changeset/custom-section-tasm-location.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/template-webpack-plugin": patch
+---
+
+Record a custom section's real location on the asset it was assembled from. An asset that moved into `customSections` kept the `lepusCode` or `manifest` location it was stamped with before the split, so consumers reading `lynx:tasm-section` were pointed at a section the bundle does not carry.

--- a/.changeset/section-keyed-debug-info.md
+++ b/.changeset/section-keyed-debug-info.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/debug-metadata-rsbuild-plugin": patch
+---
+
+File each main thread chunk's bytecode debug info under the artifact it was compiled from. A bundle whose main thread code lives in `JsBytecode` custom sections had every unit the encoder produced piled onto its first main thread artifact, keyed by section name, while the other entries got none.

--- a/packages/rspeedy/plugin-debug-metadata/src/LynxDebugMetadataPlugin.ts
+++ b/packages/rspeedy/plugin-debug-metadata/src/LynxDebugMetadataPlugin.ts
@@ -16,7 +16,10 @@ import type {
 } from '@lynx-js/template-webpack-plugin'
 
 import { collectArtifacts } from './collectors/artifacts.js'
-import { parseLepusNGDebugInfo } from './collectors/bytecode-debug-info.js'
+import {
+  parseDebugInfoUnits,
+  takeDebugInfoUnit,
+} from './collectors/bytecode-debug-info.js'
 import {
   collectEntryPathMap,
   collectLazyBundleEntryResources,
@@ -275,17 +278,17 @@ export class LynxDebugMetadataPluginImpl {
             if (section) artifact.tasmSection = section
           }
 
-          const lepusNG = parseLepusNGDebugInfo(args.debugInfo)
-          if (lepusNG) {
-            const target = metadata.artifacts.find(a =>
-              a.kind === 'main-thread'
-              && a.tasmSection?.[0] === 'lepusCode'
-              && a.tasmSection?.[1] === 'root'
-            ) ?? metadata.artifacts.find(a => a.kind === 'main-thread')
-            if (target) {
-              target.debugSources.unshift({
+          // The artifact already names the script, so every unit keeps the
+          // `lepusNG_debug_info` key a card's debug info uses.
+          const units = parseDebugInfoUnits(args.debugInfo)
+          if (units) {
+            for (const artifact of metadata.artifacts) {
+              if (artifact.kind !== 'main-thread') continue
+              const body = takeDebugInfoUnit(artifact, units)
+              if (!body) continue
+              artifact.debugSources.unshift({
                 kind: 'bytecode-debug-info',
-                debugInfo: lepusNG,
+                debugInfo: { lepusNG_debug_info: body },
               })
             }
           }

--- a/packages/rspeedy/plugin-debug-metadata/src/collectors/bytecode-debug-info.ts
+++ b/packages/rspeedy/plugin-debug-metadata/src/collectors/bytecode-debug-info.ts
@@ -2,11 +2,14 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
-import type { LepusNGDebugInfo } from '@lynx-js/debug-metadata'
+import type { Artifact, LepusNGDebugInfoBody } from '@lynx-js/debug-metadata'
 
-export function parseLepusNGDebugInfo(
+// The unit a card's root lepus code is filed under.
+export const ROOT_DEBUG_INFO_UNIT = 'lepusNG_debug_info'
+
+export function parseDebugInfoUnits(
   debugInfoJson: string,
-): LepusNGDebugInfo | undefined {
+): Map<string, LepusNGDebugInfoBody> | undefined {
   if (!debugInfoJson) return undefined
   let parsed: unknown
   try {
@@ -14,8 +17,43 @@ export function parseLepusNGDebugInfo(
   } catch {
     return undefined
   }
-  if (!parsed || typeof parsed !== 'object') return undefined
-  const maybe = parsed as Partial<LepusNGDebugInfo>
-  if (!maybe.lepusNG_debug_info) return undefined
-  return maybe as LepusNGDebugInfo
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return undefined
+  }
+
+  const units = new Map<string, LepusNGDebugInfoBody>()
+  for (const [name, value] of Object.entries(parsed)) {
+    if (isDebugInfoBody(value)) units.set(name, value)
+  }
+  return units.size > 0 ? units : undefined
+}
+
+function isDebugInfoBody(value: unknown): value is LepusNGDebugInfoBody {
+  return typeof value === 'object' && value !== null
+    && Array.isArray((value as Partial<LepusNGDebugInfoBody>).function_info)
+}
+
+// A unit is named after the asset it was compiled from, except a card's root
+// lepus code. Removed from `units` so two artifacts cannot claim the same one.
+export function takeDebugInfoUnit(
+  artifact: Pick<Artifact, 'filename' | 'path' | 'tasmSection'>,
+  units: Map<string, LepusNGDebugInfoBody>,
+): LepusNGDebugInfoBody | undefined {
+  const named = [artifact.path, artifact.filename]
+    .flatMap(name => [name, name.replace(/\.[^./]+$/, '')])
+    .find(name => units.has(name))
+  if (named !== undefined) return take(units, named)
+
+  const isRoot = artifact.tasmSection?.[0] === 'lepusCode'
+    && artifact.tasmSection[1] === 'root'
+  return isRoot ? take(units, ROOT_DEBUG_INFO_UNIT) : undefined
+}
+
+function take(
+  units: Map<string, LepusNGDebugInfoBody>,
+  name: string,
+): LepusNGDebugInfoBody | undefined {
+  const body = units.get(name)
+  units.delete(name)
+  return body
 }

--- a/packages/rspeedy/plugin-debug-metadata/test/bytecode-debug-info.test.ts
+++ b/packages/rspeedy/plugin-debug-metadata/test/bytecode-debug-info.test.ts
@@ -4,50 +4,104 @@
 
 import { describe, expect, test } from 'vitest'
 
-import { parseLepusNGDebugInfo } from '../src/collectors/bytecode-debug-info.js'
+import type { LepusNGDebugInfoBody } from '@lynx-js/debug-metadata'
 
-const validEnvelope = {
-  lepusNG_debug_info: {
-    function_source: 'function foo(){}',
-    function_number: 1,
-    end_line_num: 1,
-    function_info: [
-      {
-        function_id: 0,
-        function_name: 'foo',
-        file_name: 'main-thread.js',
-        line_number: 1,
-        column_number: 0,
-        pc2line_len: 0,
-        pc2line_buf: [],
-        line_col: [],
-        pc2caller_info: {},
-      },
-    ],
-  },
-}
+import {
+  parseDebugInfoUnits,
+  takeDebugInfoUnit,
+} from '../src/collectors/bytecode-debug-info.js'
 
-describe('parseLepusNGDebugInfo', () => {
+const body = (functionName: string): LepusNGDebugInfoBody => ({
+  function_source: 'function foo(){}',
+  function_number: 1,
+  end_line_num: 1,
+  function_info: [
+    {
+      function_id: 0,
+      function_name: functionName,
+      file_name: 'main-thread.js',
+      line_number: 1,
+      column_number: 0,
+      pc2line_len: 0,
+      pc2line_buf: [],
+      line_col: [],
+      pc2caller_info: {},
+    },
+  ],
+})
+
+const artifact = (filename: string, root = false) => ({
+  filename,
+  path: `.lynx/main/${filename}`,
+  tasmSection: root ? ['lepusCode', 'root'] : undefined,
+})
+
+describe('parseDebugInfoUnits', () => {
   test('returns undefined for empty string', () => {
-    expect(parseLepusNGDebugInfo('')).toBeUndefined()
+    expect(parseDebugInfoUnits('')).toBeUndefined()
   })
 
   test('returns undefined for invalid JSON', () => {
-    expect(parseLepusNGDebugInfo('{ not json')).toBeUndefined()
+    expect(parseDebugInfoUnits('{ not json')).toBeUndefined()
   })
 
-  test('returns undefined when the envelope is missing', () => {
-    expect(parseLepusNGDebugInfo(JSON.stringify({}))).toBeUndefined()
-    expect(
-      parseLepusNGDebugInfo(JSON.stringify({ some_other_key: 1 })),
-    ).toBeUndefined()
+  test('returns undefined for a payload that holds no unit', () => {
+    expect(parseDebugInfoUnits(JSON.stringify({}))).toBeUndefined()
+    expect(parseDebugInfoUnits(JSON.stringify({ other: 1 }))).toBeUndefined()
+    expect(parseDebugInfoUnits(JSON.stringify([body('foo')]))).toBeUndefined()
   })
 
-  test('returns the parsed payload when the envelope is present', () => {
-    const parsed = parseLepusNGDebugInfo(JSON.stringify(validEnvelope))
-    expect(parsed).toEqual(validEnvelope)
-    expect(parsed?.lepusNG_debug_info.function_info[0]?.function_name).toBe(
-      'foo',
-    )
+  test('collects every unit the encoder filed', () => {
+    const units = parseDebugInfoUnits(JSON.stringify({
+      lepusNG_debug_info: body('root'),
+      'Card__main-thread': body('section'),
+    }))
+
+    expect([...units!.keys()]).toEqual([
+      'lepusNG_debug_info',
+      'Card__main-thread',
+    ])
+  })
+})
+
+describe('takeDebugInfoUnit', () => {
+  test('takes the root unit for a card main thread chunk', () => {
+    const units = new Map([['lepusNG_debug_info', body('root')]])
+
+    expect(takeDebugInfoUnit(artifact('main-thread.js', true), units))
+      .toEqual(body('root'))
+    expect(units.size).toBe(0)
+  })
+
+  test('prefers the unit named after the asset over the root unit', () => {
+    const units = new Map([
+      ['lepusNG_debug_info', body('root')],
+      ['Card__main-thread', body('section')],
+    ])
+
+    expect(takeDebugInfoUnit(artifact('Card__main-thread.js', true), units))
+      .toEqual(body('section'))
+    expect([...units.keys()]).toEqual(['lepusNG_debug_info'])
+  })
+
+  test('gives every main thread entry its own unit', () => {
+    const units = new Map([
+      ['First__main-thread', body('first')],
+      ['Second__main-thread', body('second')],
+    ])
+
+    expect(takeDebugInfoUnit(artifact('First__main-thread.js', true), units))
+      .toEqual(body('first'))
+    expect(takeDebugInfoUnit(artifact('Second__main-thread.js'), units))
+      .toEqual(body('second'))
+    expect(units.size).toBe(0)
+  })
+
+  test('takes nothing when no unit was compiled from the asset', () => {
+    const units = new Map([['Other__main-thread', body('other')]])
+
+    expect(takeDebugInfoUnit(artifact('Card__main-thread.js'), units))
+      .toBeUndefined()
+    expect(units.size).toBe(1)
   })
 })

--- a/packages/webpack/template-webpack-plugin/src/LynxTemplatePlugin.ts
+++ b/packages/webpack/template-webpack-plugin/src/LynxTemplatePlugin.ts
@@ -601,14 +601,19 @@ export function buildCustomSections(
 ): {
   sections: Record<string, CustomSectionEntry>;
   remainingManifest: Record<string, string>;
+  // The asset each section was assembled from, so its recorded location can
+  // follow it out of `lepusCode` / `manifest`.
+  sectionByAsset: Map<string, string>;
 } {
   const sections: Record<string, CustomSectionEntry> = {};
+  const sectionByAsset = new Map<string, string>();
 
   mainThreadAssets.forEach((asset, index) => {
     const name = naming.mainThread(asset.name, index);
     if (name === undefined) {
       return;
     }
+    sectionByAsset.set(asset.name, name);
     sections[name] = {
       ...(enableBytecode ? { encoding: 'JsBytecode' as const } : {}),
       content: asset.source.source().toString(),
@@ -627,6 +632,7 @@ export function buildCustomSections(
       remainingManifest[manifestKey] = content;
       continue;
     }
+    sectionByAsset.set(manifestKey.replace(/^\//, ''), name);
     sections[name] = { content };
   }
 
@@ -635,6 +641,7 @@ export function buildCustomSections(
     if (name === undefined) {
       return;
     }
+    sectionByAsset.set(asset.name, name);
     const ruleList = cssChunksToMap(
       [asset.source.source().toString()],
       cssPlugins,
@@ -646,7 +653,7 @@ export function buildCustomSections(
     };
   });
 
-  return { sections, remainingManifest };
+  return { sections, remainingManifest, sectionByAsset };
 }
 
 // A lazy bundle is a single component: the runtime resolves these three
@@ -1271,6 +1278,19 @@ class LynxTemplatePluginImpl {
         enableCSSSelector: this.#options.enableCSSSelector,
       })
       : null;
+
+    // `LynxEncodePlugin` records where each asset sits in `tasm.json` before
+    // the split runs, so the ones that move into a section are restamped here.
+    if (customSectionSplit) {
+      for (const [assetName, section] of customSectionSplit.sectionByAsset) {
+        const asset = compilation.getAsset(assetName);
+        if (!asset) continue;
+        compilation.updateAsset(asset.name, asset.source, {
+          ...asset.info,
+          'lynx:tasm-section': ['customSections', section],
+        });
+      }
+    }
 
     const resolvedEncodeOptions: EncodeOptions = {
       ...encodeData,


### PR DESCRIPTION
`debug-metadata.json` gained a level a card's never had. For a bundle whose main thread code lives in `JsBytecode` custom sections, such as `@lynx-js/react-umd`, the first main thread artifact carried:

```json
"debugInfo": {
  "lepusNG_debug_info": { "function_number": 1, ... },
  "ReactLynx__main-thread": { "function_source": "...", ... }
}
```

Two problems. The artifact already names the script it describes through `filename` and `path`, so the section-name level is redundant and no consumer looks for it. And with more than one main thread entry, every unit the encoder produced landed on the *first* artifact while the others got nothing:

| artifact | before | after |
| --- | --- | --- |
| `ReactLynx__main-thread.js` | 2 units, keyed by section name | `lepusNG_debug_info`, 651 functions |
| `SecondEntry__main-thread.js` | no bytecode debug info at all | `lepusNG_debug_info`, 651 functions |

Match each unit to the artifact it was compiled from, and keep it under `lepusNG_debug_info` so the shape matches a card's. A card is unchanged: 264 functions under the same key.

The encoder's `lepusNG_debug_info` entry for such a bundle describes an empty root, one `<eval>` function with no source, and is dropped by this matching. It is what consumers fall back to when a frame's file name matches no entry, so remapping used to run against a stub. lynx-family/lynx#9177 stops the encoder from emitting it and gives each section's functions their file name; this change stands on its own and fixes the shape with today's published encoder too.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected bytecode debug metadata assignment for bundles with multiple main-thread chunks.
  * Associated each debug-information unit with the artifact it was compiled from, preventing incorrect grouping or duplicate assignment.
  * Improved handling and validation of debug metadata stored in custom sections.
  * Corrected asset metadata so moved custom-section assets report their actual section location.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->