### PR TITLE
perf(react): reduce element template commit overhead

### DIFF
--- a/packages/react/runtime/__test__/element-template/native/callDestroyLifetimeFun.test.ts
+++ b/packages/react/runtime/__test__/element-template/native/callDestroyLifetimeFun.test.ts
@@ -57,7 +57,7 @@ describe('callDestroyLifetimeFun', () => {
 
     callDestroyLifetimeFun();
 
-    expect(globalCommitContext.nonPayload.removedSubtreesAwaitingTeardown).toEqual([]);
+    expect([...globalCommitContext.nonPayload.removedSubtreesAwaitingTeardown]).toEqual([]);
     expect(globalCommitContext.ops).toEqual([]);
     expect(backgroundElementTemplateInstanceManager.values.size).toBe(0);
   });

--- a/packages/react/runtime/__test__/element-template/runtime/background/commit-context.test.ts
+++ b/packages/react/runtime/__test__/element-template/runtime/background/commit-context.test.ts
@@ -30,7 +30,7 @@ describe('ElementTemplate commit context', () => {
     markRemovedSubtreeForPostDispatchTeardown(root);
     markRemovedSubtreeForPostDispatchTeardown(root);
 
-    expect(globalCommitContext.nonPayload.removedSubtreesAwaitingTeardown).toEqual([root]);
+    expect([...globalCommitContext.nonPayload.removedSubtreesAwaitingTeardown]).toEqual([root]);
     expect({
       ops: globalCommitContext.ops,
       flushOptions: globalCommitContext.flushOptions,
@@ -52,7 +52,27 @@ describe('ElementTemplate commit context', () => {
 
     resetGlobalCommitContext();
 
-    expect(globalCommitContext.nonPayload.removedSubtreesAwaitingTeardown).toEqual([]);
+    expect([...globalCommitContext.nonPayload.removedSubtreesAwaitingTeardown]).toEqual([]);
+  });
+
+  it('deduplicates a removal batch in first-seen order and keeps dispatched batches independent', () => {
+    const roots = Array.from({ length: 512 }, () => new BackgroundElementTemplateInstance('view'));
+    for (const root of roots) {
+      markRemovedSubtreeForPostDispatchTeardown(root);
+    }
+    for (let i = roots.length - 1; i >= 0; i -= 1) {
+      markRemovedSubtreeForPostDispatchTeardown(roots[i]!);
+    }
+    const dispatched = takeRemovedSubtreesForPostDispatchTeardown();
+    expect(dispatched).toEqual(roots);
+
+    markRemovedSubtreeForPostDispatchTeardown(roots[0]!);
+    resetGlobalCommitContext();
+    expect(takeRemovedSubtreesForPostDispatchTeardown()).toEqual([]);
+    expect(dispatched).toEqual(roots);
+
+    markRemovedSubtreeForPostDispatchTeardown(roots[1]!);
+    expect(takeRemovedSubtreesForPostDispatchTeardown()).toEqual([roots[1]]);
   });
 
   it('collects only handles that are registered in the main-thread registry', () => {

--- a/packages/react/runtime/__test__/element-template/runtime/background/commit-hook.test.ts
+++ b/packages/react/runtime/__test__/element-template/runtime/background/commit-hook.test.ts
@@ -270,7 +270,7 @@ describe('ElementTemplate commit hook', () => {
       expect(takeDelayedRunOnMainThreadData()).toEqual([]);
       expect(removeEventListener).toHaveBeenCalledWith(WorkletEvents.FunctionCallRet, expect.any(Function));
       expect(globalCommitContext.ops).toEqual([]);
-      expect(globalCommitContext.nonPayload.removedSubtreesAwaitingTeardown).toEqual([]);
+      expect([...globalCommitContext.nonPayload.removedSubtreesAwaitingTeardown]).toEqual([]);
 
       options.__c?.({} as unknown as object, []);
       expect(ref).not.toHaveBeenCalled();
@@ -557,7 +557,7 @@ describe('ElementTemplate commit hook', () => {
       globalCommitContext.ops = createRawTextOps(1, 'flush');
 
       options.__c?.({} as unknown as object, []);
-      expect(globalCommitContext.nonPayload.removedSubtreesAwaitingTeardown).toEqual([]);
+      expect([...globalCommitContext.nonPayload.removedSubtreesAwaitingTeardown]).toEqual([]);
       vi.advanceTimersByTime(9999);
       expect(backgroundElementTemplateInstanceManager.get(root.instanceId)).toBe(root);
 
@@ -732,7 +732,7 @@ describe('ElementTemplate commit hook', () => {
 
     resetElementTemplateHydrationListener();
 
-    expect(globalCommitContext.nonPayload.removedSubtreesAwaitingTeardown).toEqual([root]);
+    expect([...globalCommitContext.nonPayload.removedSubtreesAwaitingTeardown]).toEqual([root]);
   });
 
   it('cancels scheduled removed subtree cleanup on background destroy', () => {

--- a/packages/react/runtime/__test__/element-template/runtime/background/hydrate.test.ts
+++ b/packages/react/runtime/__test__/element-template/runtime/background/hydrate.test.ts
@@ -367,7 +367,7 @@ describe('hydrate', () => {
       [101, 102, 103],
     ]);
     expect(root.elementSlots[0]).toBeUndefined();
-    expect(globalCommitContext.nonPayload.removedSubtreesAwaitingTeardown).toEqual([]);
+    expect([...globalCommitContext.nonPayload.removedSubtreesAwaitingTeardown]).toEqual([]);
     expect(backgroundElementTemplateInstanceManager.get(101)).toBeUndefined();
     expect(backgroundElementTemplateInstanceManager.get(102)).toBeUndefined();
     expect(backgroundElementTemplateInstanceManager.get(103)).toBeUndefined();
@@ -398,7 +398,7 @@ describe('hydrate', () => {
       [stale.instanceId],
     ]);
     expect(root.elementSlots[0]).toEqual([keep]);
-    expect(globalCommitContext.nonPayload.removedSubtreesAwaitingTeardown).toEqual([stale]);
+    expect([...globalCommitContext.nonPayload.removedSubtreesAwaitingTeardown]).toEqual([stale]);
   });
 
   it('moves serialized children to match the background slot order', () => {
@@ -431,7 +431,7 @@ describe('hydrate', () => {
       null,
     ]);
     expect(root.elementSlots[0]).toEqual([b, a, c]);
-    expect(globalCommitContext.nonPayload.removedSubtreesAwaitingTeardown).toEqual([]);
+    expect([...globalCommitContext.nonPayload.removedSubtreesAwaitingTeardown]).toEqual([]);
   });
 
   it('treats a source-before-target cross-slot hydrate candidate as remove and recreate', () => {
@@ -474,7 +474,7 @@ describe('hydrate', () => {
     ]);
     expect(root.elementSlots[0]).toBeUndefined();
     expect(root.elementSlots[1]).toEqual([moved]);
-    expect(globalCommitContext.nonPayload.removedSubtreesAwaitingTeardown).toEqual([]);
+    expect([...globalCommitContext.nonPayload.removedSubtreesAwaitingTeardown]).toEqual([]);
     expect(backgroundElementTemplateInstanceManager.get(mainThreadId)).toBeUndefined();
     expect(backgroundElementTemplateInstanceManager.get(localId)).toBe(moved);
   });
@@ -555,7 +555,7 @@ describe('hydrate', () => {
     ]);
     expect(root.elementSlots[0]).toEqual([keep]);
     expect(root.elementSlots[1]).toEqual([moved]);
-    expect(globalCommitContext.nonPayload.removedSubtreesAwaitingTeardown).toEqual([]);
+    expect([...globalCommitContext.nonPayload.removedSubtreesAwaitingTeardown]).toEqual([]);
     expect(backgroundElementTemplateInstanceManager.get(-2)).toBeUndefined();
   });
 
@@ -598,7 +598,7 @@ describe('hydrate', () => {
     ]);
     expect(root.elementSlots[0]).toEqual([moved]);
     expect(root.elementSlots[1]).toBeUndefined();
-    expect(globalCommitContext.nonPayload.removedSubtreesAwaitingTeardown).toEqual([]);
+    expect([...globalCommitContext.nonPayload.removedSubtreesAwaitingTeardown]).toEqual([]);
     expect(backgroundElementTemplateInstanceManager.get(mainThreadId)).toBeUndefined();
     expect(backgroundElementTemplateInstanceManager.get(localId)).toBe(moved);
   });
@@ -663,7 +663,7 @@ describe('hydrate', () => {
     ]);
     expect(root.elementSlots[0]).toBeUndefined();
     expect(root.elementSlots[1]).toEqual([first, second]);
-    expect(globalCommitContext.nonPayload.removedSubtreesAwaitingTeardown).toEqual([]);
+    expect([...globalCommitContext.nonPayload.removedSubtreesAwaitingTeardown]).toEqual([]);
     expect(backgroundElementTemplateInstanceManager.get(-2)).toBeUndefined();
     expect(backgroundElementTemplateInstanceManager.get(-3)).toBeUndefined();
     expect(backgroundElementTemplateInstanceManager.get(firstLocalId)).toBe(first);
@@ -832,7 +832,7 @@ describe('hydrate', () => {
     expect(root.elementSlots[0]).toEqual([entryB, entryA]);
     expect(backgroundElementTemplateInstanceManager.get(-11)).toBe(entryA);
     expect(backgroundElementTemplateInstanceManager.get(-12)).toBe(entryB);
-    expect(globalCommitContext.nonPayload.removedSubtreesAwaitingTeardown).toEqual([]);
+    expect([...globalCommitContext.nonPayload.removedSubtreesAwaitingTeardown]).toEqual([]);
   });
 
   it('ignores native main-bundle sentinel urls during hydrate', () => {

--- a/packages/react/runtime/__test__/element-template/runtime/background/instance.test.ts
+++ b/packages/react/runtime/__test__/element-template/runtime/background/instance.test.ts
@@ -474,7 +474,7 @@ describe('BackgroundElementTemplateInstance', () => {
       -11,
       [-11],
     ]);
-    expect(globalCommitContext.nonPayload.removedSubtreesAwaitingTeardown).toEqual([item]);
+    expect([...globalCommitContext.nonPayload.removedSubtreesAwaitingTeardown]).toEqual([item]);
     expect(cleanup).toHaveBeenCalledTimes(1);
     expect(ref).not.toHaveBeenCalled();
   });
@@ -493,7 +493,7 @@ describe('BackgroundElementTemplateInstance', () => {
     list.removeChild(item, true);
 
     expect(globalCommitContext.ops).toEqual([]);
-    expect(globalCommitContext.nonPayload.removedSubtreesAwaitingTeardown).toEqual([]);
+    expect([...globalCommitContext.nonPayload.removedSubtreesAwaitingTeardown]).toEqual([]);
   });
 
   it('emits logical updates for both lists when an item moves across typed lists', () => {
@@ -1459,7 +1459,7 @@ describe('BackgroundElementTemplateInstance', () => {
         child.instanceId,
         [child.instanceId, grandchild.instanceId],
       ]);
-      expect(globalCommitContext.nonPayload.removedSubtreesAwaitingTeardown).toEqual([child]);
+      expect([...globalCommitContext.nonPayload.removedSubtreesAwaitingTeardown]).toEqual([child]);
     });
 
     it('queues direct ref cleanup when removing a hydrated subtree', () => {
@@ -1625,7 +1625,7 @@ describe('BackgroundElementTemplateInstance', () => {
 
       expect(parent.elementSlots[0]).toBeUndefined();
       expect(globalCommitContext.ops).toEqual([]);
-      expect(globalCommitContext.nonPayload.removedSubtreesAwaitingTeardown).toEqual([]);
+      expect([...globalCommitContext.nonPayload.removedSubtreesAwaitingTeardown]).toEqual([]);
       expect(backgroundElementTemplateInstanceManager.get(childId)).toBeUndefined();
     });
 
@@ -1682,7 +1682,7 @@ describe('BackgroundElementTemplateInstance', () => {
 
       expect(parent.elementSlots[0]).toBeUndefined();
       expect(globalCommitContext.ops).toEqual([]);
-      expect(globalCommitContext.nonPayload.removedSubtreesAwaitingTeardown).toEqual([]);
+      expect([...globalCommitContext.nonPayload.removedSubtreesAwaitingTeardown]).toEqual([]);
     });
   });
 

--- a/packages/react/runtime/__test__/element-template/runtime/hydration/hydration-listener.test.ts
+++ b/packages/react/runtime/__test__/element-template/runtime/hydration/hydration-listener.test.ts
@@ -647,7 +647,7 @@ describe('ElementTemplate hydration listener', () => {
       expect(() => envManager.switchToBackground()).not.toThrow();
       expect(reportError).toHaveBeenCalledWith(serializeError);
       expect(globalCommitContext.ops).toEqual([]);
-      expect(globalCommitContext.nonPayload.removedSubtreesAwaitingTeardown).toEqual([]);
+      expect([...globalCommitContext.nonPayload.removedSubtreesAwaitingTeardown]).toEqual([]);
       expect(takeMainThreadRefInitValuePatch()).toEqual([]);
       expect(takeDelayedRunOnMainThreadData()).toEqual([]);
       expect(removeEventListener).toHaveBeenCalledWith(WorkletEvents.FunctionCallRet, expect.any(Function));

--- a/packages/react/runtime/__test__/element-template/runtime/patch/element-template-patch.test.tsx
+++ b/packages/react/runtime/__test__/element-template/runtime/patch/element-template-patch.test.tsx
@@ -20,7 +20,10 @@ import type {
   ElementTemplateUpdateCommitContext,
   SerializedEtNode,
 } from '../../../../src/element-template/protocol/types.js';
-import { createElementTemplateUpdateEvent } from '../../../../src/element-template/protocol/update-event.js';
+import {
+  createElementTemplateUpdateEvent,
+  parseElementTemplateUpdateEventPayload,
+} from '../../../../src/element-template/protocol/update-event.js';
 import { __page, setupPage } from '../../../../src/element-template/runtime/page/page.js';
 import { __root } from '../../../../src/element-template/runtime/page/root-instance.js';
 import { applyElementTemplateUpdateCommands } from '../../../../src/element-template/runtime/patch.js';
@@ -3544,7 +3547,7 @@ describe('ElementTemplate patch stream (apply)', () => {
     `);
   });
 
-  it('normalizes undefined attribute slot values to null on create', () => {
+  it('reuses create attribute slots normalized by the update transport', () => {
     envManager.switchToMainThread();
     const createTemplateMock = globalThis.__CreateElementTemplate as unknown as {
       mockClear: () => void;
@@ -3552,16 +3555,26 @@ describe('ElementTemplate patch stream (apply)', () => {
     };
     createTemplateMock.mockClear();
 
-    applyElementTemplateUpdateCommands([
-      ElementTemplateUpdateOps.createTemplate,
-      8,
-      '_et_builtin_raw_text',
-      null,
-      [undefined, 'x'] as unknown as ElementTemplateUpdateCommandStream[number],
-      [],
-    ]);
+    const rawSlots = [undefined, 'x'];
+    rawSlots.length = 3;
+    const event = createElementTemplateUpdateEvent({
+      ops: [
+        ElementTemplateUpdateOps.createTemplate,
+        8,
+        '_et_builtin_raw_text',
+        null,
+        rawSlots as unknown as ElementTemplateUpdateCommandStream[number],
+        [],
+      ],
+      flushOptions: {},
+    });
+    const payload = parseElementTemplateUpdateEventPayload(event.data);
+    const attributeSlots = payload.ops[4];
+    expect(attributeSlots).toEqual([null, 'x', null]);
 
-    expect(createTemplateMock.mock.calls[0]?.[2]).toEqual([null, 'x']);
+    applyElementTemplateUpdateCommands(payload.ops);
+
+    expect(createTemplateMock.mock.calls[0]?.[2]).toBe(attributeSlots);
   });
 
   it('passes bundleUrl from createTemplate patch to native create', () => {

--- a/packages/react/runtime/src/element-template/background/commit-context.ts
+++ b/packages/react/runtime/src/element-template/background/commit-context.ts
@@ -12,7 +12,7 @@ interface ElementTemplateCommitNonPayloadState {
   // Background-only JS objects must not be included in the cross-thread update
   // payload. They ride alongside the payload until the dispatch boundary
   // schedules delayed cleanup.
-  removedSubtreesAwaitingTeardown: BackgroundElementTemplateInstance[];
+  removedSubtreesAwaitingTeardown: Set<BackgroundElementTemplateInstance>;
 }
 
 type ElementTemplateGlobalCommitContext = ElementTemplateUpdateCommitContext & {
@@ -20,7 +20,7 @@ type ElementTemplateGlobalCommitContext = ElementTemplateUpdateCommitContext & {
 };
 
 const nonPayload: ElementTemplateCommitNonPayloadState = {
-  removedSubtreesAwaitingTeardown: [],
+  removedSubtreesAwaitingTeardown: new Set(),
 };
 
 export const globalCommitContext = coreGlobalCommitContext as unknown as ElementTemplateGlobalCommitContext;
@@ -29,20 +29,19 @@ globalCommitContext.nonPayload = nonPayload;
 
 export function resetGlobalCommitContext(): void {
   resetCoreGlobalCommitContext();
-  nonPayload.removedSubtreesAwaitingTeardown = [];
+  nonPayload.removedSubtreesAwaitingTeardown.clear();
 }
 
 export function markRemovedSubtreeForPostDispatchTeardown(
   root: BackgroundElementTemplateInstance,
 ): void {
-  const { removedSubtreesAwaitingTeardown } = globalCommitContext.nonPayload;
-  if (!removedSubtreesAwaitingTeardown.includes(root)) {
-    removedSubtreesAwaitingTeardown.push(root);
-  }
+  globalCommitContext.nonPayload.removedSubtreesAwaitingTeardown.add(root);
 }
 
 export function takeRemovedSubtreesForPostDispatchTeardown(): BackgroundElementTemplateInstance[] {
-  const removedSubtreesAwaitingTeardown = globalCommitContext.nonPayload.removedSubtreesAwaitingTeardown;
-  globalCommitContext.nonPayload.removedSubtreesAwaitingTeardown = [];
-  return removedSubtreesAwaitingTeardown;
+  const { removedSubtreesAwaitingTeardown } = globalCommitContext.nonPayload;
+  // Each delayed cleanup owns its batch after the current commit is reset.
+  const roots = [...removedSubtreesAwaitingTeardown];
+  removedSubtreesAwaitingTeardown.clear();
+  return roots;
 }

--- a/packages/react/runtime/src/element-template/runtime/patch.ts
+++ b/packages/react/runtime/src/element-template/runtime/patch.ts
@@ -48,6 +48,8 @@ import type { MainThreadDynamicAttrSubtreeHandle } from './template/main-thread-
 
 export type { ElementTemplateUpdateCommandStream } from '../protocol/types.js';
 
+// The update event's JSON transport already normalizes array holes and undefined
+// entries to null. Consume those wire values without copying each attr array.
 export function applyElementTemplateUpdateCommands(
   stream: ElementTemplateUpdateCommandStream,
   isHydration = false,
@@ -81,11 +83,10 @@ export function applyElementTemplateUpdateCommands(
           continue;
         }
 
-        const preparedAttributeSlots = normalizeAttributeSlots(attributeSlots);
         const templateType = elementTemplateTypeTag(templateKey, bundleUrl);
         const nativeAttributeSlots = prepareMainThreadDynamicAttrSlotsForNative(
           templateType,
-          preparedAttributeSlots,
+          attributeSlots,
         );
         const nativeRef = __CreateElementTemplate(
           templateKey,
@@ -100,7 +101,7 @@ export function applyElementTemplateUpdateCommands(
           initializeMainThreadDynamicAttrSlots(
             handleId,
             templateType,
-            preparedAttributeSlots,
+            attributeSlots,
           );
         }
         break;
@@ -513,13 +514,4 @@ function validateCreateTemplatePayload(
     return new Error('ElementTemplate update create elementSlots must be an array, null, or undefined.');
   }
   return null;
-}
-
-function normalizeAttributeSlots(
-  attributeSlots: SerializableValue[] | null | undefined,
-): SerializableValue[] | null | undefined {
-  if (attributeSlots == null) {
-    return attributeSlots;
-  }
-  return attributeSlots.map((value) => (value === undefined ? null : value));
 }


### PR DESCRIPTION
Element Template commits spend avoidable work deduplicating removed subtree roots and copying each create command's attribute slots. This groups two local optimizations in the existing commit and patch paths.

Use an insertion-ordered Set for pending teardown roots, then hand each delayed cleanup an independent array at dispatch. Deduplication no longer scans earlier roots, while cleanup order and timer ownership remain unchanged. The patch executor also reuses attribute arrays already normalized by the update event's JSON transport; MTRef slots still receive their separate native preparation when needed.

These are internal ET changes with no published API or protocol change, so no changeset is needed.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup scheduling by preventing duplicate subtree teardown work and preserving independent cleanup batches.
  * Ensured sparse attribute updates are correctly normalized during transport and applied to native elements.
  * Updated runtime behavior to rely on transport-level attribute normalization without changing user-visible results.

* **Tests**
  * Expanded coverage for teardown batching, reset behavior, hydration, element removal, and sparse attribute updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->