### PR TITLE
fix(examples): bake the lazy bundle host into react-et-lazy-bundle

### DIFF
--- a/examples/react-et-lazy-bundle/lynx.config.js
+++ b/examples/react-et-lazy-bundle/lynx.config.js
@@ -1,10 +1,36 @@
+import os from 'node:os';
+
 import { pluginQRCode } from '@lynx-js/qrcode-rsbuild-plugin';
 import { pluginReactLynx } from '@lynx-js/react-rsbuild-plugin';
 import { defineConfig } from '@lynx-js/rspeedy';
 
 const enableBundleAnalysis = !!process.env['RSPEEDY_BUNDLE_ANALYSIS'];
 
+function detectLanHost() {
+  for (const ifaces of Object.values(os.networkInterfaces())) {
+    for (const iface of ifaces ?? []) {
+      if (iface.family === 'IPv4' && !iface.internal) {
+        return iface.address;
+      }
+    }
+  }
+  throw new Error('No external IPv4 interface found for lazy bundle host.');
+}
+
+// Lazy bundles are fetched by absolute URL: with the default `/` public path a
+// device gets a relative schema, never fetches the lazy bundle and never
+// resolves the `import()`.
+const port = Number(process.env['LYNX_LAZY_BUNDLE_PORT'] ?? '54174');
+const assetPrefix = `http://${detectLanHost()}:${port}/`;
+
 export default defineConfig({
+  output: {
+    assetPrefix,
+  },
+  server: {
+    port,
+    strictPort: true,
+  },
   plugins: [
     pluginReactLynx({
       experimental_useElementTemplate: true,


### PR DESCRIPTION
\`examples/react-et-lazy-bundle\` has no \`output.assetPrefix\`, so a production build ships \`/lazy-bundle/…\` as the lazy bundle schema. LynxExplorer never fetches a relative schema and never calls back, so every \`import()\` stays pending and the page sits on \`dynamic-pending\`, \`basic-loading\`, \`inner-loading\`, … forever (a development build works because the dev server injects an absolute public path).

Bake the LAN address the way \`examples/react-lazy-bundle\` does (\`LYNX_LAZY_BUNDLE_PORT\`, default 54174). Together with #3819 a production build renders \`first-screen-ready\`, \`basic-ready\`, \`nested-ready\`, \`parallel-*-ready\`, \`remount-ready-1\` on LynxExplorer with 0 errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lazy bundle loading in the React example by using a network-accessible URL.
  * Added support for configuring the lazy bundle server port through an environment variable, with a default port provided.
  * The server now requires the configured port to be available, helping prevent unexpected port changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->