### PR TITLE
perf(react): skip deep equality for forced ET hydrate slots

### DIFF
--- a/packages/react/runtime/__test__/element-template/runtime/background/hydrate.test.ts
+++ b/packages/react/runtime/__test__/element-template/runtime/background/hydrate.test.ts
@@ -112,24 +112,30 @@ describe('hydrate', () => {
     }
   });
 
-  it('forces direct MTEvent hydrate slot updates even when wrappers are deep-equal', () => {
+  it('hydrates direct MTEvent slots without serializing deep-equal wrappers', () => {
     __etAttrPlanMap.root = [0, adaptMTEventAttrSlot];
-    const ctx = { _wkltId: 'tap' };
+    const ctx = { _wkltId: 'tap', _c: { items: [1, 2], label: 'same' } };
     const root = new BackgroundElementTemplateInstance('root', [ctx]);
+    const serialized = createHydrationTemplate(root.instanceId, 'root', {
+      attributeSlots: [{
+        type: 'worklet',
+        value: { _wkltId: 'tap', _c: { items: [1, 2], label: 'same' } },
+      }],
+    });
+    const stringify = vi.spyOn(JSON, 'stringify');
+    try {
+      const stream = hydrate(serialized, root);
 
-    const stream = hydrate(
-      createHydrationTemplate(root.instanceId, 'root', {
-        attributeSlots: [{ type: 'worklet', value: { _wkltId: 'tap' } }],
-      }),
-      root,
-    );
-
-    expect(stream).toEqual([
-      ElementTemplateUpdateOps.setMainThreadEvent,
-      root.instanceId,
-      0,
-      { type: 'worklet', value: ctx },
-    ]);
+      expect(stringify).not.toHaveBeenCalled();
+      expect(stream).toEqual([
+        ElementTemplateUpdateOps.setMainThreadEvent,
+        root.instanceId,
+        0,
+        { type: 'worklet', value: ctx },
+      ]);
+    } finally {
+      stringify.mockRestore();
+    }
   });
 
   it('keeps deep-equal hydrate wrappers skipped without a direct MTEvent attr plan', () => {
@@ -162,25 +168,31 @@ describe('hydrate', () => {
     expect(stream).toEqual([]);
   });
 
-  it('forces callback MTRef hydrate slot updates when wrappers are deep-equal', () => {
+  it('hydrates callback MTRef slots without serializing deep-equal wrappers', () => {
     __etAttrPlanMap.root = [0, adaptMTRefAttrSlot];
-    const callback = { _wkltId: 'ref-callback' };
+    const callback = { _wkltId: 'ref-callback', _c: { items: [1, 2], label: 'same' } };
     const root = new BackgroundElementTemplateInstance('root');
     root.attributeSlots = [{ type: 'main-thread-ref', value: callback }];
+    const serialized = createHydrationTemplate(root.instanceId, 'root', {
+      attributeSlots: [{
+        type: 'main-thread-ref',
+        value: { _wkltId: 'ref-callback', _c: { items: [1, 2], label: 'same' } },
+      }],
+    });
+    const stringify = vi.spyOn(JSON, 'stringify');
+    try {
+      const stream = hydrate(serialized, root);
 
-    const stream = hydrate(
-      createHydrationTemplate(root.instanceId, 'root', {
-        attributeSlots: [{ type: 'main-thread-ref', value: { _wkltId: 'ref-callback' } }],
-      }),
-      root,
-    );
-
-    expect(stream).toEqual([
-      ElementTemplateUpdateOps.setMainThreadRef,
-      root.instanceId,
-      0,
-      { type: 'main-thread-ref', value: callback },
-    ]);
+      expect(stringify).not.toHaveBeenCalled();
+      expect(stream).toEqual([
+        ElementTemplateUpdateOps.setMainThreadRef,
+        root.instanceId,
+        0,
+        { type: 'main-thread-ref', value: callback },
+      ]);
+    } finally {
+      stringify.mockRestore();
+    }
   });
 
   it('keeps deep-equal object MTRef hydrate wrappers skipped', () => {

--- a/packages/react/runtime/src/element-template/background/hydrate.ts
+++ b/packages/react/runtime/src/element-template/background/hydrate.ts
@@ -26,6 +26,7 @@ import type {
   SerializedTypedNode,
 } from '../protocol/types.js';
 import { getMainThreadDynamicAttrSlotKinds } from '../runtime/template/attr-slot-plan.js';
+import type { MainThreadDynamicAttrKind } from '../runtime/template/attr-slot-plan.js';
 import { isMTEventNativeWrapper } from '../runtime/template/main-thread-event-ctx.js';
 import type { MTRefNativeWrapper } from '../runtime/template/main-thread-ref-ctx.js';
 
@@ -568,12 +569,13 @@ function hydrateAttributeSlots(
   afterSlots: SerializableValue[],
 ): void {
   const slotCount = Math.max(beforeSlots.length, afterSlots.length);
+  const slotKinds = getMainThreadDynamicAttrSlotKinds(templateType);
   for (let slotIndex = 0; slotIndex < slotCount; slotIndex += 1) {
     const beforeValue = beforeSlots[slotIndex];
     const afterValue = afterSlots[slotIndex];
     if (
-      isDirectOrDeepEqual(beforeValue, afterValue)
-      && !shouldForceMainThreadHydrateSlot(templateType, slotIndex, afterValue)
+      !shouldForceMainThreadHydrateSlot(slotKinds?.get(slotIndex), afterValue)
+      && isDirectOrDeepEqual(beforeValue, afterValue)
     ) {
       continue;
     }
@@ -591,11 +593,9 @@ function hydrateAttributeSlots(
 }
 
 function shouldForceMainThreadHydrateSlot(
-  templateType: string,
-  attrSlotIndex: number,
+  slotKind: MainThreadDynamicAttrKind | undefined,
   value: SerializableValue | undefined,
 ): boolean {
-  const slotKind = getMainThreadDynamicAttrSlotKinds(templateType)?.get(attrSlotIndex);
   if (slotKind === 'mt-event') {
     return isMTEventNativeWrapper(value);
   }


### PR DESCRIPTION
ET hydration must hand off direct main-thread event wrappers and callback refs even when their values are deeply equal. Checking equality first unnecessarily serializes both wrapper capture graphs before emitting the update anyway.

Check the forced-handoff condition before equality and look up the template's cached slot kinds once per slot loop. Ordinary attributes and object refs keep their existing comparison behavior. Regression tests verify that deep-equal event and callback-ref wrappers produce the same handoff commands without calling `JSON.stringify`.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved hydration of dynamic event and reference slots when values are deeply equal.
  - Preserved the original context and callback objects during hydration without unnecessary serialization.
  - Ensured force-hydration behavior is evaluated correctly for each dynamic attribute slot type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->