### PR TITLE
fix(lynx-bundle-rslib-config): wrap main-thread assets by their mark

### DIFF
--- a/.changeset/external-bundle-main-thread-wrapper-mark.md
+++ b/.changeset/external-bundle-main-thread-wrapper-mark.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/lynx-bundle-rslib-config": patch
+---
+
+Wrap the main-thread assets of an external bundle by their `lynx:main-thread` mark instead of a filename pattern derived from the entry name, so an entry named like a path (`./App.js`) keeps its wrapper and no longer fails with `module is not defined`.

--- a/packages/rspeedy/lynx-bundle-rslib-config/src/externalBundleRslibConfig.ts
+++ b/packages/rspeedy/lynx-bundle-rslib-config/src/externalBundleRslibConfig.ts
@@ -810,9 +810,7 @@ const externalBundleRsbuildPlugin = ({
           // dprint-ignore
           chain
           .plugin(MainThreadRuntimeWrapperWebpackPlugin.name)
-          .use(MainThreadRuntimeWrapperWebpackPlugin, [{
-            test: mainThreadEntryName.map((name) => new RegExp(`${escapeRegex(name)}\\.js$`)),
-          }])
+          .use(MainThreadRuntimeWrapperWebpackPlugin)
           .end()
         }
 
@@ -841,5 +839,3 @@ const externalBundleRsbuildPlugin = ({
     )
   },
 })
-
-const escapeRegex = (str: string) => str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')

--- a/packages/rspeedy/lynx-bundle-rslib-config/src/webpack/MainThreadRuntimeWrapperWebpackPlugin.ts
+++ b/packages/rspeedy/lynx-bundle-rslib-config/src/webpack/MainThreadRuntimeWrapperWebpackPlugin.ts
@@ -12,7 +12,7 @@ const PLUGIN_NAME = 'MainThreadRuntimeWrapperWebpackPlugin'
  */
 export interface MainThreadRuntimeWrapperWebpackPluginOptions {
   /**
-   * Include all modules that pass test assertion.
+   * Include the assets marked `lynx:main-thread` that pass test assertion.
    *
    * @defaultValue `/\.js$/`
    *
@@ -31,25 +31,39 @@ export class MainThreadRuntimeWrapperWebpackPlugin {
   ) {}
 
   apply(compiler: Rspack.Compiler): void {
-    const { BannerPlugin } = compiler.webpack
-    new BannerPlugin({
-      test: this.options.test ?? /\.js$/,
-      raw: true,
-      stage: compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_NONE,
-      banner: `(function () {
+    const test = this.options.test ?? /\.js$/
+    const header = `(function () {
   // TODO: remove this after \`useModuleWrapper\` supports MTS
   var globDynamicComponentEntry = '__Card__';
   const module = { exports: {} }
-  const exports = module.exports`,
-    }).apply(compiler)
-    new BannerPlugin({
-      test: this.options.test ?? /\.js$/,
-      raw: true,
-      stage: compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_NONE,
-      banner: `return module.exports
-})()`,
-      footer: true,
-    }).apply(compiler)
+  const exports = module.exports`
+    const footer = `return module.exports
+})()`
+
+    compiler.hooks.thisCompilation.tap(PLUGIN_NAME, (compilation) => {
+      const { ModuleFilenameHelpers, sources: { ConcatSource } } =
+        compiler.webpack
+      compilation.hooks.processAssets.tap(
+        {
+          name: PLUGIN_NAME,
+          stage: compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_NONE,
+        },
+        () => {
+          for (const asset of compilation.getAssets()) {
+            if (!ModuleFilenameHelpers.matchObject({ test }, asset.name)) {
+              continue
+            }
+            if (!asset.info['lynx:main-thread']) {
+              continue
+            }
+            compilation.updateAsset(
+              asset.name,
+              (source) => new ConcatSource(header, '\n', source, '\n', footer),
+            )
+          }
+        },
+      )
+    })
 
     const { RuntimeGlobals, RuntimeModule } = compiler.webpack
     class LoadingConsumerModulesRuntimeModule extends RuntimeModule {

--- a/packages/rspeedy/lynx-bundle-rslib-config/test/external-bundle.test.ts
+++ b/packages/rspeedy/lynx-bundle-rslib-config/test/external-bundle.test.ts
@@ -529,6 +529,41 @@ describe('JsBytecode encoding', () => {
     })
   })
 
+  it('should wrap a main-thread entry named like a path', async () => {
+    const distRoot = path.join(fixtureDir, 'dist', 'utils-path-name')
+    const rslibConfig = defineExternalBundleRslibConfig({
+      source: {
+        entry: {
+          './utils.js': path.join(fixtureDir, 'index.ts'),
+        },
+      },
+      id: 'utils-path-name',
+      output: {
+        distPath: {
+          root: distRoot,
+        },
+      },
+      plugins: [pluginReactLynx()],
+    }, {
+      enableJsBytecode: false,
+    })
+
+    await build(rslibConfig)
+
+    const decodedResult = await decodeTemplate(
+      path.join(distRoot, 'utils-path-name.lynx.bundle'),
+    )
+    const mainThreadSection =
+      decodedResult['custom-sections']['./utils.js__main-thread']
+    expect(mainThreadSection).toBeTypeOf('string')
+    // The wrapper survives minification as an IIFE that returns the module.
+    expect(mainThreadSection).toMatch(/^\(function\s*\(\)\s*\{/)
+    expect(mainThreadSection!.trimEnd()).toMatch(
+      /\}\)\(\);?(\n\/\/# sourceMappingURL=\S*)?$/,
+    )
+    expect(mainThreadSection).toMatch(/\{\s*exports\s*:\s*\{\s*\}\s*\}/)
+  })
+
   it('should not compile main thread chunks to bytecode in development by default', async () => {
     const decodedResult = await buildAndDecode(
       'utils-dev-no-bytecode',


### PR DESCRIPTION
## Problem

`examples/react-externals` fails to load on a device since #3751:

```
QuickContext::Execute() exception!!!
main-thread.js exception: ReferenceError: module is not defined
  at ./App.js__main-thread:19:469
→ Error: Failed to load script ./App.js__main-thread in http://…/comp-lib.lynx.bundle
```

`MainThreadRuntimeWrapperWebpackPlugin` selects the assets to wrap with a regex built from each main-thread entry name, but the asset is emitted under `path.posix.join(intermediateDir, \`${entryName}.js\`)`. For an entry named like a path (`./App.js`, as this example does) the regex keeps the `./` that `path.posix.join` normalizes away:

```
/\.\/App\.js__main-thread\.js$/   vs   .lynx/comp-lib/App.js__main-thread.js   → no match
```

So the main-thread chunk stays unwrapped and nothing defines `module`. Plain entry names (`ReactLynx`, `utils`) match, which is why only this example is affected. Before #3751 the background wrapper happened to cover it.

## Fix

Select the assets by the `lynx:main-thread` mark — the same mark the background wrapper now skips — so both wrappers tell the threads apart the same way regardless of how an entry is named. The `test` option stays as an extra filter with the same default.

## Verification

- Regression test: an entry named `./utils.js` now gets the IIFE wrapper.
- `react-externals` on a Pixel 4 XL, preview mode: `LynxError` 2 → 0, `module is not defined` gone, page renders.
- Bisect: `5637926c5^` clean, `5637926c5` and current main fail, this branch clean.

`react-externals` only has bundle-analysis coverage in CI, so a runtime break there is invisible to it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed external bundle main-thread assets not being wrapped when entry names resemble file paths.
  - Main-thread runtime wrappers are now applied consistently to assets marked for main-thread execution, including path-like entries.
  - Improved reliability of generated external bundles by preserving the expected runtime wrapper and exports structure.

- **Tests**
  - Added coverage confirming path-like entries, such as `./utils.js`, receive the expected runtime wrapper.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->