### PR TITLE
chore(deps): update github-actions

### DIFF
--- a/.github/workflows/code-scanning.yml
+++ b/.github/workflows/code-scanning.yml
@@ -26,7 +26,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
+        uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           sarif_file: results.sarif
           category: zizmor

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -193,14 +193,14 @@ jobs:
           corepack pnpm turbo build --filter !benchx_cli --filter "!@lynx-js/benchmark-*" --summarize
       - name: Select Changesets mode
         id: changesets
-        uses: changesets/action/select-mode@22ccf9aa43179fe9e27dc62e575971d28cce197c # v2.0.0
+        uses: changesets/action/select-mode@8488615a623b1b9c987934bb89eae8af6a946ac1 # v2.1.1
       - name: Get current date
         if: steps.changesets.outputs.mode == 'version'
         id: date
         run: echo "::set-output name=date::$(date -u +'%Y-%m-%d %H:%M:%S')"
       - name: Version packages
         if: steps.changesets.outputs.mode == 'version'
-        uses: changesets/action/version@22ccf9aa43179fe9e27dc62e575971d28cce197c # v2.0.0
+        uses: changesets/action/version@8488615a623b1b9c987934bb89eae8af6a946ac1 # v2.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -209,12 +209,12 @@ jobs:
       - name: Pack packages
         if: steps.changesets.outputs.mode == 'publish'
         id: pack
-        uses: changesets/action/pack@22ccf9aa43179fe9e27dc62e575971d28cce197c # v2.0.0
+        uses: changesets/action/pack@8488615a623b1b9c987934bb89eae8af6a946ac1 # v2.1.1
         with:
           publish-plan-artifact-id: ${{ steps.changesets.outputs.publish-plan-artifact-id }}
       - name: Publish packages
         if: steps.changesets.outputs.mode == 'publish'
-        uses: changesets/action/publish@22ccf9aa43179fe9e27dc62e575971d28cce197c # v2.0.0
+        uses: changesets/action/publish@8488615a623b1b9c987934bb89eae8af6a946ac1 # v2.1.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           pack-dir-artifact-id: ${{ steps.pack.outputs.pack-dir-artifact-id }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -46,7 +46,7 @@ jobs:
           key: test
           save-if: ${{ github.ref_name == 'main' }}
       - name: Install llvm-cov and nextest
-        uses: taiki-e/install-action@6c6fd71fe4fb72c3697d269963d0e15df8adedad # v2
+        uses: taiki-e/install-action@5b4d68e2e660441203ab128a23676f1e4faf1532 # v2.86.3
         with:
           tool: cargo-llvm-cov,cargo-nextest
       - name: Install runtime dependencies


### PR DESCRIPTION
Bump the pinned action SHAs: `github/codeql-action/upload-sarif` to v4.37.7, `changesets/action` to v2.1.1 and `taiki-e/install-action` to v2.86.3.

The version comments name the exact release each SHA belongs to, which is what `zizmor` checks.

Supersedes #3430, whose merge requests were being dropped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated code-scanning, publishing, and Rust testing workflows to use newer, pinned tool versions.
  * Improved the reliability and consistency of security checks, package publishing, and test execution.
  * No changes to public features or application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->