### PR TITLE
fix(react): provide the devtools lepus methods on the Element Template main thread

### DIFF
--- a/.changeset/et-devtools-lepus-methods.md
+++ b/.changeset/et-devtools-lepus-methods.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react": patch
+---
+
+Provide `getUniqueIdListBySnapshotId` and `getSnapshotIdByUniqueId` on the Element Template main thread when devtools are enabled, so `@lynx-js/preact-devtools` no longer fails with `getUniqueIdListBySnapshotId is not a function`.

--- a/packages/react/runtime/__test__/element-template/native/index.test.ts
+++ b/packages/react/runtime/__test__/element-template/native/index.test.ts
@@ -41,6 +41,7 @@ describe('element-template native index wiring', () => {
     globalThis.__ALOG_ELEMENT_API__ = true;
 
     const injectCalledByNative = vi.fn();
+    const injectLepusMethods = vi.fn();
     const installElementTemplatePatchListener = vi.fn();
     const installOnMtsDestruction = vi.fn();
     const initElementTemplatePAPICallAlog = vi.fn();
@@ -55,6 +56,7 @@ describe('element-template native index wiring', () => {
 
     vi.doMock('../../../src/element-template/native/main-thread-api.js', () => ({
       injectCalledByNative,
+      injectLepusMethods,
     }));
     vi.doMock('../../../src/element-template/native/patch-listener.js', () => ({
       installElementTemplatePatchListener,
@@ -98,6 +100,7 @@ describe('element-template native index wiring', () => {
 
     expect(initElementTemplatePAPICallAlog).toHaveBeenCalledTimes(1);
     expect(injectCalledByNative).toHaveBeenCalledTimes(1);
+    expect(injectLepusMethods).toHaveBeenCalledTimes(1);
     expect(installElementTemplatePatchListener).toHaveBeenCalledTimes(1);
     expect(installOnMtsDestruction).toHaveBeenCalledTimes(1);
     expect(initProfileHook).toHaveBeenCalledTimes(1);
@@ -116,6 +119,7 @@ describe('element-template native index wiring', () => {
     globalThis.lynx.performance.isProfileRecording = vi.fn(() => true);
 
     const injectCalledByNative = vi.fn();
+    const injectLepusMethods = vi.fn();
     const installElementTemplatePatchListener = vi.fn();
     const installOnMtsDestruction = vi.fn();
     const installElementTemplateCommitHook = vi.fn();
@@ -143,6 +147,7 @@ describe('element-template native index wiring', () => {
 
     vi.doMock('../../../src/element-template/native/main-thread-api.js', () => ({
       injectCalledByNative,
+      injectLepusMethods,
     }));
     vi.doMock('../../../src/element-template/native/patch-listener.js', () => ({
       installElementTemplatePatchListener,
@@ -218,6 +223,7 @@ describe('element-template native index wiring', () => {
     );
 
     expect(injectCalledByNative).not.toHaveBeenCalled();
+    expect(injectLepusMethods).not.toHaveBeenCalled();
     expect(installElementTemplatePatchListener).not.toHaveBeenCalled();
     expect(installOnMtsDestruction).not.toHaveBeenCalled();
   });

--- a/packages/react/runtime/__test__/element-template/native/lepus-methods.test.ts
+++ b/packages/react/runtime/__test__/element-template/native/lepus-methods.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { BackgroundElementTemplateInstance } from '../../../src/element-template/background/instance.js';
+import { injectLepusMethods } from '../../../src/element-template/native/main-thread-api.js';
+import { elementTemplateRegistry } from '../../../src/element-template/runtime/template/registry.js';
+
+interface FakeRef {
+  uid: number;
+}
+
+type LepusMethods = typeof globalThis & {
+  getUniqueIdListBySnapshotId: (args: { snapshotId: number }) => { uniqueIdList: number[] } | null;
+  getSnapshotIdByUniqueId: (args: { uniqueId: number }) => { snapshotId: number } | null;
+};
+
+describe('injectLepusMethods', () => {
+  beforeEach(() => {
+    vi.stubGlobal('__GetElementUniqueID', (ref: FakeRef) => ref.uid);
+    elementTemplateRegistry.set(-1, { uid: 101 } as unknown as ElementRef);
+    elementTemplateRegistry.set(7, { uid: 707 } as unknown as ElementRef);
+    injectLepusMethods();
+  });
+
+  afterEach(() => {
+    elementTemplateRegistry.clear();
+    vi.unstubAllGlobals();
+  });
+
+  it('maps a handle id to the unique id of its element', () => {
+    const g = globalThis as LepusMethods;
+    expect(g.getUniqueIdListBySnapshotId({ snapshotId: -1 })).toEqual({ uniqueIdList: [101] });
+    expect(g.getUniqueIdListBySnapshotId({ snapshotId: 7 })).toEqual({ uniqueIdList: [707] });
+  });
+
+  it('returns null for an unknown or missing handle id', () => {
+    const g = globalThis as LepusMethods;
+    expect(g.getUniqueIdListBySnapshotId({ snapshotId: 42 })).toBeNull();
+    expect(g.getUniqueIdListBySnapshotId({} as { snapshotId: number })).toBeNull();
+  });
+
+  it('maps a unique id back to its handle id', () => {
+    const g = globalThis as LepusMethods;
+    expect(g.getSnapshotIdByUniqueId({ uniqueId: 707 })).toEqual({ snapshotId: 7 });
+    expect(g.getSnapshotIdByUniqueId({ uniqueId: 101 })).toEqual({ snapshotId: -1 });
+    expect(g.getSnapshotIdByUniqueId({ uniqueId: 999 })).toBeNull();
+  });
+
+  it('exposes the instance id as __id for devtools', () => {
+    const instance = new BackgroundElementTemplateInstance('view');
+    instance.instanceId = 12;
+    expect(instance.__id).toBe(12);
+  });
+});

--- a/packages/react/runtime/src/element-template/background/instance.ts
+++ b/packages/react/runtime/src/element-template/background/instance.ts
@@ -52,6 +52,11 @@ const EMPTY_REMOVED_SUBTREE_HANDLE_IDS: number[] = [];
 
 export class BackgroundElementTemplateInstance {
   public instanceId: number = 0; // Assigned by manager
+
+  // `@lynx-js/preact-devtools` keys an instance by `__id`, as it does a `SnapshotInstance`.
+  get __id(): number {
+    return this.instanceId;
+  }
   public type: string;
 
   public parent: BackgroundElementTemplateInstance | null = null;

--- a/packages/react/runtime/src/element-template/native/index.ts
+++ b/packages/react/runtime/src/element-template/native/index.ts
@@ -6,7 +6,7 @@ import type { ComponentChild, ContainerNode, VNode } from 'preact';
 import { render } from 'preact';
 
 import { callDestroyLifetimeFun } from './callDestroyLifetimeFun.js';
-import { injectCalledByNative } from './main-thread-api.js';
+import { injectCalledByNative, injectLepusMethods } from './main-thread-api.js';
 import { installOnMtsDestruction } from './mts-destroy.js';
 import { installElementTemplatePatchListener } from './patch-listener.js';
 import { reloadBackground } from './reload-background.js';
@@ -55,6 +55,9 @@ function init(): void {
   if (__MAIN_THREAD__) {
     installMainThreadHooks();
     injectCalledByNative();
+    if (__DEV__ || (typeof __REACT_DEVTOOL__ !== 'undefined' && __REACT_DEVTOOL__)) {
+      injectLepusMethods();
+    }
     installElementTemplatePatchListener();
     installOnMtsDestruction();
     if (__PROFILE__) {

--- a/packages/react/runtime/src/element-template/native/main-thread-api.ts
+++ b/packages/react/runtime/src/element-template/native/main-thread-api.ts
@@ -6,6 +6,7 @@ import { reloadMainThread } from './reload-main-thread.js';
 import { applyUpdatePageData } from '../../core/lynx-page-data.js';
 import { __page, createElementTemplatePage, setupPage } from '../runtime/page/page.js';
 import { renderMainThread } from '../runtime/render/render-main-thread.js';
+import { forEachElementTemplateNativeRef, getElementTemplateTargetNativeRef } from '../runtime/template/registry.js';
 
 function injectCalledByNative(): void {
   const calledByNative: LynxCallByNative = {
@@ -49,7 +50,37 @@ function updateGlobalProps(_data: unknown, options?: UpdatePageOption): void {
   }
 }
 
+// The lepus methods `@lynx-js/preact-devtools` calls to map an instance to
+// its elements; the snapshot runtime injects the same pair.
+function injectLepusMethods(): void {
+  Object.assign(globalThis, {
+    getUniqueIdListBySnapshotId,
+    getSnapshotIdByUniqueId,
+  });
+}
+
+function getUniqueIdListBySnapshotId({ snapshotId }: { snapshotId: number }) {
+  if (typeof snapshotId !== 'number') {
+    return null;
+  }
+  const nativeRef = getElementTemplateTargetNativeRef(snapshotId);
+  if (nativeRef == null) {
+    return null;
+  }
+  return { uniqueIdList: [__GetElementUniqueID(nativeRef)] };
+}
+
+function getSnapshotIdByUniqueId({ uniqueId }: { uniqueId: number }) {
+  let snapshotId: number | null = null;
+  forEachElementTemplateNativeRef((id, nativeRef) => {
+    if (snapshotId === null && __GetElementUniqueID(nativeRef) === uniqueId) {
+      snapshotId = id;
+    }
+  });
+  return snapshotId === null ? null : { snapshotId };
+}
+
 /**
  * @internal
  */
-export { injectCalledByNative };
+export { injectCalledByNative, injectLepusMethods };

--- a/packages/react/runtime/src/element-template/runtime/template/registry.ts
+++ b/packages/react/runtime/src/element-template/runtime/template/registry.ts
@@ -46,6 +46,20 @@ export function deleteElementTemplateNativeRef(id: number): void {
   otherRefs.delete(id);
 }
 
+export function forEachElementTemplateNativeRef(
+  callback: (id: number, nativeRef: ElementRef) => void,
+): void {
+  for (let index = 0; index < negativeRefs.length; index++) {
+    const nativeRef = negativeRefs[index];
+    if (nativeRef !== undefined) {
+      callback(-index - 1, nativeRef);
+    }
+  }
+  for (const [id, nativeRef] of otherRefs) {
+    callback(id, nativeRef);
+  }
+}
+
 export function clearElementTemplateNativeRefRegistry(): void {
   negativeRefs.length = 0;
   otherRefs.clear();


### PR DESCRIPTION
Follow-up to #3808 (which makes the development build link); this makes the devtools work at runtime under Element Template.

## Problem

`@lynx-js/preact-devtools` maps each instance to the elements it owns by calling two lepus methods on the main thread, `getUniqueIdListBySnapshotId` and `getSnapshotIdByUniqueId`. The snapshot runtime injects both in `lynx.ts` whenever devtools are enabled; the Element Template runtime has its own main-thread bootstrap (`element-template/native`) and never did, so on a device every mapping call fails:

```
main-thread.js exception: TypeError: getUniqueIdListBySnapshotId is not a function
error_code:1101 sub_code:110100
```

`examples/react-et-lazy-bundle-standalone` in `rspeedy dev` shows ~30 of these on a single load (Pixel 4 XL, LynxExplorer built from lynx `develop` today). The devtools also derive the id they pass from `vnode.__e.__id`, which an Element Template instance did not expose.

## Fix

- Inject both methods on the Element Template main thread under the same `__DEV__ || __REACT_DEVTOOL__` gate as the snapshot runtime, resolving ids through the Element Template handle registry (`getElementTemplateTargetNativeRef` / a new `forEachElementTemplateNativeRef`).
- Expose `instanceId` as `__id` on `BackgroundElementTemplateInstance`, the name the devtools already use for a `SnapshotInstance`.

## Verification

- New unit tests cover the id → unique id mapping, the reverse lookup, null for unknown or missing ids, and `__id`.
- The native wiring test asserts the injection runs on the main thread only.
- `test:et`: 79 files, 806 tests pass.