### PR TITLE
fix(debug-metadata): include contentHash in the release key

### DIFF
--- a/.changeset/release-key-content-hash.md
+++ b/.changeset/release-key-content-hash.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/debug-metadata-rsbuild-plugin": patch
+---
+
+Fold `chunk.contentHash` into the release key so a CSS-only change produces a new release.

--- a/packages/rspeedy/plugin-debug-metadata/src/release-banner.ts
+++ b/packages/rspeedy/plugin-debug-metadata/src/release-banner.ts
@@ -22,13 +22,17 @@ export function computeReleaseKey(...parts: string[]): string {
 /**
  * The artifact release key — baked into the runtime banner and stored as each
  * source map's `key`. A 160-bit hash over the chunk's *module identifiers* plus
- * its `chunk.hash`, rather than re-hashing the bundler's truncated 64-bit
- * `chunk.hash` alone (which wouldn't make it any stronger). The module-id set
- * is the chunk's source modules: different apps bundle different files, so two
- * apps can't produce the same release even if their 64-bit `chunk.hash`
- * collides — no `uniqueName` / `bid` namespace to configure — while `chunk.hash`
- * still tracks content changes within one app. Module identifiers are fixed at
- * build time and banner-independent, so the banner (build time) and the
+ * its `chunk.hash` and every entry of its `chunk.contentHash`, rather than
+ * re-hashing the bundler's truncated 64-bit `chunk.hash` alone (which wouldn't
+ * make it any stronger). The module-id set is the chunk's source modules:
+ * different apps bundle different files, so two apps can't produce the same
+ * release even if their 64-bit `chunk.hash` collides — no `uniqueName` / `bid`
+ * namespace to configure. `chunk.hash` only covers what the JavaScript
+ * pipeline renders, so the per-source-type `chunk.contentHash` entries carry
+ * the rest: an edit confined to an extracted CSS module moves
+ * `contentHash['css/mini-extract']` alone, leaving `chunk.hash` and every
+ * module identifier untouched. All three inputs are fixed once the chunk is
+ * hashed and are banner-independent, so the banner (build time) and the
  * collector (encode time) compute the same value for the same chunk.
  */
 export function computeChunkReleaseKey(
@@ -45,9 +49,14 @@ export function computeChunkReleaseKey(
   // `getChunkModules` order is not guaranteed stable; sort so the key is
   // deterministic for a given module set.
   moduleIds.sort()
+  const contentHash: Record<string, string> = chunk.contentHash ?? {}
+  const contentHashes = Object.entries(contentHash)
+    .map(([sourceType, hash]) => `${sourceType}=${hash}`)
+    .sort()
   const key = computeReleaseKey(
     chunk.name ?? '',
     chunk.hash ?? '',
+    ...contentHashes,
     ...moduleIds,
   )
   releaseKeyCache.set(chunk, key)

--- a/packages/rspeedy/plugin-debug-metadata/test/release-key.test.ts
+++ b/packages/rspeedy/plugin-debug-metadata/test/release-key.test.ts
@@ -21,7 +21,17 @@ function fakeChunkGraph(
 }
 
 function fakeChunk(over: Partial<Rspack.Chunk> = {}): Rspack.Chunk {
-  return { name: 'main', hash: 'abc', runtime: 'main', ...over } as Rspack.Chunk
+  return {
+    name: 'main',
+    hash: 'abc',
+    runtime: 'main',
+    contentHash: { javascript: 'js1' },
+    ...over,
+  } as Rspack.Chunk
+}
+
+function hashedChunk(contentHash: Record<string, string>): Rspack.Chunk {
+  return fakeChunk({ contentHash } as Partial<Rspack.Chunk>)
 }
 
 describe('computeReleaseKey', () => {
@@ -66,5 +76,42 @@ describe('computeChunkReleaseKey', () => {
     ).not.toBe(
       computeChunkReleaseKey(fakeChunkGraph('m1'), fakeChunk({ hash: 'h2' })),
     )
+  })
+
+  test('a CSS-only edit changes the key (`chunk.hash` does not move)', () => {
+    expect(
+      computeChunkReleaseKey(
+        fakeChunkGraph('m1'),
+        hashedChunk({ javascript: 'js1', 'css/mini-extract': 'css1' }),
+      ),
+    ).not.toBe(
+      computeChunkReleaseKey(
+        fakeChunkGraph('m1'),
+        hashedChunk({ javascript: 'js1', 'css/mini-extract': 'css2' }),
+      ),
+    )
+  })
+
+  test('content hash order does not affect the key (sorted)', () => {
+    expect(
+      computeChunkReleaseKey(
+        fakeChunkGraph('m1'),
+        hashedChunk({ javascript: 'a', 'css/mini-extract': 'b' }),
+      ),
+    ).toBe(
+      computeChunkReleaseKey(
+        fakeChunkGraph('m1'),
+        hashedChunk({ 'css/mini-extract': 'b', javascript: 'a' }),
+      ),
+    )
+  })
+
+  test('a chunk with no content hash still yields a key', () => {
+    expect(
+      computeChunkReleaseKey(
+        fakeChunkGraph('m1'),
+        fakeChunk({ contentHash: undefined } as Partial<Rspack.Chunk>),
+      ),
+    ).toMatch(/^[0-9a-f]{40}$/)
   })
 })


### PR DESCRIPTION
`computeChunkReleaseKey` hashes `chunk.name` + `chunk.hash` + the chunk's sorted module identifiers. None of those move when a change is confined to an extracted CSS module: the identifiers are paths, and `chunk.hash` only covers what the JavaScript pipeline renders. The chunk therefore keeps its release across a real source change, and one release ends up pointing at several different source maps.

Observed on a production build, same chunk, two consecutive commits — one CSS file gained a `transition` declaration:

```
chunk.hash    42898431b0829b2c -> 42898431b0829b2c   (unchanged)
contentHash['css/mini-extract']
              bc0b6cdb6f3dab64 -> 95411242994dd50f   (changed)
release       2bacc33d0fce     -> 2bacc33d0fce       (unchanged)
```

The emitted maps differ in `mappings` and `sourcesContent`, so remapping against the wrong sibling yields wrong positions.

Fix: fold every `chunk.contentHash` entry into the key, sorted by source type. With the same two builds the release becomes `f8083bafd3dc -> 8a28582c6fe7`.

Release keys change for chunks that emit non-JS source types. Both producers of the key (the runtime banner and the artifact collector) read it through the same per-chunk cache within one compilation, so they stay in agreement.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Release keys now reflect CSS-only and other source-specific content changes, ensuring updated releases are generated when output changes.
  * Content-hash ordering no longer affects release-key results.
  * Chunks without content hashes continue to produce valid release keys.

* **Chores**
  * Added a patch release entry for the debug metadata plugin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->