### PR TITLE
feat(rsbuild-plugin): build an external bundle without a DSL plugin

### DIFF
--- a/.changeset/plain-external-bundle-engine.md
+++ b/.changeset/plain-external-bundle-engine.md
@@ -1,0 +1,6 @@
+---
+"@lynx-js/lynx-bundle-rslib-config": patch
+"@lynx-js/rsbuild-plugin": patch
+---
+
+Build an external bundle without a DSL plugin using `pluginLynx` alone. It now registers the runtime wrapper and the encoder a bundle needs to be loadable, and `defineExternalBundleRslibConfig` falls back to its own exported `LAYERS` when no DSL exposes them.

--- a/examples/react-externals/lynx.config.ts
+++ b/examples/react-externals/lynx.config.ts
@@ -48,6 +48,12 @@ export default defineConfig({
         : { reactlynx: true },
       externals: {
         './App.js': 'comp-lib.lynx.bundle',
+        './utils.js': {
+          bundlePath: 'utils.lynx.bundle',
+          libraryName: './utils.js',
+          background: { sectionPath: './utils.js' },
+          async: true,
+        },
       },
       globalObject: 'globalThis',
     }),

--- a/examples/react-externals/package.json
+++ b/examples/react-externals/package.json
@@ -4,11 +4,12 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "pnpm run build:comp-lib && rspeedy build && cross-env REACTLYNX_ASYNC=true pnpm run build:comp-lib && cross-env REACTLYNX_ASYNC=true rspeedy build",
+    "build": "pnpm run build:comp-lib && pnpm run build:utils && rspeedy build && cross-env REACTLYNX_ASYNC=true pnpm run build:comp-lib && cross-env REACTLYNX_ASYNC=true pnpm run build:utils && cross-env REACTLYNX_ASYNC=true rspeedy build",
     "build:comp-lib": "rslib build --config rslib-comp-lib.config.ts",
     "build:comp-lib:dev": "cross-env NODE_ENV=development rslib build --config rslib-comp-lib.config.ts",
-    "dev": "pnpm run build:comp-lib && rspeedy dev",
-    "dev:react-async": "cross-env REACTLYNX_ASYNC=true pnpm run build:comp-lib && cross-env REACTLYNX_ASYNC=true rspeedy dev",
+    "build:utils": "rslib build --config rslib-utils.config.ts",
+    "dev": "pnpm run build:comp-lib && pnpm run build:utils && rspeedy dev",
+    "dev:react-async": "cross-env REACTLYNX_ASYNC=true pnpm run build:comp-lib && cross-env REACTLYNX_ASYNC=true pnpm run build:utils && cross-env REACTLYNX_ASYNC=true rspeedy dev",
     "preview": "rspeedy preview",
     "preview:react-async": "cross-env REACTLYNX_ASYNC=true rspeedy preview"
   },
@@ -21,6 +22,7 @@
     "@lynx-js/preact-devtools": "catalog:lynxjs",
     "@lynx-js/qrcode-rsbuild-plugin": "workspace:*",
     "@lynx-js/react-rsbuild-plugin": "workspace:*",
+    "@lynx-js/rsbuild-plugin": "workspace:*",
     "@lynx-js/rspeedy": "workspace:*",
     "@lynx-js/types": "4.1.0",
     "@types/react": "^19.2.18",

--- a/examples/react-externals/rslib-utils.config.ts
+++ b/examples/react-externals/rslib-utils.config.ts
@@ -1,0 +1,27 @@
+import {
+  LAYERS,
+  defineExternalBundleRslibConfig,
+} from '@lynx-js/lynx-bundle-rslib-config';
+import { pluginLynx } from '@lynx-js/rsbuild-plugin';
+
+const isAsync = process.env['REACTLYNX_ASYNC'] === 'true';
+
+export default defineExternalBundleRslibConfig({
+  id: 'utils',
+  source: {
+    entry: {
+      './utils.js': {
+        import: './src/utils.ts',
+        layer: LAYERS.BACKGROUND,
+      },
+    },
+  },
+  plugins: [pluginLynx()],
+  output: {
+    cleanDistPath: false,
+    globalObject: 'globalThis',
+    ...(isAsync && {
+      distPath: { root: 'dist-external-bundle-react-async' },
+    }),
+  },
+});

--- a/examples/react-externals/src/index.tsx
+++ b/examples/react-externals/src/index.tsx
@@ -7,6 +7,15 @@ import { App } from './App.js';
 
 import './index.css';
 
+function logTapHint() {
+  'background only';
+  void import('./utils.js').then(({ formatTapCount }) => {
+    console.info(formatTapCount(0));
+  });
+}
+
+logTapHint();
+
 root.render(
   // biome-ignore lint/style/useFragmentSyntax: Just to demonstrate import react is external
   <Fragment>

--- a/examples/react-externals/src/utils.ts
+++ b/examples/react-externals/src/utils.ts
@@ -1,0 +1,6 @@
+export function formatTapCount(count: number): string {
+  if (count === 0) {
+    return 'Tap the logo and have fun!';
+  }
+  return `Tapped ${count} ${count === 1 ? 'time' : 'times'}`;
+}

--- a/examples/react-externals/tsconfig.json
+++ b/examples/react-externals/tsconfig.json
@@ -14,6 +14,7 @@
     "external-bundle",
     "lynx.config.ts",
     "rslib-comp-lib.config.ts",
+    "rslib-utils.config.ts",
     "rslib-reactlynx.config.ts",
   ],
   "references": [

--- a/packages/rspeedy/lynx-bundle-rslib-config/etc/lynx-bundle-rslib-config.api.md
+++ b/packages/rspeedy/lynx-bundle-rslib-config/etc/lynx-bundle-rslib-config.api.md
@@ -27,6 +27,14 @@ export interface EncodeOptions {
 }
 
 // @public
+export interface ExposedLayers {
+    // (undocumented)
+    readonly BACKGROUND: string;
+    // (undocumented)
+    readonly MAIN_THREAD: string;
+}
+
+// @public
 export interface ExternalBundleLibConfig extends LibConfig {
     // (undocumented)
     output?: OutputConfig;
@@ -59,6 +67,9 @@ export type ExternalsPresets = {
 export type ExternalsPresetValue = boolean | {
     async?: boolean;
 };
+
+// @public
+export const LAYERS: ExposedLayers;
 
 // @public
 export class MainThreadRuntimeWrapperWebpackPlugin {

--- a/packages/rspeedy/lynx-bundle-rslib-config/src/externalBundleRslibConfig.ts
+++ b/packages/rspeedy/lynx-bundle-rslib-config/src/externalBundleRslibConfig.ts
@@ -602,9 +602,24 @@ export function defineExternalBundleRslibConfig(
   }
 }
 
-interface ExposedLayers {
+/**
+ * The layer names an external bundle is split by.
+ *
+ * @public
+ */
+export interface ExposedLayers {
   readonly BACKGROUND: string
   readonly MAIN_THREAD: string
+}
+
+/**
+ * The layer names an entry is split by without a DSL plugin.
+ *
+ * @public
+ */
+export const LAYERS: ExposedLayers = {
+  BACKGROUND: 'lynx:background',
+  MAIN_THREAD: 'lynx:main-thread',
 }
 
 // The consuming application loads a section by the name of the chunk it holds.
@@ -662,16 +677,9 @@ const externalBundleRsbuildPlugin = ({
   // ensure dsl plugin has exposed LAYERS
   enforce: 'post',
   setup(api) {
-    // Get layer names from react-rsbuild-plugin
-    const LAYERS = api.useExposed<ExposedLayers>(
+    const layers = api.useExposed<ExposedLayers>(
       Symbol.for('LAYERS'),
-    )
-
-    if (!LAYERS) {
-      throw new Error(
-        'lynx-bundle-rslib-config requires exposed `LAYERS`. Please install a DSL plugin, for example `pluginReactLynx` for ReactLynx.',
-      )
-    }
+    ) ?? LAYERS
 
     const exposed = api.useExposed<{
       LynxTemplatePlugin: typeof LynxTemplatePluginClass
@@ -679,7 +687,7 @@ const externalBundleRsbuildPlugin = ({
 
     if (!exposed) {
       throw new Error(
-        'lynx-bundle-rslib-config requires exposed `LynxTemplatePlugin`. Please apply `pluginLynx` from `@lynx-js/rsbuild-plugin`, which a DSL plugin such as `pluginReactLynx` does for you.',
+        'lynx-bundle-rslib-config requires an exposed `LynxTemplatePlugin`. Apply `pluginLynx` from `@lynx-js/rsbuild-plugin`, or a DSL plugin such as `pluginReactLynx` that applies it for you.',
       )
     }
 
@@ -691,7 +699,7 @@ const externalBundleRsbuildPlugin = ({
 
     if (!lynxConfig) {
       throw new Error(
-        'lynx-bundle-rslib-config requires an exposed Lynx config. Please apply `pluginLynx` from `@lynx-js/rsbuild-plugin`, which a DSL plugin such as `pluginReactLynx` does for you.',
+        'lynx-bundle-rslib-config requires an exposed Lynx config. Apply `pluginLynx` from `@lynx-js/rsbuild-plugin`, or a DSL plugin such as `pluginReactLynx` that applies it for you.',
       )
     }
 
@@ -707,7 +715,7 @@ const externalBundleRsbuildPlugin = ({
         const jsMainRule = chain.module
           .rule(CHAIN_ID.RULE.JS)
           .oneOf(CHAIN_ID.ONE_OF.JS_MAIN)
-        for (const layer of [LAYERS.BACKGROUND, LAYERS.MAIN_THREAD]) {
+        for (const layer of [layers.BACKGROUND, layers.MAIN_THREAD]) {
           // Only tap when the DSL plugin has registered a loader for this
           // layer. Creating the use entry here would produce a loader-less
           // `{ options }` record that Rspack >= 2.0.8 rejects.
@@ -753,26 +761,26 @@ const externalBundleRsbuildPlugin = ({
               backgroundEntryName.push(backgroundEntry)
               addLayeredEntry(mainThreadEntry, {
                 import: value,
-                layer: LAYERS.MAIN_THREAD,
+                layer: layers.MAIN_THREAD,
               })
               addLayeredEntry(backgroundEntry, {
                 import: value,
-                layer: LAYERS.BACKGROUND,
+                layer: layers.BACKGROUND,
               })
             } else {
               // object
               const { layer } = value
-              if (layer === LAYERS.MAIN_THREAD) {
+              if (layer === layers.MAIN_THREAD) {
                 mainThreadEntryName.push(entryName)
                 addLayeredEntry(entryName, {
                   ...value,
-                  layer: LAYERS.MAIN_THREAD,
+                  layer: layers.MAIN_THREAD,
                 })
-              } else if (layer === LAYERS.BACKGROUND) {
+              } else if (layer === layers.BACKGROUND) {
                 backgroundEntryName.push(entryName)
                 addLayeredEntry(entryName, {
                   ...value,
-                  layer: LAYERS.BACKGROUND,
+                  layer: layers.BACKGROUND,
                 })
               } else {
                 // not specify layer
@@ -782,11 +790,11 @@ const externalBundleRsbuildPlugin = ({
                 backgroundEntryName.push(backgroundEntry)
                 addLayeredEntry(mainThreadEntry, {
                   ...value,
-                  layer: LAYERS.MAIN_THREAD,
+                  layer: layers.MAIN_THREAD,
                 })
                 addLayeredEntry(backgroundEntry, {
                   ...value,
-                  layer: LAYERS.BACKGROUND,
+                  layer: layers.BACKGROUND,
                 })
               }
             }
@@ -795,7 +803,7 @@ const externalBundleRsbuildPlugin = ({
         chain
           .plugin(MarkMainThreadWebpackPlugin.name)
           .use(MarkMainThreadWebpackPlugin, [{
-            layer: LAYERS.MAIN_THREAD,
+            layer: layers.MAIN_THREAD,
           }])
           .end()
 

--- a/packages/rspeedy/lynx-bundle-rslib-config/src/index.ts
+++ b/packages/rspeedy/lynx-bundle-rslib-config/src/index.ts
@@ -9,12 +9,14 @@
  */
 export {
   defineExternalBundleRslibConfig,
+  LAYERS,
   builtInExternalsPresetDefinitions,
   reactLynxExternalsPreset,
   DEFAULT_EXTERNAL_BUNDLE_LIB_CONFIG as defaultExternalBundleLibConfig,
 } from './externalBundleRslibConfig.js'
 export type {
   EncodeOptions,
+  ExposedLayers,
   ExternalBundleLibConfig,
   ExternalObject,
   Externals,

--- a/packages/rspeedy/lynx-bundle-rslib-config/test/external-bundle.test.ts
+++ b/packages/rspeedy/lynx-bundle-rslib-config/test/external-bundle.test.ts
@@ -15,7 +15,10 @@ import { pluginLynx } from '@lynx-js/rsbuild-plugin'
 import { LynxEncodePlugin } from '@lynx-js/template-webpack-plugin'
 
 import { decodeTemplate } from './utils.js'
-import { defineExternalBundleRslibConfig } from '../src/index.js'
+import {
+  LAYERS as DEFAULT_LAYERS,
+  defineExternalBundleRslibConfig,
+} from '../src/index.js'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
@@ -1399,5 +1402,42 @@ describe('intermediate directory', () => {
     ).toStrictEqual(
       expect.arrayContaining(['utils.js', 'utils__main-thread.js']),
     )
+  })
+})
+
+describe('without a DSL plugin', () => {
+  const fixtureDir = path.join(__dirname, './fixtures/utils-lib')
+
+  it('builds with `pluginLynx` alone', async () => {
+    const distRoot = path.join(fixtureDir, 'dist', 'plain-engine')
+
+    await build(defineExternalBundleRslibConfig({
+      source: {
+        entry: {
+          './utils.js': {
+            import: path.join(fixtureDir, 'index.ts'),
+            layer: DEFAULT_LAYERS.BACKGROUND,
+          },
+        },
+      },
+      id: 'plain-engine',
+      output: { distPath: { root: distRoot } },
+      plugins: [pluginLynx()],
+    }))
+
+    const decodedResult = await decodeTemplate(
+      path.join(distRoot, 'plain-engine.lynx.bundle'),
+    )
+
+    // The entry picks one layer, so the bundle carries one section.
+    expect(Object.keys(decodedResult['custom-sections'])).toStrictEqual([
+      './utils.js',
+    ])
+
+    // `lynx.loadScript` returns the completion value of the section, which the
+    // runtime wrapper provides. Without it the bundle still builds, and fails
+    // to load on device.
+    expect(decodedResult['custom-sections']['./utils.js'])
+      .toMatch(/^\(function\s*\(\)\s*\{/)
   })
 })

--- a/packages/rspeedy/lynx-bundle-rslib-config/test/external-bundle.test.ts
+++ b/packages/rspeedy/lynx-bundle-rslib-config/test/external-bundle.test.ts
@@ -1440,4 +1440,25 @@ describe('without a DSL plugin', () => {
     expect(decodedResult['custom-sections']['./utils.js'])
       .toMatch(/^\(function\s*\(\)\s*\{/)
   })
+
+  it('builds a web bundle with `pluginLynx` alone', async () => {
+    const distRoot = path.join(fixtureDir, 'dist', 'plain-engine-web')
+
+    await build(defineExternalBundleRslibConfig({
+      source: {
+        entry: {
+          './utils.js': {
+            import: path.join(fixtureDir, 'index.ts'),
+            layer: DEFAULT_LAYERS.BACKGROUND,
+          },
+        },
+      },
+      id: 'plain-engine-web',
+      output: { distPath: { root: distRoot } },
+      plugins: [pluginLynx()],
+    }, { target: 'web', engineVersion: '3.5' }))
+
+    expect(fs.existsSync(path.join(distRoot, 'plain-engine-web.web.bundle')))
+      .toBe(true)
+  })
 })

--- a/packages/rspeedy/plugin-lynx/package.json
+++ b/packages/rspeedy/plugin-lynx/package.json
@@ -42,6 +42,7 @@
     "@lynx-js/cache-events-webpack-plugin": "workspace:^",
     "@lynx-js/chunk-loading-webpack-plugin": "workspace:^",
     "@lynx-js/debug-metadata-rsbuild-plugin": "workspace:^",
+    "@lynx-js/runtime-wrapper-webpack-plugin": "workspace:^",
     "@lynx-js/template-webpack-plugin": "workspace:^",
     "@lynx-js/web-rsbuild-server-middleware": "workspace:*",
     "@lynx-js/webpack-dev-transport": "workspace:^",

--- a/packages/rspeedy/plugin-lynx/src/plugins/template.plugin.ts
+++ b/packages/rspeedy/plugin-lynx/src/plugins/template.plugin.ts
@@ -19,7 +19,11 @@ export function pluginTemplate(): RsbuildPlugin {
         return
       }
 
-      api.modifyBundlerChain((chain) => {
+      api.modifyBundlerChain((chain, { environment }) => {
+        if (environment.name !== 'lynx') {
+          return
+        }
+
         if (!chain.plugins.has(PLUGIN_NAME_RUNTIME_WRAPPER)) {
           chain
             .plugin(PLUGIN_NAME_RUNTIME_WRAPPER)

--- a/packages/rspeedy/plugin-lynx/src/plugins/template.plugin.ts
+++ b/packages/rspeedy/plugin-lynx/src/plugins/template.plugin.ts
@@ -7,6 +7,7 @@ import { RuntimeWrapperWebpackPlugin } from '@lynx-js/runtime-wrapper-webpack-pl
 import {
   LynxEncodePlugin,
   LynxTemplatePlugin,
+  WebEncodePlugin,
 } from '@lynx-js/template-webpack-plugin'
 
 export function pluginTemplate(): RsbuildPlugin {
@@ -20,7 +21,10 @@ export function pluginTemplate(): RsbuildPlugin {
       }
 
       api.modifyBundlerChain((chain, { environment }) => {
-        if (environment.name !== 'lynx') {
+        if (environment.name === 'web') {
+          if (!chain.plugins.has(PLUGIN_NAME_WEB)) {
+            chain.plugin(PLUGIN_NAME_WEB).use(WebEncodePlugin, []).end()
+          }
           return
         }
 
@@ -43,3 +47,4 @@ export function pluginTemplate(): RsbuildPlugin {
 }
 
 const PLUGIN_NAME_RUNTIME_WRAPPER = 'lynx:runtime-wrapper'
+const PLUGIN_NAME_WEB = 'lynx:web'

--- a/packages/rspeedy/plugin-lynx/src/plugins/template.plugin.ts
+++ b/packages/rspeedy/plugin-lynx/src/plugins/template.plugin.ts
@@ -3,13 +3,39 @@
 // LICENSE file in the root directory of this source tree.
 import type { RsbuildPlugin } from '@rsbuild/core'
 
-import { LynxTemplatePlugin } from '@lynx-js/template-webpack-plugin'
+import { RuntimeWrapperWebpackPlugin } from '@lynx-js/runtime-wrapper-webpack-plugin'
+import {
+  LynxEncodePlugin,
+  LynxTemplatePlugin,
+} from '@lynx-js/template-webpack-plugin'
 
 export function pluginTemplate(): RsbuildPlugin {
   return {
     name: 'lynx:rsbuild:template',
     setup(api) {
       api.expose(Symbol.for('LynxTemplatePlugin'), { LynxTemplatePlugin })
+
+      if (api.context.callerName !== 'rslib') {
+        return
+      }
+
+      api.modifyBundlerChain((chain) => {
+        if (!chain.plugins.has(PLUGIN_NAME_RUNTIME_WRAPPER)) {
+          chain
+            .plugin(PLUGIN_NAME_RUNTIME_WRAPPER)
+            .use(RuntimeWrapperWebpackPlugin, [{}])
+            .end()
+        }
+
+        if (!chain.plugins.has(LynxEncodePlugin.name)) {
+          chain
+            .plugin(LynxEncodePlugin.name)
+            .use(LynxEncodePlugin, [{}])
+            .end()
+        }
+      })
     },
   }
 }
+
+const PLUGIN_NAME_RUNTIME_WRAPPER = 'lynx:runtime-wrapper'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -547,6 +547,9 @@ importers:
       '@lynx-js/react-rsbuild-plugin':
         specifier: workspace:*
         version: link:../../packages/rspeedy/plugin-react
+      '@lynx-js/rsbuild-plugin':
+        specifier: workspace:*
+        version: link:../../packages/rspeedy/plugin-lynx
       '@lynx-js/rspeedy':
         specifier: workspace:*
         version: link:../../packages/rspeedy/core
@@ -1800,6 +1803,9 @@ importers:
       '@lynx-js/debug-metadata-rsbuild-plugin':
         specifier: workspace:^
         version: link:../plugin-debug-metadata
+      '@lynx-js/runtime-wrapper-webpack-plugin':
+        specifier: workspace:^
+        version: link:../../webpack/runtime-wrapper-webpack-plugin
       '@lynx-js/template-webpack-plugin':
         specifier: workspace:^
         version: link:../../webpack/template-webpack-plugin


### PR DESCRIPTION
## Problem

`defineExternalBundleRslibConfig` needs four things from the plugins it is given, and a DSL plugin such as `pluginReactLynx` was the only thing that supplied them all:

- the layer names, exposed as `LAYERS`
- a runtime wrapper
- an encoder
- the Lynx build engine, `pluginLynx`

Only the last of those is named by the error a config gets when something is missing, and the runtime wrapper is not checked at all: leave it out and the bundle builds, then `lynx.loadScript` throws on device.

This is what `lynx/byted-lynx-examples` hit after the 2026-09-04 release. Its `external-bundle` example builds one bundle with `pluginReactLynx` (fine) and one plain TypeScript bundle with a config that only exposes `LAYERS` — which was enough before the encoders moved to the DSL in #3744:

```
error  lynx-bundle-rslib-config requires exposed `LynxTemplatePlugin`.
       Please apply `pluginLynx` from `@lynx-js/rsbuild-plugin` ...
```

Following that message gets you `Cannot destructure property 'buffer' of '(intermediate value)'`, and following *that* gets you a bundle that fails at runtime.

## Change

`pluginLynx` is the Lynx build engine, so it registers the runtime wrapper and the encoder for an `rslib` caller. A plugin that already registered one under the same name keeps it, so a DSL keeps the ones it registers with its own options, and a page build is untouched (the fallback is behind `callerName === 'rslib'`).

`defineExternalBundleRslibConfig` falls back to layer names of its own when no DSL exposes them, exported as `LAYERS` so an entry can pick a thread.

A bundle of plain TypeScript is then:

```ts
import { defineExternalBundleRslibConfig, LAYERS } from '@lynx-js/lynx-bundle-rslib-config'
import { pluginLynx } from '@lynx-js/rsbuild-plugin'

export default defineExternalBundleRslibConfig({
  id: 'utils',
  source: {
    entry: {
      './utils.js': { import: './src/utils.ts', layer: LAYERS.BACKGROUND },
    },
  },
  plugins: [pluginLynx()],
})
```

## Verification

`examples/react-externals` builds such a bundle and loads it from background code. On a Pixel 4 XL, dev mode:

- before: `Failed to load script ./utils.js in http://…/utils.lynx.bundle`
- after: no errors, and the bundle's `formatTapCount` logs from the background thread

The entry picks the background layer, so the bundle carries one section (1.9 kB) instead of two (2.7 kB).

`plugin-lynx` 155/155 and `lynx-bundle-rslib-config` 36/36 pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - External bundles can now be built with the Lynx plugin alone, without an additional DSL plugin.
  - Added default layer settings and public layer definitions for external bundle configuration.
  - Added support for web-targeted external bundle builds.
  - Added an example demonstrating asynchronous loading of a utility bundle in a React application.

- **Bug Fixes**
  - External bundles now include the runtime and encoding support required for successful loading when built with the Lynx plugin alone.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->