### PR TITLE
fix(debug-metadata): name a custom section's artifact after the section

### DIFF
--- a/.changeset/section-keyed-debug-info.md
+++ b/.changeset/section-keyed-debug-info.md
@@ -2,4 +2,4 @@
 "@lynx-js/debug-metadata-rsbuild-plugin": patch
 ---
 
-File each main thread chunk's bytecode debug info under the artifact it was compiled from. A bundle whose main thread code lives in `JsBytecode` custom sections had every unit the encoder produced piled onto its first main thread artifact, keyed by section name, while the other entries got none.
+File each main thread chunk's bytecode debug info under the artifact it was compiled from, and name that artifact after the section carrying it. A bundle whose main thread code lives in `JsBytecode` custom sections had every unit the encoder produced piled onto its first main thread artifact, keyed by section name, while the other entries got none; each artifact was also reported as the file it was assembled from, `<name>.js`, rather than the `<name>` a stack frame carries.

--- a/packages/rspeedy/lynx-bundle-rslib-config/test/external-bundle.test.ts
+++ b/packages/rspeedy/lynx-bundle-rslib-config/test/external-bundle.test.ts
@@ -1218,16 +1218,37 @@ describe('debug metadata', () => {
       rstest.unstubAllEnvs()
     }
 
-    expect(
-      fs.existsSync(
-        path.join(
-          distRoot,
-          '.lynx',
-          'utils-debug-metadata',
-          'debug-metadata.json',
-        ),
-      ),
-    ).toBe(true)
+    const metadataPath = path.join(
+      distRoot,
+      '.lynx',
+      'utils-debug-metadata',
+      'debug-metadata.json',
+    )
+    expect(fs.existsSync(metadataPath)).toBe(true)
+
+    // A devtool looks an artifact up by the name a stack frame carries, which
+    // for a bundle assembled from custom sections is the section name.
+    const metadata = JSON.parse(
+      await fs.promises.readFile(metadataPath, 'utf-8'),
+    ) as {
+      artifacts: {
+        kind: string
+        filename: string
+        path: string
+        tasmSection?: string[]
+      }[]
+    }
+    const mainThreadArtifact = metadata.artifacts.find(a =>
+      a.kind === 'main-thread'
+    )
+    expect(mainThreadArtifact?.tasmSection).toEqual([
+      'customSections',
+      'utils__main-thread',
+    ])
+    expect(mainThreadArtifact?.filename).toBe('utils__main-thread')
+    expect(mainThreadArtifact?.path).toBe(
+      '.lynx/utils-debug-metadata/utils__main-thread.js',
+    )
 
     // The release banner has to sit inside the module wrapper, which is what
     // `lynx.loadScript` takes the section's value from.

--- a/packages/rspeedy/plugin-debug-metadata/src/LynxDebugMetadataPlugin.ts
+++ b/packages/rspeedy/plugin-debug-metadata/src/LynxDebugMetadataPlugin.ts
@@ -275,7 +275,13 @@ export class LynxDebugMetadataPluginImpl {
 
           for (const artifact of metadata.artifacts) {
             const section = readTasmSection(compilation, artifact.path)
-            if (section) artifact.tasmSection = section
+            if (!section) continue
+            artifact.tasmSection = section
+            // A custom section is addressed by its own name, which is the name
+            // a stack frame carries, not the file it was assembled from.
+            if (section[0] === 'customSections' && section[1] !== undefined) {
+              artifact.filename = section[1]
+            }
           }
 
           // The artifact already names the script, so every unit keeps the

--- a/packages/tools/debug-metadata/etc/debug-metadata.api.md
+++ b/packages/tools/debug-metadata/etc/debug-metadata.api.md
@@ -7,7 +7,6 @@
 // @public
 export interface Artifact {
     debugSources: DebugSource[];
-    // (undocumented)
     filename: string;
     kind: 'main-thread' | 'background' | 'css';
     path: string;

--- a/packages/tools/debug-metadata/src/types.ts
+++ b/packages/tools/debug-metadata/src/types.ts
@@ -199,6 +199,10 @@ export interface Artifact {
    * - `css` — extracted CSS chunk (lives in the `css` section).
    */
   kind: 'main-thread' | 'background' | 'css';
+  /**
+   * The name this artifact is addressed by: the emitted file's basename, or
+   * the section name when the bundle carries it as a custom section.
+   */
   filename: string;
   /**
    * Bundler-relative path of the emitted asset itself (e.g.


### PR DESCRIPTION
A bundle that carries its main thread code as a `JsBytecode` custom section, such as `@lynx-js/react-umd`, reported its artifact as the file it was assembled from:

```json
{ "kind": "main-thread", "filename": "ReactLynx__main-thread.js", "tasmSection": ["customSections", "ReactLynx__main-thread"] }
```

A stack frame from that section carries `ReactLynx__main-thread`, and the encoder files its debug info unit under that same name, so `findArtifact` — an exact match on `filename` — found nothing for the name a frame actually carries. The extra `.js` was the only difference.

Name the artifact after the section it is carried as. `path` still points at the emitted file, so nothing loses track of where the asset is.

| | before | after |
| --- | --- | --- |
| `filename` | `ReactLynx__main-thread.js` | `ReactLynx__main-thread` |
| `path` | `.lynx/react-prod/ReactLynx__main-thread.js` | unchanged |

A card is unaffected: its main thread chunk is `lepusCode/root`, not a custom section, and keeps `main-thread.js`. Verified by building `@lynx-js/react-umd` and `examples/react`; the bytecode debug info still attaches to the artifact (652 functions).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Debug metadata now correctly identifies artifacts carried in custom sections, using the section name to associate stack frames with the appropriate source.
  * Main-thread debug information now reports the correct artifact name instead of the assembled JavaScript filename.

* **Documentation**
  * Clarified how artifact filenames and custom section names are represented in debug metadata.
  * Improved documentation for available debug source information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->