### PR TITLE
fix(examples): stop the standalone lazy-bundle builds from rebuilding sibling examples

### DIFF
--- a/examples/react-et-lazy-bundle-standalone/package.json
+++ b/examples/react-et-lazy-bundle-standalone/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "pnpm run --parallel \"/^build:(producer|consumer)$/\"",
+    "build": "pnpm run build:producer && pnpm run build:consumer",
     "build:consumer": "rspeedy build --config lynx.config.consumer.js",
     "build:producer": "rspeedy build --config lynx.config.producer.js",
     "dev": "node scripts/serve.mjs dev",

--- a/examples/react-lazy-bundle-standalone/package.json
+++ b/examples/react-lazy-bundle-standalone/package.json
@@ -8,7 +8,7 @@
     "build:consumer": "rspeedy build --config lynx.config.consumer.js",
     "build:fetchbundle": "cross-env LAZY_BUNDLE_FETCHBUNDLE=1 pnpm run build:querycomponent",
     "build:producer": "rspeedy build --config lynx.config.producer.js",
-    "build:querycomponent": "pnpm run --parallel \"/^build:(producer|consumer)$/\"",
+    "build:querycomponent": "pnpm run build:producer && pnpm run build:consumer",
     "dev": "node scripts/serve.mjs dev",
     "dev:consumer": "rspeedy dev --config lynx.config.consumer.js",
     "dev:fetchbundle": "cross-env LAZY_BUNDLE_FETCHBUNDLE=1 node scripts/serve.mjs dev",


### PR DESCRIPTION
`pnpm run --parallel <pattern>` is a recursive command. Run from `examples/react-et-lazy-bundle-standalone` (and `react-lazy-bundle-standalone`'s `build:querycomponent`) it matches every workspace package that has `build:producer` / `build:consumer` scripts:

```
Scope: 98 of 99 workspace projects
../react-debug-metadata build:consumer$ ...
../react-debug-metadata build:producer$ ...
. build:consumer$ ...
. build:producer$ ...
../react-lazy-bundle-standalone build:consumer$ ...
../react-lazy-bundle-standalone build:producer$ ...
```

So one turbo task also rebuilt `react-debug-metadata` and `react-lazy-bundle-standalone` while turbo was building them in their own tasks. The concurrent builds race on the same `dist-*` directories and fail intermittently, e.g. on `main` in https://github.com/lynx-family/lynx-stack/actions/runs/33882136574 (Build (Windows)):

```
../react-debug-metadata build:producer: error × Rspack FS Error: IO error: Error: ENOENT: no such file or directory, open '...\react-debug-metadata\dist-consumer\.lynx\main\background.<hash>.js'
 Failed:    @lynx-js/example-react-et-lazy-bundle-standalone#build
```

This runs the two scripts of the current package sequentially instead. The consumer config only reads the producer's host and port (`demo-ports.js`), not its output, so the order does not matter for correctness.

Verified locally with `pnpm turbo build --force` over the three examples twice: 20/20 tasks succeed each round.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated example build workflows to run producer builds before consumer builds, improving build sequencing and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Reproduced locally with the original scripts (same three examples, `pnpm turbo build --force`, three rounds): round 1 failed, rounds 2 and 3 passed.

```
@lynx-js/example-react-debug-metadata:build:   rsbuild 10:12:46 Error: ENOENT: no such file or directory, unlink '.../react-debug-metadata/dist-consumer/...'
@lynx-js/example-react-debug-metadata:build:   rsbuild 10:12:46 Error: ENOENT: no such file or directory, rmdir '.../react-debug-metadata/dist-consumer/...'
 Tasks:    17 successful, 20 total
Failed:    @lynx-js/example-react-debug-metadata#build
```