### PR TITLE
fix(react): expose the Element Template instance mapping to preact devtools

### DIFF
--- a/.changeset/et-devtools-instance-bridge.md
+++ b/.changeset/et-devtools-instance-bridge.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react": patch
+---
+
+Expose the Element Template instance ↔ element mapping `@lynx-js/preact-devtools` needs: the main thread provides `getUniqueIdListByElementTemplateHandleId`, and the background thread emits `onBackgroundElementTemplateInstanceUpdateId` when an instance is re-keyed on hydration, so element highlight/selection works on Element Template pages.

--- a/packages/react/runtime/__test__/element-template/native/index.test.ts
+++ b/packages/react/runtime/__test__/element-template/native/index.test.ts
@@ -4,6 +4,52 @@ import { ElementTemplateEnvManager } from '../test-utils/debug/envManager.js';
 
 const envManager = new ElementTemplateEnvManager();
 
+function mockMainThreadWiring() {
+  const injectLepusMethods = vi.fn();
+  vi.doMock('../../../src/element-template/native/main-thread-api.js', () => ({
+    injectCalledByNative: vi.fn(),
+    injectLepusMethods,
+  }));
+  vi.doMock('../../../src/element-template/native/patch-listener.js', () => ({
+    installElementTemplatePatchListener: vi.fn(),
+  }));
+  vi.doMock('../../../src/element-template/native/mts-destroy.js', () => ({
+    installOnMtsDestruction: vi.fn(),
+  }));
+  vi.doMock('../../../src/element-template/debug/elementPAPICall.js', () => ({
+    initElementTemplatePAPICallAlog: vi.fn(),
+  }));
+  vi.doMock('../../../src/element-template/debug/profile.js', () => ({
+    initProfileHook: vi.fn(),
+  }));
+  vi.doMock('../../../src/element-template/lynx/env.js', () => ({
+    setupLynxEnv: vi.fn(),
+  }));
+  vi.doMock('../../../src/element-template/background/commit-hook.js', () => ({
+    installElementTemplateCommitHook: vi.fn(),
+  }));
+  vi.doMock('../../../src/element-template/background/document.js', () => ({
+    setupBackgroundElementTemplateDocument: vi.fn(),
+  }));
+  vi.doMock('../../../src/element-template/background/hydration-listener.js', () => ({
+    installElementTemplateHydrationListener: vi.fn(),
+  }));
+  vi.doMock('../../../src/element-template/runtime/page/root-instance.js', () => ({
+    setRoot: vi.fn(),
+  }));
+  vi.doMock('../../../src/element-template/lynx/performance.js', () => ({
+    initTimingAPI: vi.fn(),
+  }));
+  vi.doMock('../../../src/element-template/background/instance.js', () => ({
+    BackgroundElementTemplateInstance: class BackgroundElementTemplateInstance {},
+    BackgroundPageRootInstance: class BackgroundPageRootInstance {},
+  }));
+  vi.doMock('../../../src/element-template/native/reload-background.js', () => ({
+    reloadBackground: vi.fn(),
+  }));
+  return { injectLepusMethods };
+}
+
 describe('element-template native index wiring', () => {
   const originalNodeEnv = process.env['NODE_ENV'];
 
@@ -41,6 +87,7 @@ describe('element-template native index wiring', () => {
     globalThis.__ALOG_ELEMENT_API__ = true;
 
     const injectCalledByNative = vi.fn();
+    const injectLepusMethods = vi.fn();
     const installElementTemplatePatchListener = vi.fn();
     const installOnMtsDestruction = vi.fn();
     const initElementTemplatePAPICallAlog = vi.fn();
@@ -55,6 +102,7 @@ describe('element-template native index wiring', () => {
 
     vi.doMock('../../../src/element-template/native/main-thread-api.js', () => ({
       injectCalledByNative,
+      injectLepusMethods,
     }));
     vi.doMock('../../../src/element-template/native/patch-listener.js', () => ({
       installElementTemplatePatchListener,
@@ -98,6 +146,7 @@ describe('element-template native index wiring', () => {
 
     expect(initElementTemplatePAPICallAlog).toHaveBeenCalledTimes(1);
     expect(injectCalledByNative).toHaveBeenCalledTimes(1);
+    expect(injectLepusMethods).toHaveBeenCalledTimes(1);
     expect(installElementTemplatePatchListener).toHaveBeenCalledTimes(1);
     expect(installOnMtsDestruction).toHaveBeenCalledTimes(1);
     expect(initProfileHook).toHaveBeenCalledTimes(1);
@@ -110,12 +159,30 @@ describe('element-template native index wiring', () => {
     expect(initTimingAPI).not.toHaveBeenCalled();
   });
 
+  it('injects the devtools lepus methods outside development only when REACT_DEVTOOL is enabled', async () => {
+    envManager.resetEnv('main');
+    const { injectLepusMethods } = mockMainThreadWiring();
+    vi.stubGlobal('__DEV__', false);
+    try {
+      await import('../../../src/element-template/native/index.js');
+      expect(injectLepusMethods).not.toHaveBeenCalled();
+
+      vi.resetModules();
+      vi.stubGlobal('__REACT_DEVTOOL__', true);
+      await import('../../../src/element-template/native/index.js');
+      expect(injectLepusMethods).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
   it('installs background wiring only on background thread', async () => {
     envManager.resetEnv('background');
     process.env['NODE_ENV'] = 'production';
     globalThis.lynx.performance.isProfileRecording = vi.fn(() => true);
 
     const injectCalledByNative = vi.fn();
+    const injectLepusMethods = vi.fn();
     const installElementTemplatePatchListener = vi.fn();
     const installOnMtsDestruction = vi.fn();
     const installElementTemplateCommitHook = vi.fn();
@@ -143,6 +210,7 @@ describe('element-template native index wiring', () => {
 
     vi.doMock('../../../src/element-template/native/main-thread-api.js', () => ({
       injectCalledByNative,
+      injectLepusMethods,
     }));
     vi.doMock('../../../src/element-template/native/patch-listener.js', () => ({
       installElementTemplatePatchListener,
@@ -218,6 +286,7 @@ describe('element-template native index wiring', () => {
     );
 
     expect(injectCalledByNative).not.toHaveBeenCalled();
+    expect(injectLepusMethods).not.toHaveBeenCalled();
     expect(installElementTemplatePatchListener).not.toHaveBeenCalled();
     expect(installOnMtsDestruction).not.toHaveBeenCalled();
   });

--- a/packages/react/runtime/__test__/element-template/native/lepus-methods.test.ts
+++ b/packages/react/runtime/__test__/element-template/native/lepus-methods.test.ts
@@ -1,0 +1,43 @@
+// Copyright 2025 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { injectLepusMethods } from '../../../src/element-template/native/main-thread-api.js';
+import { __page } from '../../../src/element-template/runtime/page/page.js';
+import { elementTemplateRegistry } from '../../../src/element-template/runtime/template/registry.js';
+
+interface FakeRef {
+  uid: number;
+}
+
+type LepusMethods = typeof globalThis & {
+  getUniqueIdListByElementTemplateHandleId: (args: { handleId: number }) => { uniqueIdList: number[] } | null;
+};
+
+describe('injectLepusMethods', () => {
+  beforeEach(() => {
+    vi.stubGlobal('__GetElementUniqueID', (ref: FakeRef | typeof __page) => ref === __page ? 1 : (ref as FakeRef).uid);
+    elementTemplateRegistry.set(-1, { uid: 101 } as unknown as ElementRef);
+    elementTemplateRegistry.set(7, { uid: 707 } as unknown as ElementRef);
+    injectLepusMethods();
+  });
+
+  afterEach(() => {
+    elementTemplateRegistry.clear();
+    vi.unstubAllGlobals();
+  });
+
+  it('maps a handle id to the unique id of its element', () => {
+    const g = globalThis as LepusMethods;
+    expect(g.getUniqueIdListByElementTemplateHandleId({ handleId: -1 })).toEqual({ uniqueIdList: [101] });
+    expect(g.getUniqueIdListByElementTemplateHandleId({ handleId: 7 })).toEqual({ uniqueIdList: [707] });
+  });
+
+  it('returns null for an unknown or missing handle id', () => {
+    const g = globalThis as LepusMethods;
+    expect(g.getUniqueIdListByElementTemplateHandleId({ handleId: 42 })).toBeNull();
+    expect(g.getUniqueIdListByElementTemplateHandleId({} as { handleId: number })).toBeNull();
+  });
+});

--- a/packages/react/runtime/__test__/element-template/runtime/background/manager.test.ts
+++ b/packages/react/runtime/__test__/element-template/runtime/background/manager.test.ts
@@ -2,7 +2,7 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   BackgroundElementTemplateInstance,
   BackgroundPageRootInstance,
@@ -138,5 +138,41 @@ describe('BackgroundElementTemplateInstanceManager', () => {
     backgroundElementTemplateInstanceManager.clear();
     expect(backgroundElementTemplateInstanceManager.get(instance.instanceId)).toBeUndefined();
     expect(backgroundElementTemplateInstanceManager.values.size).toBe(0);
+  });
+
+  it('announces a re-keyed instance to devtools through GlobalEventEmitter', () => {
+    const emit = vi.fn();
+    const getJSModule = vi.spyOn(lynx, 'getJSModule').mockReturnValue({ emit } as never);
+    try {
+      const instance = new BackgroundElementTemplateInstance('view');
+      const oldId = instance.instanceId;
+
+      backgroundElementTemplateInstanceManager.updateId(oldId, -5);
+
+      expect(getJSModule).toHaveBeenCalledWith('GlobalEventEmitter');
+      expect(emit).toHaveBeenCalledWith('onBackgroundElementTemplateInstanceUpdateId', [{ oldId, newId: -5 }]);
+    } finally {
+      getJSModule.mockRestore();
+    }
+  });
+
+  it('only announces re-keyed instances outside development when REACT_DEVTOOL is enabled', () => {
+    const emit = vi.fn();
+    const getJSModule = vi.spyOn(lynx, 'getJSModule').mockReturnValue({ emit } as never);
+    vi.stubGlobal('__DEV__', false);
+    try {
+      const silent = new BackgroundElementTemplateInstance('view');
+      backgroundElementTemplateInstanceManager.updateId(silent.instanceId, -6);
+      expect(emit).not.toHaveBeenCalled();
+
+      vi.stubGlobal('__REACT_DEVTOOL__', true);
+      const announced = new BackgroundElementTemplateInstance('view');
+      const oldId = announced.instanceId;
+      backgroundElementTemplateInstanceManager.updateId(oldId, -7);
+      expect(emit).toHaveBeenCalledWith('onBackgroundElementTemplateInstanceUpdateId', [{ oldId, newId: -7 }]);
+    } finally {
+      vi.unstubAllGlobals();
+      getJSModule.mockRestore();
+    }
   });
 });

--- a/packages/react/runtime/__test__/element-template/test-utils/mock/globals.js
+++ b/packages/react/runtime/__test__/element-template/test-utils/mock/globals.js
@@ -26,6 +26,13 @@ export function injectGlobals() {
 
   installPerformanceGlobals();
   globalThis.lynx.getApp = () => lynxApp;
+  const globalEventEmitter = {
+    emit: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    removeAllListeners: vi.fn(),
+  };
+  globalThis.lynx.getJSModule = (name) => name === 'GlobalEventEmitter' ? globalEventEmitter : undefined;
 
   globalThis.requestAnimationFrame = setTimeout;
   globalThis.cancelAnimationFrame = clearTimeout;

--- a/packages/react/runtime/src/element-template/background/manager.ts
+++ b/packages/react/runtime/src/element-template/background/manager.ts
@@ -52,8 +52,12 @@ export const backgroundElementTemplateInstanceManager: {
     instance.instanceId = newId;
     this.values.set(newId, instance);
 
-    // DevTools event emission can be added here later
-    // if (__DEV__) { ... }
+    // `@lynx-js/preact-devtools` keys the instance by this id and re-keys it here.
+    if (__DEV__ || (typeof __REACT_DEVTOOL__ !== 'undefined' && __REACT_DEVTOOL__)) {
+      lynx.getJSModule('GlobalEventEmitter').emit('onBackgroundElementTemplateInstanceUpdateId', [
+        { oldId, newId },
+      ]);
+    }
   },
 
   get(id: number): BackgroundElementTemplateInstance | undefined {

--- a/packages/react/runtime/src/element-template/native/index.ts
+++ b/packages/react/runtime/src/element-template/native/index.ts
@@ -6,7 +6,7 @@ import type { ComponentChild, ContainerNode, VNode } from 'preact';
 import { render } from 'preact';
 
 import { callDestroyLifetimeFun } from './callDestroyLifetimeFun.js';
-import { injectCalledByNative } from './main-thread-api.js';
+import { injectCalledByNative, injectLepusMethods } from './main-thread-api.js';
 import { installOnMtsDestruction } from './mts-destroy.js';
 import { installElementTemplatePatchListener } from './patch-listener.js';
 import { reloadBackground } from './reload-background.js';
@@ -55,6 +55,9 @@ function init(): void {
   if (__MAIN_THREAD__) {
     installMainThreadHooks();
     injectCalledByNative();
+    if (__DEV__ || (typeof __REACT_DEVTOOL__ !== 'undefined' && __REACT_DEVTOOL__)) {
+      injectLepusMethods();
+    }
     installElementTemplatePatchListener();
     installOnMtsDestruction();
     if (__PROFILE__) {

--- a/packages/react/runtime/src/element-template/native/main-thread-api.ts
+++ b/packages/react/runtime/src/element-template/native/main-thread-api.ts
@@ -6,6 +6,7 @@ import { reloadMainThread } from './reload-main-thread.js';
 import { applyUpdatePageData } from '../../core/lynx-page-data.js';
 import { __page, createElementTemplatePage, setupPage } from '../runtime/page/page.js';
 import { renderMainThread } from '../runtime/render/render-main-thread.js';
+import { getElementTemplateTargetNativeRef } from '../runtime/template/registry.js';
 
 function injectCalledByNative(): void {
   const calledByNative: LynxCallByNative = {
@@ -50,6 +51,27 @@ function updateGlobalProps(_data: unknown, options?: UpdatePageOption): void {
 }
 
 /**
+ * `@lynx-js/preact-devtools` maps a background instance to its element through
+ * this method, keyed by the handle id shared with the main thread.
+ */
+function injectLepusMethods(): void {
+  Object.assign(globalThis, {
+    getUniqueIdListByElementTemplateHandleId,
+  });
+}
+
+function getUniqueIdListByElementTemplateHandleId({ handleId }: { handleId: number }) {
+  if (typeof handleId !== 'number') {
+    return null;
+  }
+  const nativeRef = getElementTemplateTargetNativeRef(handleId);
+  if (nativeRef == null) {
+    return null;
+  }
+  return { uniqueIdList: [__GetElementUniqueID(nativeRef)] };
+}
+
+/**
  * @internal
  */
-export { injectCalledByNative };
+export { injectCalledByNative, injectLepusMethods };


### PR DESCRIPTION
`@lynx-js/preact-devtools` maps a background instance to its elements to highlight and select them. The snapshot runtime serves that through `getUniqueIdListBySnapshotId` on the main thread and re-keys instances with `onBackgroundSnapshotInstanceUpdateId`; the Element Template runtime provided neither, so every mapping call failed on Element Template pages:

```
main-thread.js exception: TypeError: getUniqueIdListBySnapshotId is not a function
```

This provides the Element Template counterparts, keyed by the handle id shared between the two threads:

- main thread: `getUniqueIdListByElementTemplateHandleId({ handleId })`, resolved through the handle registry, injected under the same `__DEV__ || __REACT_DEVTOOL__` gate as the snapshot runtime
- background: `onBackgroundElementTemplateInstanceUpdateId` emitted when hydration re-keys an instance

The devtools side that consumes this contract is lynx-family/preact-devtools#21.

Verified on device (LynxExplorer built from lynx `develop`) with `examples/react-element-template` in `rspeedy dev`, `@lynx-js/preact-devtools` from the pkg.pr.new preview of that PR, and `import '@lynx-js/preact-devtools'` enabled: the devtools resolve every instance through the new method (no main-thread exceptions), and conditional children keep mapping correctly across re-renders.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved developer-tool support for Element Template pages, including more reliable element highlighting and selection.
  * Added synchronization for Element Template instance ID changes during hydration.
  * Added mapping support between Element Template handles and element unique IDs.
  * These improvements are available when React DevTools support is enabled.

* **Bug Fixes**
  * Corrected element identification when instances are re-keyed during hydration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->