### PR TITLE
fix(react): encode the templates of an Element Template lazy bundle

### DIFF
--- a/.changeset/et-lazy-bundle-templates.md
+++ b/.changeset/et-lazy-bundle-templates.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react-webpack-plugin": patch
+---
+
+Encode the element templates of a lazy bundle into that lazy bundle. Its chunk groups come from dynamic imports and have no name, so looking them up in `compilation.namedChunkGroups` found nothing and every Element Template lazy bundle shipped without its templates: the main thread could not create them, the lazy component never rendered, and a development build reported `No BehaviorController defined for class template`.

--- a/packages/webpack/react-webpack-plugin/src/ReactWebpackPlugin.ts
+++ b/packages/webpack/react-webpack-plugin/src/ReactWebpackPlugin.ts
@@ -149,13 +149,35 @@ export function collectElementTemplatesForEntries<TChunk>(
     chunk: TChunk,
   ) => Iterable<ModuleWithElementTemplateBuildInfo>,
 ): Record<string, Record<string, unknown>> {
-  const elementTemplates: Record<string, Record<string, unknown>> = {};
-  const visited = new Set<ModuleWithElementTemplateBuildInfo>();
+  const chunkGroups: { chunks: Iterable<TChunk> }[] = [];
   for (const entryName of entryNames) {
     const chunkGroup = getChunkGroup(entryName);
-    if (chunkGroup === undefined) {
-      continue;
+    if (chunkGroup !== undefined) {
+      chunkGroups.push(chunkGroup);
     }
+  }
+  return collectElementTemplatesForChunkGroups(chunkGroups, getChunkModules);
+}
+
+/**
+ * Collect element templates for the chunk groups an encoded bundle covers.
+ *
+ * A lazy bundle's chunk groups come from dynamic imports and have no name, so
+ * they have to be walked directly rather than looked up in
+ * `compilation.namedChunkGroups`; otherwise the lazy bundle is encoded without
+ * its templates and the main thread cannot create them.
+ *
+ * @internal
+ */
+export function collectElementTemplatesForChunkGroups<TChunk>(
+  chunkGroups: Iterable<{ chunks: Iterable<TChunk> }>,
+  getChunkModules: (
+    chunk: TChunk,
+  ) => Iterable<ModuleWithElementTemplateBuildInfo>,
+): Record<string, Record<string, unknown>> {
+  const elementTemplates: Record<string, Record<string, unknown>> = {};
+  const visited = new Set<ModuleWithElementTemplateBuildInfo>();
+  for (const chunkGroup of chunkGroups) {
     for (const chunk of chunkGroup.chunks) {
       for (const module of getChunkModules(chunk)) {
         if (visited.has(module)) {
@@ -586,12 +608,9 @@ class ReactWebpackPlugin {
           `${this.constructor.name}.ElementTemplate`,
           (args) => {
             const { chunkGraph } = compilation;
-            const elementTemplates = collectElementTemplatesForEntries(
-              args.chunkGroups.flatMap(cg =>
-                cg.name === null || cg.name === undefined ? [] : [cg.name]
-              ),
-              (name) => compilation.namedChunkGroups.get(name),
-              (chunk) =>
+            const elementTemplates = collectElementTemplatesForChunkGroups(
+              args.chunkGroups,
+              (chunk: Chunk) =>
                 chunkGraph.getChunkModules(
                   chunk,
                 ) as ModuleWithElementTemplateBuildInfo[],

--- a/packages/webpack/react-webpack-plugin/test/ReactWebpackPlugin.test.ts
+++ b/packages/webpack/react-webpack-plugin/test/ReactWebpackPlugin.test.ts
@@ -4,6 +4,7 @@
 import { describe, expect, it } from '@rstest/core';
 
 import {
+  collectElementTemplatesForChunkGroups,
   collectElementTemplatesForEntries,
   collectElementTemplatesFromModule,
   mergeElementTemplate,
@@ -219,6 +220,21 @@ function moduleWithTemplate(
     },
   };
 }
+
+describe('collectElementTemplatesForChunkGroups', () => {
+  it('collects the templates of an unnamed lazy bundle chunk group', () => {
+    const lazyModule = moduleWithTemplate('_et_lazy', { type: 'text' });
+    const lazyChunk = { id: 'src_LazyComponent_tsx' };
+    // A dynamic import produces a chunk group without a name.
+    const lazyGroup = { name: null, chunks: [lazyChunk] };
+    const getChunkModules = (chunk: typeof lazyChunk) =>
+      chunk === lazyChunk ? [lazyModule] : [];
+
+    expect(
+      collectElementTemplatesForChunkGroups([lazyGroup], getChunkModules),
+    ).toEqual({ _et_lazy: { type: 'text' } });
+  });
+});
 
 describe('collectElementTemplatesForEntries', () => {
   it('scopes templates to the encoded bundle so a lazy template does not leak into the main bundle', () => {


### PR DESCRIPTION
A lazy bundle's chunk groups come from dynamic imports and have no name. `ReactWebpackPlugin` collected element templates by looking the covered chunk groups up in `compilation.namedChunkGroups`, so every Element Template lazy bundle was encoded with an empty `elementTemplate` map (production and development alike).

On device the main thread then cannot create the lazy component's templates:

- production: the lazy component silently never renders (`examples/react-et-lazy-bundle` stays on `basic-loading`, `inner-loading`, …)
- development: `No BehaviorController defined for class template` / `Can't find ui tag` on every lazy template

This walks the chunk groups the encoded bundle covers directly. With the fix, the lazy bundles of `examples/react-et-lazy-bundle` carry their templates again and a development build renders `basic-ready`, `nested-ready`, `parallel-*-ready`, `remount-ready-1` on LynxExplorer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed lazy-loaded components failing to render because their element templates were missing from lazy bundles.
  * Unnamed lazy bundles created through dynamic imports now include the required templates.
  * Resolved a development-build error related to missing behavior controllers for class templates.

* **Tests**
  * Added coverage for element templates in unnamed lazy bundles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->