### PR TITLE
fix(react): export __page from the Element Template internal entry

### DIFF
--- a/.changeset/et-internal-page-export.md
+++ b/.changeset/et-internal-page-export.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react": patch
+---
+
+Export `__page` from the Element Template internal entry, so a development build that imports `@lynx-js/preact-devtools` no longer fails with `export '__page' was not found in '@lynx-js/react/internal'`.

--- a/packages/react/runtime/__test__/element-template/internal/legacy-internal-guardrail.test.ts
+++ b/packages/react/runtime/__test__/element-template/internal/legacy-internal-guardrail.test.ts
@@ -18,6 +18,14 @@ describe('legacy internal guardrail', () => {
     expect('adaptMTRefAttrSlot' in ElementTemplateRuntime).toBe(false);
   });
 
+  it('exposes the page binding preact devtools imports from the internal entry', () => {
+    // `@lynx-js/preact-devtools` imports `__page` from `@lynx-js/react/internal`,
+    // which resolves here under Element Template; a missing export fails the
+    // development build with an ESModulesLinkingError.
+    expect('__page' in ElementTemplateInternal).toBe(true);
+    expect('__page' in ElementTemplateRuntime).toBe(false);
+  });
+
   it('keeps the ET main-thread event loader surface minimal', () => {
     expect(ElementTemplateInternal.loadWorkletRuntime).toBeTypeOf('function');
     expect('loadWorkletRuntime' in ElementTemplateRuntime).toBe(false);

--- a/packages/react/runtime/src/element-template/internal.ts
+++ b/packages/react/runtime/src/element-template/internal.ts
@@ -67,3 +67,4 @@ export {
   adaptSpreadAttrSlot,
 } from './runtime/template/attr-slot-plan.js';
 export { __ElementTemplatePage } from './runtime/page/authored-page.js';
+export { __page } from './runtime/page/page.js';


### PR DESCRIPTION
Closes #3394.

## Problem

`@lynx-js/preact-devtools` (`react-lynx/setup.js`) imports `__page` from `@lynx-js/react/internal`. Under Element Template that specifier is aliased to `@lynx-js/react/element-template/internal`, which never exported `__page`, so a development build of any Element Template consumer that imports the devtools fails to link:

```
cd examples/react-et-lazy-bundle-standalone
pnpm exec rspeedy build --config lynx.config.consumer.js --mode development

ESModulesLinkingError: export '__page' (imported as '__page') was not found in '@lynx-js/react/internal'
```

The devtools only touch `__page` at runtime behind `lynx.preactDevtoolsCtx.__DEBUG__`, so nothing eliminates the import and the build stops. `rspeedy dev` then keeps serving whatever `dist-consumer/` already holds, which is how this surfaces on a device as `TypeError: getUniqueIdListBySnapshotId is not a function` (details on the issue).

## Fix

Export the Element Template page binding (`element-template/runtime/page/page.ts`) from the internal entry under the same name the snapshot entry uses.

## Verification

- Guardrail test asserts the internal entry exposes `__page` and the public entry does not.
- `test:et`: 78 files, 803 tests pass.
- The repro command above now builds `dist-consumer/main.lynx.bundle`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed development build failures involving `@lynx-js/preact-devtools` by making the internal `__page` export available through the expected entry point.
  - Kept `__page` unavailable from the public Element Template runtime entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->