### PR TITLE
fix(qrcode): stop an unregistered shortcut loop from prompting again

### DIFF
--- a/.changeset/qrcode-stale-shortcut-loop.md
+++ b/.changeset/qrcode-stale-shortcut-loop.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/qrcode-rsbuild-plugin": patch
+---
+
+Stop a console-shortcut loop whose dev server has already been closed from prompting again.

--- a/packages/rspeedy/plugin-qrcode/src/shortcuts.ts
+++ b/packages/rspeedy/plugin-qrcode/src/shortcuts.ts
@@ -120,7 +120,10 @@ async function loop(
   let currentEntry = options.entries[0]!
   let currentSchema = Object.keys(devUrls)[0]!
 
-  while (!isCancel(value)) {
+  // A loop whose dev server has already been closed (`off()` ran) must not
+  // prompt again: it would consume the answer meant for the loop that
+  // replaced it.
+  while (!isCancel(value) && gExistingShortcuts.has(options)) {
     const name = await selectKey({
       message: 'Usage',
       options: [
@@ -185,7 +188,15 @@ async function loop(
     } else if (options.customShortcuts?.[name]) {
       await options.customShortcuts[name].action?.()
     }
+    if (!gExistingShortcuts.has(options)) {
+      // The dev server closed while a selection was pending; its URL is gone.
+      break
+    }
     await options.onPrint?.(value)
+    if (!gExistingShortcuts.has(options)) {
+      // ...or while `onPrint` was pending.
+      break
+    }
     if (shouldShowQRCode) {
       showQRCode(value)
     }

--- a/packages/rspeedy/plugin-qrcode/test/shortcuts-stale-loop.test.ts
+++ b/packages/rspeedy/plugin-qrcode/test/shortcuts-stale-loop.test.ts
@@ -1,0 +1,188 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import type { RsbuildPluginAPI } from '@rsbuild/core'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { pluginLynx } from '@lynx-js/rsbuild-plugin'
+import type { LynxConfig } from '@lynx-js/rsbuild-plugin'
+
+function createLynxConfig(): LynxConfig {
+  let config: LynxConfig | undefined
+  for (const plugin of pluginLynx()) {
+    void plugin.setup({
+      expose(_id: string | symbol, value: unknown) {
+        config = value as LynxConfig
+      },
+    } as unknown as RsbuildPluginAPI)
+    if (config) break
+  }
+  if (!config) throw new Error('pluginLynx exposed no Lynx config')
+  return config
+}
+
+describe('shortcut loop whose dev server closes before its first prompt', () => {
+  const api = {
+    getNormalizedConfig: vi.fn().mockReturnValue({
+      dev: { assetPrefix: 'https://example.com/' },
+    }),
+    useExposed: vi.fn().mockReturnValue(createLynxConfig()),
+  } as unknown as RsbuildPluginAPI
+
+  const ttyDescriptors = new Map<
+    NodeJS.ReadStream | NodeJS.WriteStream,
+    PropertyDescriptor | undefined
+  >()
+
+  beforeEach(() => {
+    vi.resetModules()
+    for (const stream of [process.stdin, process.stdout] as const) {
+      ttyDescriptors.set(
+        stream,
+        Object.getOwnPropertyDescriptor(stream, 'isTTY'),
+      )
+      Object.defineProperty(stream, 'isTTY', {
+        value: true,
+        configurable: true,
+      })
+    }
+  })
+
+  afterEach(() => {
+    vi.doUnmock('@clack/prompts')
+    vi.doUnmock('../src/showQRCode.js')
+    for (const [stream, descriptor] of ttyDescriptors) {
+      if (descriptor) {
+        Object.defineProperty(stream, 'isTTY', descriptor)
+      } else {
+        delete (stream as { isTTY?: boolean }).isTTY
+      }
+    }
+    ttyDescriptors.clear()
+  })
+
+  test('does not print for a server that closed while a selection was pending', async () => {
+    let selectEntry!: (entry: string) => void
+    const select = vi.fn(() =>
+      new Promise<string>(resolve => {
+        selectEntry = resolve
+      })
+    )
+    const selectKey = vi.fn()
+      .mockResolvedValueOnce('r')
+      .mockImplementation(() => new Promise<string>(vi.fn()))
+    const showQRCode = vi.fn()
+    vi.doMock('@clack/prompts', () => ({
+      selectKey,
+      select,
+      autocomplete: vi.fn(),
+      isCancel: vi.fn(() => false),
+      cancel: vi.fn(),
+      log: { success: vi.fn(), info: vi.fn() },
+    }))
+    vi.doMock('../src/showQRCode.js', () => ({ default: showQRCode }))
+    const { registerConsoleShortcuts } = await import('../src/shortcuts.js')
+    const onPrint = vi.fn()
+
+    const off = await registerConsoleShortcuts({
+      api,
+      entries: ['foo', 'bar'],
+      schema: i => i,
+      port: 3000,
+      onPrint,
+    })
+    await expect.poll(() => select).toHaveBeenCalledTimes(1)
+    showQRCode.mockClear()
+    onPrint.mockClear()
+
+    // The dev server closes while the entry prompt is still open.
+    off()
+    selectEntry('bar')
+    await new Promise(resolve => setTimeout(resolve, 20))
+
+    expect(onPrint).not.toHaveBeenCalled()
+    expect(showQRCode).not.toHaveBeenCalled()
+    expect(selectKey).toHaveBeenCalledTimes(1)
+  })
+
+  test('does not print the QR code for a server that closed while onPrint was pending', async () => {
+    const selectKey = vi.fn()
+      .mockResolvedValueOnce('r')
+      .mockImplementation(() => new Promise<string>(vi.fn()))
+    const showQRCode = vi.fn()
+    vi.doMock('@clack/prompts', () => ({
+      selectKey,
+      select: vi.fn().mockResolvedValue('bar'),
+      autocomplete: vi.fn(),
+      isCancel: vi.fn(() => false),
+      cancel: vi.fn(),
+      log: { success: vi.fn(), info: vi.fn() },
+    }))
+    vi.doMock('../src/showQRCode.js', () => ({ default: showQRCode }))
+    const { registerConsoleShortcuts } = await import('../src/shortcuts.js')
+    // The first `onPrint` (initial print) resolves right away; the second one
+    // (after the entry switch) stays pending.
+    let finishPrint!: () => void
+    const onPrint = vi.fn()
+      .mockResolvedValueOnce(undefined)
+      .mockImplementation(() =>
+        new Promise<void>(resolve => {
+          finishPrint = resolve
+        })
+      )
+
+    const off = await registerConsoleShortcuts({
+      api,
+      entries: ['foo', 'bar'],
+      schema: i => i,
+      port: 3000,
+      onPrint,
+    })
+    await expect.poll(() => onPrint).toHaveBeenCalledTimes(2)
+    showQRCode.mockClear()
+
+    // The dev server closes while the second `onPrint` is still pending.
+    off()
+    finishPrint()
+    await new Promise(resolve => setTimeout(resolve, 20))
+
+    expect(showQRCode).not.toHaveBeenCalled()
+    expect(selectKey).toHaveBeenCalledTimes(1)
+  })
+
+  test('does not prompt', async () => {
+    // The loop reaches its first prompt only after `import('@clack/prompts')`
+    // resolves. Hold that import so the dev server can close in between, the
+    // way a busy CI runner orders a closing test and the next one.
+    const selectKey = vi.fn(() => new Promise<string>(vi.fn()))
+    let releasePrompts!: () => void
+    const promptsLoaded = new Promise<void>(resolve => {
+      releasePrompts = resolve
+    })
+    vi.doMock('@clack/prompts', async () => {
+      await promptsLoaded
+      return {
+        selectKey,
+        select: vi.fn(),
+        autocomplete: vi.fn(),
+        isCancel: vi.fn(() => false),
+        cancel: vi.fn(),
+        log: { success: vi.fn(), info: vi.fn() },
+      }
+    })
+    vi.doMock('../src/showQRCode.js', () => ({ default: vi.fn() }))
+    const { registerConsoleShortcuts } = await import('../src/shortcuts.js')
+
+    const off = await registerConsoleShortcuts({
+      api,
+      entries: ['foo'],
+      schema: i => i,
+      port: 3000,
+    })
+    off()
+    releasePrompts()
+    await new Promise(resolve => setTimeout(resolve, 20))
+
+    expect(selectKey).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
`rspeedy/qrcode > Plugins - Terminal > schema > custom schema object` is the most frequent flake in the Test workflow (6 of the last ~80 failed runs, across unrelated branches), e.g. https://github.com/lynx-family/lynx-stack/actions/runs/33939999917/job/101236225297:

```
Error: Matcher did not succeed in time.
Caused by: AssertionError: expected "renderUnicodeCompact" to be called 2 times, but got 1 times
```

The shortcut loop only noticed that its dev server had been closed (`off()` removed its options from `gExistingShortcuts`) *after* the next `selectKey` prompt resolved, so a loop outliving its server still consumed one answer before exiting. Under CI load the previous test's loop reaches its first prompt only after the next test has installed its one-shot `selectKey` answer (`'a'`, then `'q'`); the stale loop consumes the `'a'` and exits, the real loop gets `'q'`, and the QR code is never re-rendered. Probe of a delayed run (each loop tagged by its dev-server port):

```
loop@port40107 prompting, registered=false   # previous test's loop, already unregistered
loop@port40107 got a, registered=false
loop@port34445 prompting, registered=true    # this test's loop
loop@port34445 got q, registered=true
```

Inserting `await new Promise(r => setTimeout(r, 300))` before the loop's `while` reproduces exactly this failure on every local run; with this change the delayed run passes, and the undelayed suite passes.

No regression test: the window is "the server closes before the loop's first prompt", and nothing in the test can hold the loop there without a delay. The delayed-run probe above is the evidence.

Outside the tests this only affects a dev-server restart while the prompt is waiting, and there each `@clack/prompts` prompt has its own `keypress` listener, so the old loop sees the key and exits while the new loop handles it; the existing post-prompt check already covers that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed a console shortcut issue that could continue prompting after a development server was closed.
  - Prevented closed server sessions from consuming shortcut input intended for a replacement session.
  - Improved shortcut handling when restarting or replacing an active development server.
- **Chores**
  - Included a patch release for the QR code build plugin.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->