### PR TITLE
perf(react): cache element template ref plans

### DIFF
--- a/packages/react/runtime/__test__/element-template/runtime/prop-adapters/ref.test.ts
+++ b/packages/react/runtime/__test__/element-template/runtime/prop-adapters/ref.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { OrdinaryRefEffectQueue } from '../../../../src/core/ref.js';
 import { hydrationMap } from '../../../../src/element-template/hydration-map.js';
 import {
   clearRefState,
@@ -70,6 +71,17 @@ describe('ElementTemplate ref prop adapter', () => {
     flushPendingRefs();
 
     expect(ref).toHaveBeenCalledWith(null);
+  });
+
+  it('skips unchanged refs before allocating an effect queue token', () => {
+    const queue = vi.spyOn(OrdinaryRefEffectQueue.prototype, 'queue');
+    const ref = { current: null };
+
+    queueRefAttrUpdate(ref, ref, -2, 0);
+    queueRefAttrUpdate(null, null, -2, 0);
+
+    expect(queue).not.toHaveBeenCalled();
+    queue.mockRestore();
   });
 
   it('updates object refs and skips unchanged identities', () => {

--- a/packages/react/runtime/__test__/element-template/runtime/template/element-template-attr-slot-plan.test.ts
+++ b/packages/react/runtime/__test__/element-template/runtime/template/element-template-attr-slot-plan.test.ts
@@ -7,12 +7,14 @@ import {
 import { resetElementTemplateBackgroundFunctionRuntime } from '../../../../src/element-template/runtime/template/main-thread-background-function.js';
 import {
   __etAttrPlanMap,
+  adaptEventAttrSlot,
   adaptMTEventAttrSlot,
   adaptMTRefAttrSlot,
   adaptRefAttrSlot,
   adaptSpreadAttrSlot,
   clearEtAttrPlanMap,
   type EtAttrAdapter,
+  type EtAttrPlan,
 } from '../../../../src/element-template/runtime/template/attr-slot-plan.js';
 import { isMTEventNativeWrapper } from '../../../../src/element-template/runtime/template/main-thread-event-ctx.js';
 import type { MTRefNativeWrapper } from '../../../../src/element-template/runtime/template/main-thread-ref-ctx.js';
@@ -315,6 +317,98 @@ describe('ElementTemplate attr slot plan registry', () => {
     }));
   });
 
+  it('reuses the ref subplan across instances without rescanning unrelated adapters', () => {
+    const readAdapter = vi.fn(() => adaptEventAttrSlot);
+    const attrPlan: EtAttrPlan = [0, adaptEventAttrSlot, 1, adaptRefAttrSlot, 2, adaptSpreadAttrSlot];
+    Object.defineProperty(attrPlan, 1, { get: readAdapter });
+    __etAttrPlanMap._et_ref = attrPlan;
+
+    queueRefAttributeSlotUpdates('_et_ref', -2);
+    expect(readAdapter).toHaveBeenCalledTimes(1);
+    readAdapter.mockClear();
+
+    const effects: string[] = [];
+    const spreadRef = vi.fn(() => {
+      effects.push('spread');
+    });
+    const directRef = vi.fn(() => {
+      effects.push('direct');
+    });
+    queueRefAttributeSlotUpdates('_et_ref', -3, undefined, [vi.fn(), directRef, { ref: spreadRef }]);
+    flushPendingRefs();
+
+    expect(readAdapter).not.toHaveBeenCalled();
+    expect(effects).toEqual(['direct', 'spread']);
+    expect(directRef).toHaveBeenCalledWith(expect.objectContaining({ selector: '[ref=-3-1]' }));
+    expect(spreadRef).toHaveBeenCalledWith(expect.objectContaining({ selector: '[ref=-3-2]' }));
+  });
+
+  it('reuses an empty ref subplan and follows replacement and cleared registry entries', () => {
+    const readAdapter = vi.fn(() => adaptEventAttrSlot);
+    const eventPlan: EtAttrPlan = [0, adaptEventAttrSlot];
+    Object.defineProperty(eventPlan, 1, { get: readAdapter });
+    __etAttrPlanMap._et_ref = eventPlan;
+    queueRefAttributeSlotUpdates('_et_ref', -2);
+    queueRefAttributeSlotUpdates('_et_ref', -3);
+    expect(readAdapter).toHaveBeenCalledTimes(1);
+
+    const directRef = vi.fn();
+    __etAttrPlanMap._et_ref = [0, adaptRefAttrSlot];
+    queueRefAttributeSlotUpdates('_et_ref', -4, undefined, [directRef]);
+    flushPendingRefs();
+    expect(directRef).toHaveBeenCalledWith(expect.objectContaining({ selector: '[ref=-4-0]' }));
+
+    clearEtAttrPlanMap();
+    queueRefAttributeSlotUpdates('_et_ref', -4, [directRef]);
+    flushPendingRefs();
+    expect(directRef).toHaveBeenCalledTimes(1);
+
+    const spreadRef = vi.fn();
+    __etAttrPlanMap._et_ref = [1, adaptSpreadAttrSlot];
+    queueRefAttributeSlotUpdates('_et_ref', -5, undefined, [null, { ref: spreadRef }]);
+    flushPendingRefs();
+    expect(spreadRef).toHaveBeenCalledWith(expect.objectContaining({ selector: '[ref=-5-1]' }));
+  });
+
+  it('uses the explicit typed-host plan independently from the registered template plan', () => {
+    const ref = vi.fn();
+    __etAttrPlanMap._et_ref = [1, adaptRefAttrSlot];
+
+    queueRefAttributeSlotUpdates('_et_ref', -2);
+    queueRefAttributeSlotUpdates('_et_ref', -3, undefined, [{ ref }], [0, adaptSpreadAttrSlot]);
+    flushPendingRefs();
+
+    expect(ref).toHaveBeenCalledWith(expect.objectContaining({ selector: '[ref=-3-0]' }));
+  });
+
+  it('validates each spread ref once when queuing updates', () => {
+    const checkRef = vi.fn(Reflect.has);
+    const ref = new Proxy({ current: null }, { has: checkRef });
+    __etAttrPlanMap._et_ref = [0, adaptSpreadAttrSlot];
+
+    queueRefAttributeSlotUpdates('_et_ref', -2, undefined, [{ ref }]);
+    expect(checkRef).toHaveBeenCalledTimes(1);
+    flushPendingRefs();
+    const proxy = ref.current;
+    checkRef.mockClear();
+
+    queueRefAttributeSlotUpdates('_et_ref', -2, [{ ref }], [{ ref }]);
+    expect(checkRef).toHaveBeenCalledTimes(2);
+    flushPendingRefs();
+    expect(ref.current).toBe(proxy);
+  });
+
+  it.each([
+    ['direct', adaptRefAttrSlot, false],
+    ['spread', adaptSpreadAttrSlot, { ref: false }],
+  ])('rejects invalid %s refs when queuing updates', (_, adapter, value) => {
+    __etAttrPlanMap._et_ref = [0, adapter as EtAttrAdapter];
+    const error = 'Elements\' "ref" property should be a function, or an object created by createRef()';
+
+    expect(() => queueRefAttributeSlotUpdates('_et_ref', -2, undefined, [value])).toThrowError(error);
+    expect(() => queueRefAttributeSlotUpdates('_et_ref', -2, [value])).toThrowError(error);
+  });
+
   it('queues every ref-bearing attr slot independently', () => {
     const directRef = vi.fn();
     const objectRef = { current: null };
@@ -370,4 +464,17 @@ describe('ElementTemplate attr slot plan registry', () => {
     expect(directRef).not.toHaveBeenCalled();
     expect(spreadRef).toHaveBeenCalledWith(null);
   });
+
+  it.each([{}, { ref: undefined }, { ref: null }, undefined, null])(
+    'clears a spread ref when the next value is %j',
+    (nextValue) => {
+      const ref = vi.fn();
+      __etAttrPlanMap._et_ref = [0, adaptSpreadAttrSlot];
+
+      queueRefAttributeSlotUpdates('_et_ref', -2, [{ ref }], [nextValue]);
+      flushPendingRefs();
+
+      expect(ref).toHaveBeenCalledExactlyOnceWith(null);
+    },
+  );
 });

--- a/packages/react/runtime/src/element-template/background/attr-slots.ts
+++ b/packages/react/runtime/src/element-template/background/attr-slots.ts
@@ -2,7 +2,7 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
-import { getSpreadRefFromValue, queueRefAttrUpdate } from '../prop-adapters/ref.js';
+import { getRefFromValue, getSpreadRefFromValue, queueRefAttrUpdate } from '../prop-adapters/ref.js';
 import { ElementTemplateUpdateOps } from '../protocol/opcodes.js';
 import type { ElementTemplateUpdateOp } from '../protocol/opcodes.js';
 import type { SerializableValue } from '../protocol/types.js';
@@ -20,6 +20,10 @@ export interface PrepareAttributeSlotsOptions {
   attributePlan?: EtAttrPlan | undefined;
 }
 
+type RefAttrPlan = (number | typeof getSpreadRefFromValue)[];
+
+const refAttrPlans = new WeakMap<EtAttrPlan, RefAttrPlan>();
+
 function normalizeAttributeSlots(rawSlots: readonly unknown[]): SerializableValue[] {
   let normalizedSlots: SerializableValue[] | undefined;
   for (let slotIndex = 0; slotIndex < rawSlots.length; slotIndex += 1) {
@@ -35,37 +39,19 @@ function normalizeAttributeSlots(rawSlots: readonly unknown[]): SerializableValu
 
 function queuePlannedRefAttributeSlotUpdates(
   handleId: number,
-  attrPlan: readonly (number | EtAttrAdapter)[],
+  refAttrPlan: RefAttrPlan,
   previousRawSlots?: readonly unknown[],
   nextRawSlots?: readonly unknown[],
 ): void {
-  for (let planIndex = 0; planIndex < attrPlan.length; planIndex += 2) {
-    const attrSlotIndex = attrPlan[planIndex] as number;
-    const adapter = attrPlan[planIndex + 1] as EtAttrAdapter;
-
-    if (adapter === adaptRefAttrSlot) {
-      queueRefAttrUpdate(
-        previousRawSlots?.[attrSlotIndex],
-        nextRawSlots?.[attrSlotIndex],
-        handleId,
-        attrSlotIndex,
-      );
-      continue;
-    }
-
-    if (adapter === adaptSpreadAttrSlot) {
-      const previousSpreadRef = getSpreadRefFromValue(previousRawSlots?.[attrSlotIndex]);
-      const nextSpreadRef = getSpreadRefFromValue(nextRawSlots?.[attrSlotIndex]);
-      if (previousSpreadRef === undefined && nextSpreadRef === undefined) {
-        continue;
-      }
-      queueRefAttrUpdate(
-        previousSpreadRef,
-        nextSpreadRef ?? null,
-        handleId,
-        attrSlotIndex,
-      );
-    }
+  for (let planIndex = 0; planIndex < refAttrPlan.length; planIndex += 2) {
+    const attrSlotIndex = refAttrPlan[planIndex] as number;
+    const readRef = refAttrPlan[planIndex + 1] as typeof getSpreadRefFromValue;
+    queueRefAttrUpdate(
+      readRef(previousRawSlots?.[attrSlotIndex]) ?? null,
+      readRef(nextRawSlots?.[attrSlotIndex]) ?? null,
+      handleId,
+      attrSlotIndex,
+    );
   }
 }
 
@@ -114,7 +100,24 @@ export function queueRefAttributeSlotUpdates(
     return;
   }
 
-  queuePlannedRefAttributeSlotUpdates(handleId, attrPlan, previousRawSlots, nextRawSlots);
+  let refAttrPlan = refAttrPlans.get(attrPlan);
+  if (!refAttrPlan) {
+    refAttrPlan = [];
+    for (let planIndex = 0; planIndex < attrPlan.length; planIndex += 2) {
+      const adapter = attrPlan[planIndex + 1];
+      if (adapter === adaptRefAttrSlot || adapter === adaptSpreadAttrSlot) {
+        refAttrPlan.push(
+          attrPlan[planIndex] as number,
+          adapter === adaptRefAttrSlot ? getRefFromValue : getSpreadRefFromValue,
+        );
+      }
+    }
+    // Compiled plans are static. Keying by their identity also keeps replacement
+    // and registry teardown from retaining a stale plan for a template name.
+    refAttrPlans.set(attrPlan, refAttrPlan);
+  }
+
+  queuePlannedRefAttributeSlotUpdates(handleId, refAttrPlan, previousRawSlots, nextRawSlots);
 }
 
 export function getAttributeSlotUpdateOp(

--- a/packages/react/runtime/src/element-template/prop-adapters/ref.ts
+++ b/packages/react/runtime/src/element-template/prop-adapters/ref.ts
@@ -118,13 +118,14 @@ export function prepareSpreadRefAttrValue(
 }
 
 export function queueRefAttrUpdate(
-  oldValue: unknown,
-  newValue: unknown,
+  oldRef: EtRef | null,
+  newRef: EtRef | null,
   handleId: number,
   attrSlotIndex: number,
 ): void {
-  const oldRef = getRefFromValue(oldValue);
-  const newRef = getRefFromValue(newValue);
+  if (oldRef === newRef) {
+    return;
+  }
   refEffectQueue.queue(oldRef, newRef, [handleId, attrSlotIndex]);
 }
 


### PR DESCRIPTION
Element Template ref updates rescan every attribute adapter and repeat ref normalization even when a template's ref layout and the ref value are unchanged.

Cache an ordered ref-only plan by the compiled attribute plan's identity. The ref-effect pass visits only direct-ref and spread-ref slots, normalizes each ref once within that pass, and skips unchanged refs before allocating the selector token. Plan identity keeps registry replacement and teardown from reusing stale metadata. Ref ordering, hydration behavior, and the existing commit-time publication boundary remain unchanged.

This changes internal ET bookkeeping only, so no changeset is needed.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ref update handling to avoid unnecessary work when ref values remain unchanged.
  * Improved consistency when applying direct and spread ref updates, including clearing refs from empty or null-like values.
  * Ensured ref configurations are reused correctly across instances while honoring updated registry entries.
  * Added validation for invalid direct and spread ref values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->