### PR TITLE
perf(react): combine element template removal walks

### DIFF
--- a/packages/react/runtime/__test__/element-template/runtime/background/commit-context.test.ts
+++ b/packages/react/runtime/__test__/element-template/runtime/background/commit-context.test.ts
@@ -10,11 +10,7 @@ import {
   resetGlobalCommitContext,
   takeRemovedSubtreesForPostDispatchTeardown,
 } from '../../../../src/element-template/background/commit-context.js';
-import {
-  BackgroundElementTemplateInstance,
-  BUILTIN_RAW_TEXT_TEMPLATE_KEY,
-  collectElementTemplateSubtreeHandleIds,
-} from '../../../../src/element-template/background/instance.js';
+import { BackgroundElementTemplateInstance } from '../../../../src/element-template/background/instance.js';
 import { backgroundElementTemplateInstanceManager } from '../../../../src/element-template/background/manager.js';
 
 describe('ElementTemplate commit context', () => {
@@ -53,19 +49,5 @@ describe('ElementTemplate commit context', () => {
     resetGlobalCommitContext();
 
     expect(globalCommitContext.nonPayload.removedSubtreesAwaitingTeardown).toEqual([]);
-  });
-
-  it('collects only handles that are registered in the main-thread registry', () => {
-    const root = new BackgroundElementTemplateInstance('root');
-    const child = new BackgroundElementTemplateInstance('child');
-    const rawText = new BackgroundElementTemplateInstance(BUILTIN_RAW_TEXT_TEMPLATE_KEY, ['text']);
-    child.appendChild(rawText);
-    root.appendChild(child);
-
-    expect(collectElementTemplateSubtreeHandleIds(root)).toEqual([
-      root.instanceId,
-      child.instanceId,
-      rawText.instanceId,
-    ]);
   });
 });

--- a/packages/react/runtime/__test__/element-template/runtime/background/event/compiled-fixtures.test.tsx
+++ b/packages/react/runtime/__test__/element-template/runtime/background/event/compiled-fixtures.test.tsx
@@ -12,7 +12,6 @@ import {
   resetElementTemplateHydrationListener,
 } from '../../../../../src/element-template/background/hydration-listener.js';
 import {
-  collectElementTemplateSubtreeHandleIds,
   collectMainThreadRefSubtreeHandleIds,
   BackgroundElementTemplateInstance,
 } from '../../../../../src/element-template/background/instance.js';
@@ -53,7 +52,7 @@ import {
   renderCompiledFixtureOnMainThread,
 } from '../../../test-utils/debug/compiledThreadRunner.js';
 import { ElementTemplateEnvManager } from '../../../test-utils/debug/envManager.js';
-import { serializeBackgroundTree } from '../../../test-utils/debug/serializer.js';
+import { collectBackgroundSubtreeHandleIds, serializeBackgroundTree } from '../../../test-utils/debug/serializer.js';
 import { initWorklet } from '../../../../../src/worklet-runtime/workletRuntime.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -834,7 +833,7 @@ describe('Compiled direct event background updates', () => {
     const host = renderConditionalDirectEventOnBackground(backgroundModule, true, handler);
     hydrateConditionalDirectEventFromMainThread(mainModule, true, handler);
     const removed = getSlotChildAt(0, host);
-    const removedSubtreeHandleIds = collectElementTemplateSubtreeHandleIds(removed);
+    const removedSubtreeHandleIds = collectBackgroundSubtreeHandleIds(removed);
     const eventValue = `${removed.instanceId}:0:`;
     expect(getEventHandlerForEventValue(eventValue)).toBe(handler);
     updateEvents = [];

--- a/packages/react/runtime/__test__/element-template/runtime/background/instance.test.ts
+++ b/packages/react/runtime/__test__/element-template/runtime/background/instance.test.ts
@@ -1372,6 +1372,65 @@ describe('BackgroundElementTemplateInstance', () => {
   });
 
   describe('removeChild', () => {
+    it.each(['ordinary', 'list-item', 'list-descendant', 'list-descendant-without-MTRef'])(
+      'visits each removed instance once for %s lifetime cleanup',
+      (kind) => {
+        const list = new BackgroundListElementTemplateInstance();
+        const parent = kind === 'list-item' ? list : new BackgroundElementTemplateInstance('_et_parent');
+        if (kind.startsWith('list-descendant')) {
+          list.appendChild(parent);
+        }
+        const removed = new BackgroundElementTemplateInstance('_et_removed');
+        const first = new BackgroundElementTemplateInstance('_et_first');
+        const nested = new BackgroundElementTemplateInstance('_et_nested');
+        const last = createTextNode('last');
+        removed.appendChild(first);
+        first.appendChild(nested);
+        removed.appendChild(last);
+        parent.appendChild(removed);
+        if (kind !== 'list-descendant-without-MTRef') {
+          __etAttrPlanMap._et_nested = [0, adaptMTRefAttrSlot];
+        }
+        const nodes = [removed, first, nested, last];
+        for (const node of [list, parent, ...nodes]) {
+          node.markMaterializedByHydration();
+        }
+        markElementTemplateHydrated();
+        globalCommitContext.ops = [];
+        const childrenReads = nodes.map(node => {
+          const firstChild = node.firstChild;
+          const read = vi.fn(() => firstChild);
+          Object.defineProperty(node, 'firstChild', { configurable: true, get: read });
+          return { node, firstChild, read };
+        });
+
+        parent.removeChild(removed);
+
+        for (const { node, firstChild, read } of childrenReads) {
+          expect(read).toHaveBeenCalledTimes(1);
+          Object.defineProperty(node, 'firstChild', { configurable: true, writable: true, value: firstChild });
+        }
+        const removedIds = nodes.map(node => node.instanceId);
+        expect(globalCommitContext.ops).toEqual([
+          ...(kind === 'list-item'
+            ? [ElementTemplateUpdateOps.removeTypedListItem, parent.instanceId, removed.instanceId, removedIds]
+            : [ElementTemplateUpdateOps.removeNode, parent.instanceId, 0, removed.instanceId, removedIds]),
+          ...(kind === 'list-descendant'
+            ? [ElementTemplateUpdateOps.updateTypedListItem, list.instanceId, {
+              __etHandleRef: parent.instanceId,
+              type: '_et_parent',
+              platformInfo: {},
+              subtreeHandleIds: [],
+            }]
+            : []),
+        ]);
+        expect(globalCommitContext.nonPayload.removedSubtreesAwaitingTeardown).toEqual([removed]);
+        for (const node of nodes) {
+          expect(backgroundElementTemplateInstanceManager.get(node.instanceId)).toBe(node);
+        }
+      },
+    );
+
     it('should remove child correctly', () => {
       const parent = new BackgroundElementTemplateInstance('view');
       const child = new BackgroundElementTemplateInstance('text');
@@ -1541,27 +1600,37 @@ describe('BackgroundElementTemplateInstance', () => {
     });
 
     it('queues nested direct and spread ref cleanup when removing a hydrated subtree', () => {
-      const childCleanup = vi.fn();
+      const cleanupOrder: string[] = [];
+      const childCleanup = vi.fn(() => cleanupOrder.push('child'));
       const childRef = vi.fn(() => childCleanup);
-      const directGrandchildRef = vi.fn();
-      const grandchildCleanup = vi.fn();
+      const directGrandchildRef = vi.fn(value => {
+        if (value === null) cleanupOrder.push('grandchild-direct');
+      });
+      const grandchildCleanup = vi.fn(() => cleanupOrder.push('grandchild-spread'));
       const grandchildSpreadRef = vi.fn(() => grandchildCleanup);
+      const siblingRef = vi.fn(value => {
+        if (value === null) cleanupOrder.push('sibling');
+      });
       __etAttrPlanMap.view = [0, adaptRefAttrSlot, 1, adaptSpreadAttrSlot];
       const parent = new BackgroundElementTemplateInstance('view');
       const child = new BackgroundElementTemplateInstance('view');
       const grandchild = new BackgroundElementTemplateInstance('view');
+      const sibling = new BackgroundElementTemplateInstance('view');
       child.appendChild(grandchild);
+      child.appendChild(sibling);
       parent.appendChild(child);
 
       markElementTemplateHydrated();
       parent.markMaterializedByHydration();
       child.markMaterializedByHydration();
       grandchild.markMaterializedByHydration();
+      sibling.markMaterializedByHydration();
       child.setAttribute('attributeSlots', [childRef]);
       grandchild.setAttribute('attributeSlots', [
         directGrandchildRef,
         { ref: grandchildSpreadRef },
       ]);
+      sibling.setAttribute('attributeSlots', [siblingRef]);
       flushPendingRefs();
       expect(childRef).toHaveBeenCalledTimes(1);
       expect(directGrandchildRef).toHaveBeenCalledTimes(1);
@@ -1572,6 +1641,7 @@ describe('BackgroundElementTemplateInstance', () => {
       globalCommitContext.ops = [];
 
       parent.removeChild(child);
+      expect(cleanupOrder).toEqual([]);
       flushPendingRefs();
 
       expect(globalCommitContext.ops).toEqual([
@@ -1579,13 +1649,14 @@ describe('BackgroundElementTemplateInstance', () => {
         parent.instanceId,
         0,
         child.instanceId,
-        [child.instanceId, grandchild.instanceId],
+        [child.instanceId, grandchild.instanceId, sibling.instanceId],
       ]);
       expect(childCleanup).toHaveBeenCalledTimes(1);
       expect(grandchildCleanup).toHaveBeenCalledTimes(1);
       expect(childRef).not.toHaveBeenCalled();
       expect(grandchildSpreadRef).not.toHaveBeenCalled();
       expect(directGrandchildRef).toHaveBeenCalledWith(null);
+      expect(cleanupOrder).toEqual(['child', 'grandchild-direct', 'grandchild-spread', 'sibling']);
     });
 
     it('does not repeat direct function ref cleanup for detached subtrees on destroy', () => {

--- a/packages/react/runtime/__test__/element-template/runtime/background/update/compiled-fixtures.test.tsx
+++ b/packages/react/runtime/__test__/element-template/runtime/background/update/compiled-fixtures.test.tsx
@@ -12,7 +12,6 @@ import {
   resetElementTemplateHydrationListener,
 } from '../../../../../src/element-template/background/hydration-listener.js';
 import {
-  collectElementTemplateSubtreeHandleIds,
   collectMainThreadRefSubtreeHandleIds,
   BackgroundElementTemplateInstance,
 } from '../../../../../src/element-template/background/instance.js';
@@ -37,7 +36,7 @@ import {
 } from '../../../test-utils/debug/compiledThreadRunner.js';
 import { ElementTemplateEnvManager } from '../../../test-utils/debug/envManager.js';
 import { runFixtureTests } from '../../../test-utils/debug/fixtureRunner.js';
-import { serializeBackgroundTree } from '../../../test-utils/debug/serializer.js';
+import { collectBackgroundSubtreeHandleIds, serializeBackgroundTree } from '../../../test-utils/debug/serializer.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -191,7 +190,7 @@ describe('Compiled background Preact updates', () => {
         const host = renderCompiledOnBackground(backgroundModule, ['keep', 'remove']);
         hydrateFromMainThread(mainModule, ['keep', 'remove']);
         const removed = getSlotChildAt(1, host);
-        const removedSubtreeHandleIds = collectElementTemplateSubtreeHandleIds(removed);
+        const removedSubtreeHandleIds = collectBackgroundSubtreeHandleIds(removed);
         updateEvents = [];
 
         vi.useFakeTimers();
@@ -231,7 +230,7 @@ describe('Compiled background Preact updates', () => {
         hydrateFromMainThread(mainModule, ['keep', 'again']);
         const keep = getSlotChildAt(0, host);
         const removed = getSlotChildAt(1, host);
-        const removedSubtreeHandleIds = collectElementTemplateSubtreeHandleIds(removed);
+        const removedSubtreeHandleIds = collectBackgroundSubtreeHandleIds(removed);
         updateEvents = [];
 
         vi.useFakeTimers();

--- a/packages/react/runtime/__test__/element-template/test-utils/debug/serializer.ts
+++ b/packages/react/runtime/__test__/element-template/test-utils/debug/serializer.ts
@@ -2,6 +2,12 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
+import type { BackgroundElementTemplateInstance } from '../../../../src/element-template/background/instance.js';
+
+export function collectBackgroundSubtreeHandleIds(node: BackgroundElementTemplateInstance): number[] {
+  return [node.instanceId, ...node.childNodes.flatMap(collectBackgroundSubtreeHandleIds)];
+}
+
 export function serializeToJSX(element: any, indent: string = ''): string {
   if (!element) return '';
   if (element.type === 'rawText') {

--- a/packages/react/runtime/src/element-template/background/instance.ts
+++ b/packages/react/runtime/src/element-template/background/instance.ts
@@ -158,15 +158,26 @@ export class BackgroundElementTemplateInstance {
     return undefined;
   }
 
-  private markSubtreeDetachedFromMainThread(): void {
+  private detachSubtreeFromMainThread(
+    removedSubtreeHandleIds: number[],
+    checkForMainThreadRefs: boolean,
+  ): boolean {
     if (this.instanceId !== ELEMENT_TEMPLATE_PAGE_HANDLE_ID) {
+      removedSubtreeHandleIds.push(this.instanceId);
       this.isMaterializedOnMainThread = false;
     }
+    this.queueRefCleanup();
+    let hasMainThreadRef = checkForMainThreadRefs && hasMainThreadRefAttrSlot(this.type);
     let child = this.firstChild;
     while (child) {
-      child.markSubtreeDetachedFromMainThread();
+      const childHasMainThreadRef = child.detachSubtreeFromMainThread(
+        removedSubtreeHandleIds,
+        checkForMainThreadRefs && !hasMainThreadRef,
+      );
+      hasMainThreadRef ||= childHasMainThreadRef;
       child = child.nextSibling;
     }
+    return hasMainThreadRef;
   }
 
   releaseDetachedSubtreeFromManager(): void {
@@ -226,15 +237,17 @@ export class BackgroundElementTemplateInstance {
 
   protected cleanupDetachedChildForLifetimeRemoval(
     child: BackgroundElementTemplateInstance,
-    canEmitUpdatePatch: boolean,
-  ): void {
-    if (canEmitUpdatePatch) {
-      child.markSubtreeDetachedFromMainThread();
+    removedSubtreeHandleIds: number[] | null,
+    checkForMainThreadRefs = false,
+  ): boolean {
+    if (removedSubtreeHandleIds) {
+      // Registry cleanup, materialization state, and ref effects share the same
+      // preorder walk. Ref callbacks still run after the remove is dispatched.
+      const hasMainThreadRef = child.detachSubtreeFromMainThread(removedSubtreeHandleIds, checkForMainThreadRefs);
       // The removed JS object graph may outlive the detach until GC, so keep
       // it pending and tear it down on the Snapshot-aligned delayed boundary.
       markRemovedSubtreeForPostDispatchTeardown(child);
-      child.queueRefCleanupForSubtree();
-      return;
+      return hasMainThreadRef;
     }
 
     // Mirrors `shouldQueueRefEffects` in `setAttribute`: pre-hydration
@@ -254,6 +267,7 @@ export class BackgroundElementTemplateInstance {
       // can be released from the background manager without delayed cleanup.
       child.tearDown();
     }
+    return false;
   }
 
   // DOM API for Preact
@@ -354,20 +368,25 @@ export class BackgroundElementTemplateInstance {
       return;
     }
     const canEmitUpdatePatch = this.canEmitUpdatePatch();
-    if (canEmitUpdatePatch) {
+    const removedSubtreeHandleIds: number[] | null = canEmitUpdatePatch ? [] : null;
+    if (removedSubtreeHandleIds) {
       pushOp(
         ElementTemplateUpdateOps.removeNode,
         this.instanceId,
         slotId,
         child.instanceId,
-        collectElementTemplateSubtreeHandleIds(child),
+        removedSubtreeHandleIds,
       );
     }
-    this.cleanupDetachedChildForLifetimeRemoval(child, canEmitUpdatePatch);
+    const removedMainThreadRefs = this.cleanupDetachedChildForLifetimeRemoval(
+      child,
+      removedSubtreeHandleIds,
+      containingListItem !== undefined,
+    );
     if (
       canEmitUpdatePatch
       && containingListItem
-      && collectMainThreadRefSubtreeHandleIds(child) !== null
+      && removedMainThreadRefs
     ) {
       notifyListItemSubtreeUpdated(containingListItem);
     }
@@ -398,7 +417,7 @@ export class BackgroundElementTemplateInstance {
     }
   }
 
-  queueRefCleanupForSubtree(): void {
+  private queueRefCleanup(): void {
     if (this.rawAttributeSlots) {
       queueRefAttributeSlotUpdates(
         this.type,
@@ -408,7 +427,10 @@ export class BackgroundElementTemplateInstance {
         this.getAttributeSlotPlan(),
       );
     }
+  }
 
+  private queueRefCleanupForSubtree(): void {
+    this.queueRefCleanup();
     let child = this.firstChild;
     while (child) {
       child.queueRefCleanupForSubtree();
@@ -705,11 +727,9 @@ export class BackgroundListElementTemplateInstance extends BackgroundTypedElemen
     super.removeChild(child, true);
     if (!silent) {
       const canEmitUpdatePatch = this.canEmitUpdatePatch();
-      const removedSubtreeHandleIds = canEmitUpdatePatch
-        ? collectElementTemplateSubtreeHandleIds(child)
-        : EMPTY_REMOVED_SUBTREE_HANDLE_IDS;
-      this.cleanupDetachedChildForLifetimeRemoval(child, canEmitUpdatePatch);
-      this.emitTypedListItemRemove(child, removedSubtreeHandleIds);
+      const removedSubtreeHandleIds = canEmitUpdatePatch ? [] : null;
+      this.cleanupDetachedChildForLifetimeRemoval(child, removedSubtreeHandleIds);
+      this.emitTypedListItemRemove(child, removedSubtreeHandleIds ?? EMPTY_REMOVED_SUBTREE_HANDLE_IDS);
     }
   }
 
@@ -774,14 +794,6 @@ export function toUpdateTypedListItemCommand(
   };
 }
 
-export function collectElementTemplateSubtreeHandleIds(
-  root: BackgroundElementTemplateInstance,
-): number[] {
-  const handles: number[] = [];
-  collectElementTemplateSubtreeHandleIdsImpl(root, handles);
-  return handles;
-}
-
 export function collectMainThreadRefSubtreeHandleIds(
   root: BackgroundElementTemplateInstance,
 ): number[] | null {
@@ -802,18 +814,4 @@ function collectMainThreadRefSubtreeHandleIdsImpl(
     child = child.nextSibling;
   }
   return handles;
-}
-
-function collectElementTemplateSubtreeHandleIdsImpl(
-  instance: BackgroundElementTemplateInstance,
-  handles: number[],
-): void {
-  if (instance.instanceId !== ELEMENT_TEMPLATE_PAGE_HANDLE_ID) {
-    handles.push(instance.instanceId);
-  }
-  let child = instance.firstChild;
-  while (child) {
-    collectElementTemplateSubtreeHandleIdsImpl(child, handles);
-    child = child.nextSibling;
-  }
 }


### PR DESCRIPTION
Removing a materialized Element Template subtree walks it separately to collect handles, clear materialization state, and queue ordinary ref cleanup. Removal inside a list item also walks the subtree to detect MTRefs.

Perform that work in one preorder traversal shared by ordinary and list-item removal. The walk fills the remove command's handle array, clears materialization state, queues ref cleanup, and checks for MTRefs when list notification needs it. Remove-command ordering, deferred ref publication, delayed manager cleanup, reattachment, and silent moves retain their existing behavior.

This is an internal ET lifecycle optimization with no published API or protocol change, so no changeset is needed.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup when removing element subtrees, including nested and list-based content.
  * Ensured references are cleaned up in the correct order during removals.
  * Preserved accurate node tracking and update notifications when content is removed or re-added.

* **Tests**
  * Added coverage for multiple removal scenarios, including list descendants and missing references.
  * Expanded validation of cleanup behavior for sibling, child, and grandchild nodes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->