### PR TITLE
fix(react): type use() against React's Context

### DIFF
--- a/.changeset/compat-use-context-type.md
+++ b/.changeset/compat-use-context-type.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react": patch
+---
+
+Type the context argument of `use` with React's `Context`, matching the rest of the public surface. `@lynx-js/react` re-exports `createContext` from `react`, so declaring `use` against Preact's `Context` made a context created through the package fail to type-check.

--- a/packages/react/runtime/compat/index.d.ts
+++ b/packages/react/runtime/compat/index.d.ts
@@ -1,7 +1,7 @@
 // Copyright 2025 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
-import type { Context } from 'preact';
+import type { Context } from 'react';
 
 export * from '@lynx-js/react';
 


### PR DESCRIPTION
## What

Declare the context argument of `use` with React's `Context` instead of Preact's.

## Why

`@lynx-js/react` re-exports `createContext` from `react` (`types/react.docs.d.ts`), so the `Context` its users hold is React's. `use` was declared against Preact's `Context`, and under `exactOptionalPropertyTypes: true` the two are not assignable, so a context created through the package failed to type-check at the call site:

```
error TS2345: Argument of type 'Context<string>' is not assignable to parameter of type 'Context<string> | Promise<string>'.
  Type 'React.Context<string>' is not assignable to type 'preact.Context<string>' with 'exactOptionalPropertyTypes: true'.
      Type 'React.Consumer<string>' is not assignable to type 'preact.Consumer<string>'.
```

Reproduced from an example package with:

```tsx
import { createContext } from '@lynx-js/react';
import { use } from '@lynx-js/react/compat';

const Theme = createContext('light');
export function Probe(): string {
  return use(Theme);
}
```

The runtime is unaffected — this is a declaration-only change.