### PR TITLE
feat(react): export useInsertionEffect from @lynx-js/react/compat

### DIFF
--- a/.changeset/compat-use-insertion-effect.md
+++ b/.changeset/compat-use-insertion-effect.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react": minor
+---
+
+Export `useInsertionEffect` from `@lynx-js/react/compat`, currently an alias of `useEffect`.

--- a/packages/react/runtime/__test__/snapshot/compat/export.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/compat/export.test.jsx
@@ -21,6 +21,11 @@ describe('Default export', () => {
     expect(compat.use).toBe(preactUse);
   });
 
+  it('should include useInsertionEffect', () => {
+    expect(compat).toHaveProperty('useInsertionEffect');
+    expect(compat.useInsertionEffect).toBe(ReactLynx.useEffect);
+  });
+
   it('should include startTransition and useTransition', () => {
     expect(compat).toHaveProperty('startTransition');
     expect(compat.startTransition).toBe(preactStartTransition);
@@ -30,8 +35,8 @@ describe('Default export', () => {
   });
 
   it('should have correct number of exports', () => {
-    // +3 for startTransition, use and useTransition
-    const expectedExportCount = Object.keys(ReactLynx).length + 3;
+    // +4 for startTransition, use, useInsertionEffect and useTransition
+    const expectedExportCount = Object.keys(ReactLynx).length + 4;
     expect(Object.keys(compat).length).toBe(expectedExportCount);
   });
 });

--- a/packages/react/runtime/__test__/snapshot/compat/use-insertion-effect.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/compat/use-insertion-effect.test.jsx
@@ -1,0 +1,128 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { render } from 'preact';
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+
+import { useEffect } from '../../../src/index';
+import { useInsertionEffect } from '../../../compat';
+import { setupBackgroundDocument } from '../../../src/document';
+import { backgroundSnapshotInstanceManager, setupPage } from '../../../src/snapshot';
+import { globalEnvManager } from '../utils/envManager';
+import { elementTree, waitSchedule } from '../utils/nativeMethod';
+
+describe('useInsertionEffect', () => {
+  /** @type {import('../../../src/snapshot').SnapshotInstance} */
+  let scratch;
+
+  beforeAll(() => {
+    setupBackgroundDocument();
+    setupPage(__CreatePage('0', 0));
+  });
+
+  beforeEach(() => {
+    globalEnvManager.switchToBackground();
+    scratch = document.createElement('root');
+  });
+
+  afterEach(() => {
+    render(null, scratch);
+    elementTree.clear();
+    backgroundSnapshotInstanceManager.clear();
+  });
+
+  it('is useEffect until Preact grows a real insertion phase', () => {
+    expect(useInsertionEffect).toBe(useEffect);
+  });
+
+  it('runs before a useEffect declared after it', async () => {
+    const order = [];
+
+    function Component() {
+      useInsertionEffect(() => {
+        order.push('insertion');
+      }, []);
+      useEffect(() => {
+        order.push('effect');
+      }, []);
+      return <view />;
+    }
+
+    render(<Component />, scratch);
+    await waitSchedule();
+
+    expect(order).toEqual(['insertion', 'effect']);
+  });
+
+  it('lets a parent effect read a ref written by a child\'s insertion effect', async () => {
+    const optionsRef = { current: null };
+    let seenByParent;
+
+    function Child() {
+      useInsertionEffect(() => {
+        optionsRef.current = 'from child';
+      }, []);
+      return <view />;
+    }
+
+    function Parent() {
+      useEffect(() => {
+        seenByParent = optionsRef.current;
+      }, []);
+      return <Child />;
+    }
+
+    render(<Parent />, scratch);
+    await waitSchedule();
+
+    expect(seenByParent).toBe('from child');
+  });
+
+  it('re-runs its cleanup when the dependencies change', async () => {
+    const order = [];
+
+    function Component({ value }) {
+      useInsertionEffect(() => {
+        order.push(`setup:${value}`);
+        return () => order.push(`cleanup:${value}`);
+      }, [value]);
+      return <view />;
+    }
+
+    render(<Component value='a' />, scratch);
+    await waitSchedule();
+    expect(order).toEqual(['setup:a']);
+
+    render(<Component value='b' />, scratch);
+    await waitSchedule();
+    expect(order).toEqual(['setup:a', 'cleanup:a', 'setup:b']);
+  });
+
+  it('does not give React\'s timing guarantees, and these pin that down', async () => {
+    const order = [];
+    const ref = { current: null };
+
+    function Component() {
+      useInsertionEffect(() => {
+        ref.current = 'written';
+        return () => order.push('cleanup');
+      }, []);
+      return <view />;
+    }
+
+    render(<Component />, scratch);
+    // React would have run it inside the commit; here it is still pending.
+    expect(ref.current).toBe(null);
+
+    await waitSchedule();
+    expect(ref.current).toBe('written');
+
+    render(null, scratch);
+    // React would have run the cleanup inside the unmount commit.
+    expect(order).toEqual([]);
+
+    await waitSchedule();
+    expect(order).toEqual(['cleanup']);
+  });
+});

--- a/packages/react/runtime/compat/index.d.ts
+++ b/packages/react/runtime/compat/index.d.ts
@@ -50,12 +50,38 @@ declare function useTransition(): [false, typeof startTransition];
  * @public
  */
 declare function use<T>(resource: Promise<T> | Context<T>): T;
-export { startTransition, use, useTransition };
+
+/**
+ * Runs an effect whose write is meant to be visible to the effects that read it.
+ *
+ * Preact has no separate insertion phase, so ReactLynx forwards this to `useEffect`.
+ * Ordering within a component still follows declaration order, and across components
+ * effects run child-before-parent, which covers the pattern libraries such as
+ * react-navigation use it for:
+ *
+ * ```js
+ * useInsertionEffect(() => { optionsRef.current = options; }, [options]);
+ * useEffect(() => { readsOptionsRef(); });
+ * ```
+ *
+ * It is not React's guarantee, though. Code that only relies on the ordering above
+ * keeps working if this is ever pointed at a real insertion phase.
+ *
+ * @param effect - Imperative function that can return a cleanup function
+ * @param deps - If present, effect will only activate if the values in the list change (using ===)
+ *
+ * @public
+ *
+ * @deprecated `useInsertionEffect` in the background thread is an alias of `useEffect` and cannot offer React's insertion-phase timing: the effect has not run when `render` returns, and its cleanup is deferred to a later flush instead of running inside the unmount commit.
+ */
+declare const useInsertionEffect: typeof import('@lynx-js/react').useEffect;
+export { startTransition, use, useInsertionEffect, useTransition };
 
 // type for the default export
 declare const _default: typeof import('@lynx-js/react') & {
   startTransition: typeof startTransition;
   use: typeof use;
+  useInsertionEffect: typeof useInsertionEffect;
   useTransition: typeof useTransition;
 };
 export default _default;

--- a/packages/react/runtime/compat/index.js
+++ b/packages/react/runtime/compat/index.js
@@ -4,13 +4,16 @@
 import { startTransition, use, useTransition } from 'preact/compat';
 
 /* eslint-disable-next-line import/default */
-import ReactLynx from '@lynx-js/react';
+import ReactLynx, { useEffect } from '@lynx-js/react';
+
+const useInsertionEffect = useEffect;
 
 export default /*#__PURE__*/ Object.assign({}, ReactLynx, {
   startTransition,
   use,
+  useInsertionEffect,
   useTransition,
 });
 
 export * from '@lynx-js/react';
-export { startTransition, use, useTransition };
+export { startTransition, use, useInsertionEffect, useTransition };

--- a/packages/react/runtime/lazy/compat.js
+++ b/packages/react/runtime/lazy/compat.js
@@ -52,6 +52,7 @@ export const {
   // compat
   startTransition,
   use,
+  useInsertionEffect,
   useTransition,
 } = target[sExportsReactCompat];
 


### PR DESCRIPTION
## What

Export `useInsertionEffect` from `@lynx-js/react/compat`, currently an alias of `useEffect` and marked `@deprecated` for the same reason `useLayoutEffect` is.

## Why

react-navigation calls `useInsertionEffect`, so cards need the name to resolve. Preact has no separate insertion phase, so this forwards to `useEffect` for now.

What the callers actually rely on still holds: declaration order within a component, and child-before-parent across components — which covers the pattern react-navigation uses it for.

```js
useInsertionEffect(() => { optionsRef.current = options; }, [options]);
useEffect(() => { readsOptionsRef(); });
```

React's timing guarantees do not. The effect has not run by the time `render` returns, and its cleanup is deferred to a later flush rather than running inside the unmount commit. The `@deprecated` note spells that out at the call site, mirroring how `useLayoutEffect` is marked in `core/hooks/react.ts`. Pointing this at a real insertion phase later is a behaviour change, so both properties are pinned by tests rather than left implicit.

## Tests

`__test__/snapshot/compat/use-insertion-effect.test.jsx`, 5 cases: the alias identity, ordering against a later `useEffect`, a parent effect reading a ref written by a child's insertion effect, cleanup re-run on dependency change, and one case asserting the two timing properties React would give but this does not.

`compat/export.test.jsx` export count goes 3 → 4; `lazy/compat.js` gets the matching entry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `useInsertionEffect` to the React compatibility API as a named and default export.
  * The hook follows the runtime’s effect behavior, including ordering, dependency updates, and cleanup handling.

* **Tests**
  * Added coverage for effect execution order, refs, dependency changes, and unmount cleanup.
  * Updated compatibility export validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->