### PR TITLE
fix(react): scope the lazy-chunk definitions import to its compiler

### DIFF
--- a/.changeset/defines-import-per-compiler.md
+++ b/.changeset/defines-import-per-compiler.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react-webpack-plugin": patch
+---
+
+Keep the lazy-chunk definitions import of one compiler from leaking into another compiler in the same process, which made builds with several environments fail intermittently with `Module not found: Can't resolve '<lazy module>.__lynx-react-defines.js'`.

--- a/packages/webpack/react-webpack-plugin/src/DefinesInjection.ts
+++ b/packages/webpack/react-webpack-plugin/src/DefinesInjection.ts
@@ -42,7 +42,8 @@ export function applyDefinesInjection(
         resource?: string;
         layer?: string | null;
       };
-      definesImportByBoundary.clear();
+      const definesImports = definesImportByBoundary(compiler);
+      definesImports.clear();
 
       const traverse = (roots: Module[]) => {
         const visited = new Set<Module>();
@@ -173,7 +174,7 @@ export function applyDefinesInjection(
             present,
             `${resource}.__lynx-react-defines.js`,
             async (boundaryRequest) => {
-              definesImportByBoundary.set(
+              definesImports.set(
                 boundaryKey(
                   (mainThreadBoundary as ModuleWithMeta).layer,
                   resource,

--- a/packages/webpack/react-webpack-plugin/src/loaders/defines-import-by-boundary.ts
+++ b/packages/webpack/react-webpack-plugin/src/loaders/defines-import-by-boundary.ts
@@ -9,4 +9,16 @@ export function boundaryKey(
   return `${layer ?? ''}|${resourcePath}`;
 }
 
-export const definesImportByBoundary: Map<string, string> = new Map();
+// Keyed by compiler: rsbuild compiles every environment in one process, and a
+// boundary recorded by one compiler must not make another compiler's loader
+// import a virtual module that only exists in the first compiler.
+const definesImportsByCompiler = new WeakMap<object, Map<string, string>>();
+
+export function definesImportByBoundary(compiler: object): Map<string, string> {
+  let imports = definesImportsByCompiler.get(compiler);
+  if (!imports) {
+    imports = new Map();
+    definesImportsByCompiler.set(compiler, imports);
+  }
+  return imports;
+}

--- a/packages/webpack/react-webpack-plugin/src/loaders/main-thread.ts
+++ b/packages/webpack/react-webpack-plugin/src/loaders/main-thread.ts
@@ -124,12 +124,14 @@ const mainThreadLoader: LoaderDefinitionFunction<ReactLoaderOptions> = function(
     }
   }
 
-  const definesImport = definesImportByBoundary.get(
-    boundaryKey(
-      (currentModule as { layer?: string | null } | undefined)?.layer,
-      this.resourcePath,
-    ),
-  );
+  const definesImport = this._compiler
+    ? definesImportByBoundary(this._compiler).get(
+      boundaryKey(
+        (currentModule as { layer?: string | null } | undefined)?.layer,
+        this.resourcePath,
+      ),
+    )
+    : undefined;
 
   this.callback(
     null,

--- a/packages/webpack/react-webpack-plugin/test/defines.test.ts
+++ b/packages/webpack/react-webpack-plugin/test/defines.test.ts
@@ -1,6 +1,7 @@
 // Copyright 2026 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
+import { spawnSync } from 'node:child_process';
 import { mkdtempSync } from 'node:fs';
 import fs from 'node:fs/promises';
 import { createRequire } from 'node:module';
@@ -474,6 +475,22 @@ describe('missing definitions injection', () => {
     );
 
     expect(content).not.toContain('registerAsyncOnly;');
+  });
+
+  it('keeps the boundary import of one compiler out of the next', () => {
+    // rsbuild compiles every environment in one process. A boundary recorded
+    // while one compiler injected the lazy chunk's definitions must not make
+    // the next compiler's loader import a virtual module it never wrote. The
+    // build runs in plain Node so the plugin and its loaders share one module
+    // instance, as they do outside the test runner.
+    const result = spawnSync(
+      process.execPath,
+      [path.join(__dirname, 'fixtures/build-lazy-case-twice.mjs')],
+      { encoding: 'utf-8' },
+    );
+
+    expect(result.stdout + result.stderr).toContain('build #2: ok');
+    expect(result.status).toBe(0);
   });
 
   it('keeps the definitions of each entry apart', async () => {

--- a/packages/webpack/react-webpack-plugin/test/fixtures/build-lazy-case-twice.mjs
+++ b/packages/webpack/react-webpack-plugin/test/fixtures/build-lazy-case-twice.mjs
@@ -1,0 +1,43 @@
+// Builds the `merge-defines-lazy` case twice with two compilers in one
+// process, the way rsbuild builds every environment in one process.
+// Runs in plain Node so the plugin and its loaders share one module instance.
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { rspack } from '@rspack/core';
+
+const { default: caseConfig } = await import(
+  '../cases/main-thread/merge-defines-lazy/rspack.config.js'
+);
+
+for (let i = 1; i <= 2; i++) {
+  const compiler = rspack({
+    ...caseConfig,
+    mode: 'none',
+    externalsPresets: { node: true },
+    output: {
+      ...caseConfig.output,
+      path: mkdtempSync(path.join(tmpdir(), 'defines-lazy-twice-')),
+    },
+  });
+  await new Promise((resolve, reject) => {
+    compiler.run((err, stats) => {
+      compiler.close(() => {
+        if (err) {
+          reject(err);
+        } else if (stats.hasErrors()) {
+          reject(new Error(stats.toString({ all: false, errors: true })));
+        } else {
+          resolve();
+        }
+      });
+    });
+  }).then(
+    () => console.info(`build #${i}: ok`),
+    (error) => {
+      console.info(`build #${i}: ${error.message}`);
+      process.exit(1);
+    },
+  );
+}


### PR DESCRIPTION
`examples/react-lazy-bundle` fails intermittently on `main`, e.g. https://github.com/lynx-family/lynx-stack/actions/runs/33948583750/job/101259005729:

```
ready   built in 10.4s (web)
error   Build error:
File: ./src/LazyComponent.tsx:53:1-123
  × Module not found: Can't resolve '/home/runner/work/lynx-stack/lynx-stack/examples/react-lazy-bundle/src/LazyComponent.tsx.__lynx-react-defines.js'
error   build failed in 12.0s (lynx)
```

**Cause.** `definesImportByBoundary` (the boundary → virtual-module map the main-thread loader reads, added in #3393) was a module-level singleton keyed by layer and resource only. rsbuild compiles every environment in one process, so once the `web` compiler's `finishMake` recorded the lazy chunk's boundary, the `lynx` compiler's loader picked that entry up during its own first build and imported a virtual module that only the `web` compiler's `VirtualModulesPlugin` had written. Whether it fails depends on which compiler gets there first, hence the flake (the log above shows `web` finishing right before `lynx` failed).

Deterministic reproduction: build the same config twice in one process. On `main`, `examples/react-lazy-bundle` with `createRspeedy(...).build()` called twice:

```
[twice] build #1: ok
  × Module not found: Can't resolve '.../examples/react-lazy-bundle/src/LazyComponent.tsx.__lynx-react-defines.js'
[twice] build #2: FAILED Rspack build failed.
```

With this change both builds pass.

**Fix.** Key the map by compiler (`WeakMap<Compiler, Map>`) and look it up through the loader's `_compiler`.

**Test.** `missing definitions injection > keeps the boundary import of one compiler out of the next` builds the `merge-defines-lazy` case twice with two compilers in one process. It runs in a child Node process because inside the test runner the plugin (`src`) and the loader (`lib`) would not share the map instance, which is exactly the sharing that breaks in real builds. It fails on `main` (`build #2: ERROR in ./LazyPart.jsx ... Can't resolve`) and passes here; the whole `webpack/react` suite (129 tests) passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed intermittent module-resolution failures in multi-environment builds involving lazy-loaded chunks.
  * Isolated compiler-specific definitions so builds no longer interfere with one another.
* **Tests**
  * Added regression coverage confirming repeated lazy builds complete successfully in separate processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->