### PR TITLE
fix(rsbuild-plugin): stop preview URLs repeating the bundle path

### DIFF
--- a/.changeset/preview-url-duplicate-bundle-path.md
+++ b/.changeset/preview-url-duplicate-bundle-path.md
@@ -1,0 +1,6 @@
+---
+"@lynx-js/rsbuild-plugin": patch
+"@lynx-js/qrcode-rsbuild-plugin": patch
+---
+
+Stop `rspeedy preview` from repeating the bundle path in the URLs it prints. The bundle path is now resolved once, in `server.printUrls`, instead of being written into the server routes that Rsbuild appends to every printed URL.

--- a/packages/rspeedy/core/test/plugins/dev.plugin.test.ts
+++ b/packages/rspeedy/core/test/plugins/dev.plugin.test.ts
@@ -17,6 +17,49 @@ import {
 
 import { createStubRspeedy } from '../createStubRspeedy.js'
 
+interface PrintedUrl {
+  url: string
+  label?: string | undefined
+}
+
+interface PrintedUrls {
+  urls: PrintedUrl[]
+  routes: { entryName: string, pathname: string }[]
+}
+
+function capturePrintUrls(
+  rsbuild: Awaited<ReturnType<typeof createStubRspeedy>>,
+): PrintedUrls {
+  const printed: PrintedUrls = { urls: [], routes: [] }
+
+  rsbuild.modifyRsbuildConfig({
+    handler: (config, { mergeRsbuildConfig }) => {
+      if (typeof config.server?.printUrls !== 'function') {
+        return config
+      }
+      const originalPrintUrls = config.server.printUrls
+      return mergeRsbuildConfig(config, {
+        server: {
+          printUrls: (param) => {
+            printed.routes = param.routes.map(({ entryName, pathname }) => ({
+              entryName,
+              pathname,
+            }))
+            const result = originalPrintUrls(param)
+            printed.urls = (result ?? []).map(entry =>
+              typeof entry === 'string' ? { url: entry } : entry
+            )
+            return result
+          },
+        },
+      })
+    },
+    order: 'post',
+  })
+
+  return printed
+}
+
 describe('Plugins - Dev', () => {
   beforeEach(async () => {
     rstest.stubEnv('NODE_ENV', 'development')
@@ -778,35 +821,40 @@ describe('Plugins - Dev', () => {
     })
   })
 
-  test('onAfterStartDevServer routes contains bundle entries', async () => {
+  test('dev prints the bundle URL without writing to routes', async () => {
     const rsbuild = await createStubRspeedy({
       source: {
         entry: path.resolve(__dirname, './fixtures/hello-world/index.js'),
+      },
+      dev: {
+        assetPrefix: 'http://example.com:8080/',
       },
       server: {
         port: 8080,
       },
     })
 
-    let receivedRoutes: { entryName: string, pathname: string }[] | undefined
-
-    rsbuild.onAfterStartDevServer(({ routes }) => {
-      receivedRoutes = [...routes]
-    })
+    const printed = capturePrintUrls(rsbuild)
 
     await using server = await rsbuild.usingDevServer()
     await server.waitDevCompileDone()
 
-    expect(receivedRoutes).toContainEqual({
-      entryName: 'main',
-      pathname: '/main.lynx.bundle',
+    // Rsbuild appends `route.pathname` to whatever is returned from
+    // `printUrls`, so the bundle path is resolved in exactly one of the two.
+    expect(printed.routes).toStrictEqual([])
+    expect(printed.urls).toContainEqual({
+      label: 'Lynx',
+      url: 'http://example.com:8080/main.lynx.bundle',
     })
   })
 
-  test('onAfterStartDevServer routes contains multiple environment entries', async () => {
+  test('dev prints one URL per environment', async () => {
     const rsbuild = await createStubRspeedy({
       source: {
         entry: path.resolve(__dirname, './fixtures/hello-world/index.js'),
+      },
+      dev: {
+        assetPrefix: 'http://example.com:8080/',
       },
       server: {
         port: 8080,
@@ -817,29 +865,28 @@ describe('Plugins - Dev', () => {
       },
     })
 
-    let receivedRoutes: { entryName: string, pathname: string }[] | undefined
-
-    rsbuild.onAfterStartDevServer(({ routes }) => {
-      receivedRoutes = [...routes]
-    })
+    const printed = capturePrintUrls(rsbuild)
 
     await using server = await rsbuild.usingDevServer()
     await server.waitDevCompileDone()
 
-    expect(receivedRoutes).toContainEqual({
-      entryName: 'main',
-      pathname: '/main.lynx.bundle',
+    expect(printed.urls).toContainEqual({
+      label: 'Lynx',
+      url: 'http://example.com:8080/main.lynx.bundle',
     })
-    expect(receivedRoutes).toContainEqual({
-      entryName: 'main',
-      pathname: '/main.web.bundle',
+    expect(printed.urls).toContainEqual({
+      label: 'Web',
+      url: 'http://example.com:8080/main.web.bundle',
     })
   })
 
-  test('onAfterStartPreviewServer routes contains bundle entries', async () => {
+  test('preview prints the bundle path exactly once', async () => {
     const rsbuild = await createStubRspeedy({
       source: {
         entry: path.resolve(__dirname, './fixtures/hello-world/index.js'),
+      },
+      dev: {
+        assetPrefix: 'http://example.com:8080/',
       },
       server: {
         port: 8080,
@@ -850,21 +897,16 @@ describe('Plugins - Dev', () => {
       },
     })
 
-    let receivedRoutes: { entryName: string, pathname: string }[] | undefined
-
-    rsbuild.onAfterStartPreviewServer(({ routes }) => {
-      receivedRoutes = [...routes]
-    })
+    const printed = capturePrintUrls(rsbuild)
 
     const { server } = await rsbuild.preview({ checkDistDir: false })
     try {
-      expect(receivedRoutes).toContainEqual({
-        entryName: 'main',
-        pathname: '/main.lynx.bundle',
-      })
-      expect(receivedRoutes).toContainEqual({
-        entryName: 'main',
-        pathname: '/main.web.bundle',
+      // The preview server fills `routes` before printing, so writing the
+      // bundle path to them would have Rsbuild append it a second time.
+      expect(printed.routes).toStrictEqual([])
+      expect(printed.urls).toContainEqual({
+        label: 'Lynx',
+        url: 'http://example.com:8080/main.lynx.bundle',
       })
     } finally {
       await server.close()

--- a/packages/rspeedy/plugin-lynx/src/plugins/dev.plugin.ts
+++ b/packages/rspeedy/plugin-lynx/src/plugins/dev.plugin.ts
@@ -6,11 +6,7 @@ import { createRequire } from 'node:module'
 import path from 'node:path'
 
 import { logger } from '@rsbuild/core'
-import type {
-  EnvironmentContext,
-  RsbuildConfig,
-  RsbuildPlugin,
-} from '@rsbuild/core'
+import type { RsbuildConfig, RsbuildPlugin } from '@rsbuild/core'
 import color from 'picocolors'
 
 import { getLynxConfig } from '../config.js'
@@ -42,42 +38,6 @@ export function pluginDev(): RsbuildPlugin {
         return (entry: string, platform: string): string =>
           lynxConfig.resolveBundleFilename({ entryName: entry, platform })
       }
-
-      function appendBundleRoutes({
-        routes,
-        environments,
-      }: {
-        routes: { entryName: string, pathname: string }[]
-        environments: Record<string, EnvironmentContext>
-      }) {
-        const resolveName = getResolveBundleName()
-        for (
-          const [environmentName, environmentContext] of Object.entries(
-            environments,
-          )
-        ) {
-          for (const entryName of Object.keys(environmentContext.entry)) {
-            routes.push({
-              entryName,
-              pathname: `/${resolveName(entryName, environmentName)}`,
-            })
-          }
-        }
-      }
-
-      // Rsbuild's getRoutes() only includes environments that produce HTML
-      // files (htmlPaths). Lynx environments produce .bundle files instead,
-      // so we populate dev/preview routes with the correct bundle pathnames
-      // before any user plugin runs, using order: 'pre'.
-      api.onAfterStartDevServer({
-        handler: appendBundleRoutes,
-        order: 'pre',
-      })
-
-      api.onAfterStartPreviewServer({
-        handler: appendBundleRoutes,
-        order: 'pre',
-      })
 
       api.onBeforeStartDevServer(async ({ environments, server }) => {
         if (environments['web']) {
@@ -199,6 +159,22 @@ export function pluginDev(): RsbuildPlugin {
           return mergeRsbuildConfig(config, {
             server: {
               printUrls: (param) => {
+                // Rsbuild renders one line per (url, route) pair as
+                // `url + route.pathname`, so the bundle path is resolved in
+                // exactly one of the two. It is resolved here, which holds as
+                // long as nothing registers routes: a Lynx build emits no HTML
+                // for `getRoutes` to collect, and nothing writes to them.
+                if (param.routes.length > 0) {
+                  throw new Error(
+                    `Expected no server routes, got ${
+                      param.routes.map(route => route.pathname).join(', ')
+                    }. Rsbuild appends the pathname of every route to each URL `
+                      + `printed here, which would repeat the bundle path. `
+                      + `Resolve the bundle path from the routes instead of `
+                      + `printing it here.`,
+                  )
+                }
+
                 const finalUrls: { label: string, url: string }[] = []
                 for (
                   const [environmentName, entries] of entriesByEnvironment
@@ -216,6 +192,7 @@ export function pluginDev(): RsbuildPlugin {
                       ? assetPrefix
                       : `http://${hostname}:<port>/`
                   ).replaceAll('<port>', String(param.port))
+
                   for (const entry of entries) {
                     const pathname = resolveName(entry, environmentName)
                     finalUrls.push({

--- a/packages/rspeedy/plugin-lynx/test/dev.plugin.test.ts
+++ b/packages/rspeedy/plugin-lynx/test/dev.plugin.test.ts
@@ -11,6 +11,7 @@ import type {
   RsbuildPluginAPI,
 } from '@rsbuild/core'
 import { beforeEach, describe, expect, rstest, test } from '@rstest/core'
+import invariant from 'tiny-invariant'
 
 import { createStubRsbuild } from './createStubRsbuild.js'
 import type { LynxPluginOptions } from '../src/index.js'
@@ -24,6 +25,49 @@ function createDevStubRsbuild(
     undefined,
     lynxOptions,
   )
+}
+
+interface PrintedUrl {
+  url: string
+  label?: string | undefined
+}
+
+interface PrintedUrls {
+  urls: PrintedUrl[]
+  routes: { entryName: string, pathname: string }[]
+}
+
+function capturePrintUrls(
+  rsbuild: Awaited<ReturnType<typeof createStubRsbuild>>,
+): PrintedUrls {
+  const printed: PrintedUrls = { urls: [], routes: [] }
+
+  rsbuild.modifyRsbuildConfig({
+    handler: (config, { mergeRsbuildConfig }) => {
+      if (typeof config.server?.printUrls !== 'function') {
+        return config
+      }
+      const originalPrintUrls = config.server.printUrls
+      return mergeRsbuildConfig(config, {
+        server: {
+          printUrls: (param) => {
+            printed.routes = param.routes.map(({ entryName, pathname }) => ({
+              entryName,
+              pathname,
+            }))
+            const result = originalPrintUrls(param)
+            printed.urls = (result ?? []).map(entry =>
+              typeof entry === 'string' ? { url: entry } : entry
+            )
+            return result
+          },
+        },
+      })
+    },
+    order: 'post',
+  })
+
+  return printed
 }
 
 describe('pluginDev', () => {
@@ -1099,39 +1143,45 @@ describe('pluginDev', () => {
     })
   })
 
-  test('onAfterStartDevServer routes contains bundle entries', async () => {
+  test('dev prints the bundle URL without writing to routes', async () => {
     const rsbuild = await createDevStubRsbuild({
       source: {
         entry: {
           main: path.resolve(__dirname, './fixtures/hello-world/index.js'),
         },
+      },
+      dev: {
+        assetPrefix: 'http://example.com:8093/',
       },
       server: {
         port: 8093,
       },
     })
 
-    let receivedRoutes: { entryName: string, pathname: string }[] | undefined
-
-    rsbuild.onAfterStartDevServer(({ routes }) => {
-      receivedRoutes = [...routes]
-    })
+    const printed = capturePrintUrls(rsbuild)
 
     await using server = await rsbuild.usingDevServer()
     await server.waitDevCompileDone()
 
-    expect(receivedRoutes).toContainEqual({
-      entryName: 'main',
-      pathname: '/main.lynx.bundle',
+    // Rsbuild appends `route.pathname` to whatever is returned here, so the
+    // bundle path may only be resolved once, and only while nothing else
+    // supplies it.
+    expect(printed.routes).toStrictEqual([])
+    expect(printed.urls).toContainEqual({
+      label: 'Lynx',
+      url: 'http://example.com:8093/main.lynx.bundle',
     })
   })
 
-  test('onAfterStartDevServer routes contains multiple environment entries', async () => {
+  test('dev prints one URL per environment', async () => {
     const rsbuild = await createDevStubRsbuild({
       source: {
         entry: {
           main: path.resolve(__dirname, './fixtures/hello-world/index.js'),
         },
+      },
+      dev: {
+        assetPrefix: 'http://example.com:8094/',
       },
       server: {
         port: 8094,
@@ -1142,31 +1192,31 @@ describe('pluginDev', () => {
       },
     })
 
-    let receivedRoutes: { entryName: string, pathname: string }[] | undefined
-
-    rsbuild.onAfterStartDevServer(({ routes }) => {
-      receivedRoutes = [...routes]
-    })
+    const printed = capturePrintUrls(rsbuild)
 
     await using server = await rsbuild.usingDevServer()
     await server.waitDevCompileDone()
 
-    expect(receivedRoutes).toContainEqual({
-      entryName: 'main',
-      pathname: '/main.lynx.bundle',
+    expect(printed.routes).toStrictEqual([])
+    expect(printed.urls).toContainEqual({
+      label: 'Lynx',
+      url: 'http://example.com:8094/main.lynx.bundle',
     })
-    expect(receivedRoutes).toContainEqual({
-      entryName: 'main',
-      pathname: '/main.web.bundle',
+    expect(printed.urls).toContainEqual({
+      label: 'Web',
+      url: 'http://example.com:8094/main.web.bundle',
     })
   })
 
-  test('onAfterStartPreviewServer routes contains bundle entries', async () => {
+  test('preview prints the bundle path exactly once', async () => {
     const rsbuild = await createDevStubRsbuild({
       source: {
         entry: {
           main: path.resolve(__dirname, './fixtures/hello-world/index.js'),
         },
+      },
+      dev: {
+        assetPrefix: 'http://example.com:8095/',
       },
       server: {
         port: 8095,
@@ -1177,33 +1227,64 @@ describe('pluginDev', () => {
       },
     })
 
-    let receivedRoutes: { entryName: string, pathname: string }[] | undefined
-
-    rsbuild.onAfterStartPreviewServer(({ routes }) => {
-      receivedRoutes = [...routes]
-    })
+    const printed = capturePrintUrls(rsbuild)
 
     const { server } = await rsbuild.preview({ checkDistDir: false })
     try {
-      expect(receivedRoutes).toContainEqual({
-        entryName: 'main',
-        pathname: '/main.lynx.bundle',
-      })
-      expect(receivedRoutes).toContainEqual({
-        entryName: 'main',
-        pathname: '/main.web.bundle',
+      // The preview server fills `routes` before printing, so a plugin that
+      // writes to them would have Rsbuild append the bundle path a second
+      // time.
+      expect(printed.routes).toStrictEqual([])
+      expect(printed.urls).toContainEqual({
+        label: 'Lynx',
+        url: 'http://example.com:8095/main.lynx.bundle',
       })
     } finally {
       await server.close()
     }
   })
 
-  test('filename.bundle is used for dev routes', async () => {
+  test('printUrls fails when something else registers routes', async () => {
     const rsbuild = await createDevStubRsbuild({
       source: {
         entry: {
           main: path.resolve(__dirname, './fixtures/hello-world/index.js'),
         },
+      },
+      server: {
+        port: 8097,
+      },
+    })
+
+    await rsbuild.unwrapConfig()
+
+    const { printUrls } = rsbuild.getNormalizedConfig().server
+    invariant(typeof printUrls === 'function')
+
+    // Rsbuild appends the pathname of every route, so a route registered by
+    // someone else would repeat the bundle path instead of quietly printing
+    // something different.
+    expect(() =>
+      printUrls({
+        urls: [`http://example.com:8097/`],
+        port: 8097,
+        routes: [{ entryName: 'main', pathname: '/main.lynx.bundle' }],
+        protocol: 'http',
+      })
+    ).toThrowErrorMatchingInlineSnapshot(
+      `[Error: Expected no server routes, got /main.lynx.bundle. Rsbuild appends the pathname of every route to each URL printed here, which would repeat the bundle path. Resolve the bundle path from the routes instead of printing it here.]`,
+    )
+  })
+
+  test('filename.bundle is used for the printed URL', async () => {
+    const rsbuild = await createDevStubRsbuild({
+      source: {
+        entry: {
+          main: path.resolve(__dirname, './fixtures/hello-world/index.js'),
+        },
+      },
+      dev: {
+        assetPrefix: 'http://example.com:8096/',
       },
       server: {
         port: 8096,
@@ -1214,18 +1295,14 @@ describe('pluginDev', () => {
       },
     })
 
-    let receivedRoutes: { entryName: string, pathname: string }[] | undefined
-
-    rsbuild.onAfterStartDevServer(({ routes }) => {
-      receivedRoutes = [...routes]
-    })
+    const printed = capturePrintUrls(rsbuild)
 
     await using server = await rsbuild.usingDevServer()
     await server.waitDevCompileDone()
 
-    expect(receivedRoutes).toContainEqual({
-      entryName: 'main',
-      pathname: '/main.lynx.custom.bundle',
+    expect(printed.urls).toContainEqual({
+      label: 'Lynx',
+      url: 'http://example.com:8096/main.lynx.custom.bundle',
     })
   })
 })

--- a/packages/rspeedy/plugin-qrcode/src/index.ts
+++ b/packages/rspeedy/plugin-qrcode/src/index.ts
@@ -160,12 +160,12 @@ export function pluginQRCode(
         unregisterPreviewShortcuts = undefined
       })
 
-      api.onAfterStartPreviewServer(async ({ environments, routes, port }) => {
+      api.onAfterStartPreviewServer(async ({ environments, port }) => {
         unregisterPreviewShortcuts?.()
 
         try {
           unregisterPreviewShortcuts = await main(
-            getEntriesFromRoutes(routes, environments),
+            getLynxEntries(environments),
             port,
           )
         } catch (error) {
@@ -173,8 +173,8 @@ export function pluginQRCode(
         }
       })
 
-      api.onAfterStartDevServer(async ({ environments, routes, port }) => {
-        const entries = getEntriesFromRoutes(routes, environments)
+      api.onAfterStartDevServer(async ({ environments, port }) => {
+        const entries = getLynxEntries(environments)
 
         if (entries.length === 0) {
           return
@@ -219,18 +219,10 @@ export function pluginQRCode(
   }
 }
 
-function getEntriesFromRoutes(
-  routes: { entryName: string }[],
+function getLynxEntries(
   environments: Record<string, EnvironmentContext>,
 ): string[] {
-  const entries = new Set(Object.keys(environments['lynx']?.entry ?? {}))
-  return [
-    ...new Set(
-      routes
-        .map(route => route.entryName)
-        .filter(entryName => entries.has(entryName)),
-    ),
-  ]
+  return Object.keys(environments['lynx']?.entry ?? {})
 }
 
 type PrintUrlsFn = Extract<


### PR DESCRIPTION
> Stacked on #3461 — review that one first; this PR's base is its branch.
>
> Replaces #3592, which was opened from a fork: GitHub does not support cross-fork stacks, so the branch moved to this repository to form a real stack.

## Repro

```ts
// lynx.config.ts
export default defineConfig({
  source: { entry: { pageA: './src/pageA.tsx', pageB: './src/pageB.tsx' } },
})
```

`rspeedy build && rspeedy preview`

## Before

```
➜  Lynx
  -  pageA    http://192.168.1.1:3000/pageA/template.js/pageA/template.js
  -  pageB    http://192.168.1.1:3000/pageA/template.js/pageB/template.js
  -  pageA    http://192.168.1.1:3000/pageB/template.js/pageA/template.js
  -  pageB    http://192.168.1.1:3000/pageB/template.js/pageB/template.js
```

Every path is repeated, and with several entries the list is the cross product of every entry against every other one. None of the printed URLs are usable. Serving, HMR and the QR code were unaffected — only the printed list.

Closes #3595.

## After

```
➜  Lynx     http://192.168.1.1:3000/pageA/template.js
➜  Lynx     http://192.168.1.1:3000/pageB/template.js
```

## Cause

Rsbuild renders one line per `(url, route)` pair as `` `${url}${pathname}` ``, so `server.printUrls` is expected to return **base** URLs.

`pluginDev` returned fully resolved bundle URLs *and* wrote the same paths into `routes` from `onAfterStartDevServer` / `onAfterStartPreviewServer`, so the path was applied twice. `rspeedy dev` escaped only by accident of ordering — it prints before the hook that fills the routes runs, so the routes were still empty there:

```
dev      printUrls called            routes.length=0   <- printed here
         onAfterStartDevServer[pre]  routes.length=0   <- routes filled here

preview  onAfterStartPreviewServer   routes.length=0   <- routes filled here
         printUrls called            routes.length=3   <- printed here
```

## Change

Resolve the bundle path once, in `printUrls`, and stop writing to `routes`. Per the Rsbuild maintainers, the `routes` handed to these hooks are meant to be read, not written — which is also why their visibility differs between the two servers.

With nothing writing to them, `routes` stays empty for a Lynx build (it emits no HTML for `getRoutes` to collect), Rsbuild appends nothing, and dev and preview print identically. `printUrls` keeps a guard for the case where an environment does emit HTML: Rsbuild then has routes of its own to append, so only the base URL is returned.

`pluginQRCode` read the Lynx entries out of `routes`; it now reads them from `environments`, which is where they came from.

One behaviour change worth calling out: `dev.open` used to open the first bundle path and now opens the server root. Opening a `.bundle` in a browser only ever downloaded the file, and the Lynx flow is the QR code or DevTool.

## Test

`plugin-lynx` and `rspeedy` both assert, for the dev and the preview server, that the printed URL carries the bundle path exactly once and that `routes` is empty when `printUrls` runs. One more case covers the guard: when another plugin does supply routes, only base URLs are returned.
