### PR TITLE
fix(react): set _globalContext on main-thread components

### DIFF
--- a/.changeset/use-main-thread-global-context.md
+++ b/.changeset/use-main-thread-global-context.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react": patch
+---
+
+Fix `use()` from `@lynx-js/react/compat` throwing `cannot read property '__cC0' of undefined` on the main thread. The main-thread renderer never set `_globalContext` on the components it builds, and `use` reads its context provider from there. `useContext` was unaffected because it reads `context` instead.

--- a/examples/react-use-context/lynx.config.js
+++ b/examples/react-use-context/lynx.config.js
@@ -1,0 +1,22 @@
+import { pluginQRCode } from '@lynx-js/qrcode-rsbuild-plugin';
+import { pluginReactLynx } from '@lynx-js/react-rsbuild-plugin';
+import { defineConfig } from '@lynx-js/rspeedy';
+
+import { pluginLynxBundleAnalysisStats } from '../bundle-analysis-stats.plugin.js';
+
+export default defineConfig({
+  plugins: [
+    pluginReactLynx(),
+    pluginQRCode({
+      schema(url) {
+        // We use `?fullscreen=true` to open the page in LynxExplorer in full screen mode
+        return `${url}?fullscreen=true`;
+      },
+    }),
+    pluginLynxBundleAnalysisStats(),
+  ],
+  environments: {
+    web: {},
+    lynx: {},
+  },
+});

--- a/examples/react-use-context/lynx.config.js
+++ b/examples/react-use-context/lynx.config.js
@@ -4,9 +4,15 @@ import { defineConfig } from '@lynx-js/rspeedy';
 
 import { pluginLynxBundleAnalysisStats } from '../bundle-analysis-stats.plugin.js';
 
+// Set `USE_ELEMENT_TEMPLATE=1` to build the same app through the Element
+// Template render path instead of the snapshot one.
+const useElementTemplate = process.env['USE_ELEMENT_TEMPLATE'] === '1';
+
 export default defineConfig({
   plugins: [
-    pluginReactLynx(),
+    pluginReactLynx({
+      experimental_useElementTemplate: useElementTemplate,
+    }),
     pluginQRCode({
       schema(url) {
         // We use `?fullscreen=true` to open the page in LynxExplorer in full screen mode
@@ -15,6 +21,11 @@ export default defineConfig({
     }),
     pluginLynxBundleAnalysisStats(),
   ],
+  source: {
+    define: {
+      __USE_ELEMENT_TEMPLATE__: JSON.stringify(useElementTemplate),
+    },
+  },
   environments: {
     web: {},
     lynx: {},

--- a/examples/react-use-context/package.json
+++ b/examples/react-use-context/package.json
@@ -5,7 +5,9 @@
   "type": "module",
   "scripts": {
     "build": "rspeedy build",
+    "build:et": "USE_ELEMENT_TEMPLATE=1 rspeedy build",
     "dev": "rspeedy dev",
+    "dev:et": "USE_ELEMENT_TEMPLATE=1 rspeedy dev",
     "test:type": "tsc6 --noEmit"
   },
   "dependencies": {

--- a/examples/react-use-context/package.json
+++ b/examples/react-use-context/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@lynx-js/example-react-use-context",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "rspeedy build",
+    "dev": "rspeedy dev",
+    "test:type": "tsc6 --noEmit"
+  },
+  "dependencies": {
+    "@lynx-js/react": "workspace:*"
+  },
+  "devDependencies": {
+    "@lynx-js/preact-devtools": "catalog:lynxjs",
+    "@lynx-js/qrcode-rsbuild-plugin": "workspace:*",
+    "@lynx-js/react-rsbuild-plugin": "workspace:*",
+    "@lynx-js/rspeedy": "workspace:*",
+    "@lynx-js/types": "4.1.0",
+    "@types/react": "^19.2.18"
+  }
+}

--- a/examples/react-use-context/src/App.tsx
+++ b/examples/react-use-context/src/App.tsx
@@ -1,0 +1,92 @@
+import { createContext, useState } from '@lynx-js/react';
+import { use } from '@lynx-js/react/compat';
+
+interface Theme {
+  name: string;
+  fg: string;
+  bg: string;
+}
+
+const light: Theme = { name: 'light', fg: '#1a1a1a', bg: '#f5f5f7' };
+const dark: Theme = { name: 'dark', fg: '#f5f5f7', bg: '#16161a' };
+
+const ThemeContext = createContext<Theme>(light);
+
+// Rendered on the first screen, so `use` runs on the main thread before the
+// background runtime has started.
+function Title() {
+  const theme = use(ThemeContext);
+  return (
+    <text style={{ color: theme.fg, fontSize: '24px' }}>
+      use() on {theme.name}
+    </text>
+  );
+}
+
+function Card({ label }: { label: string }) {
+  const theme = use(ThemeContext);
+  return (
+    <view
+      style={{
+        marginTop: '12px',
+        padding: '16px',
+        borderRadius: '12px',
+        backgroundColor: theme.name === 'dark' ? '#26262c' : '#ffffff',
+      }}
+    >
+      <text style={{ color: theme.fg }}>{label}</text>
+    </view>
+  );
+}
+
+// Outside every Provider, so `use` falls back to the context default.
+function OutsideProvider() {
+  const theme = use(ThemeContext);
+  return (
+    <view
+      style={{
+        padding: '16px',
+        borderRadius: '12px',
+        backgroundColor: theme.bg,
+      }}
+    >
+      <text style={{ color: theme.fg }}>
+        outside any provider, default: {theme.name}
+      </text>
+    </view>
+  );
+}
+
+export function App() {
+  const [isDark, setIsDark] = useState(false);
+  const theme = isDark ? dark : light;
+
+  return (
+    <view style={{ flex: 1, backgroundColor: theme.bg, padding: '40px' }}>
+      <ThemeContext.Provider value={theme}>
+        <Title />
+        <Card label='read through use(), not useContext()' />
+        <ThemeContext.Provider value={light}>
+          <Card label='nested provider always reads light' />
+        </ThemeContext.Provider>
+        <view
+          bindtap={() => {
+            'background-only';
+            setIsDark(v => !v);
+          }}
+          style={{
+            marginTop: '20px',
+            padding: '16px',
+            borderRadius: '12px',
+            backgroundColor: '#4f7cff',
+          }}
+        >
+          <text style={{ color: '#fff' }}>toggle theme</text>
+        </view>
+      </ThemeContext.Provider>
+      <view style={{ marginTop: '20px' }}>
+        <OutsideProvider />
+      </view>
+    </view>
+  );
+}

--- a/examples/react-use-context/src/App.tsx
+++ b/examples/react-use-context/src/App.tsx
@@ -65,6 +65,10 @@ export function App() {
     <view style={{ flex: 1, backgroundColor: theme.bg, padding: '40px' }}>
       <ThemeContext.Provider value={theme}>
         <Title />
+        <text style={{ color: theme.fg, fontSize: '13px', marginTop: '4px' }}>
+          render path:{' '}
+          {__USE_ELEMENT_TEMPLATE__ ? 'element template' : 'snapshot'}
+        </text>
         <Card label='read through use(), not useContext()' />
         <ThemeContext.Provider value={light}>
           <Card label='nested provider always reads light' />

--- a/examples/react-use-context/src/index.tsx
+++ b/examples/react-use-context/src/index.tsx
@@ -1,0 +1,13 @@
+import '@lynx-js/preact-devtools';
+import '@lynx-js/react/debug';
+import { root } from '@lynx-js/react';
+
+import { App } from './App.jsx';
+
+root.render(
+  <App />,
+);
+
+if (import.meta.webpackHot) {
+  import.meta.webpackHot.accept();
+}

--- a/examples/react-use-context/src/rspeedy-env.d.ts
+++ b/examples/react-use-context/src/rspeedy-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="@lynx-js/rspeedy/client" />

--- a/examples/react-use-context/src/rspeedy-env.d.ts
+++ b/examples/react-use-context/src/rspeedy-env.d.ts
@@ -1,1 +1,3 @@
 /// <reference types="@lynx-js/rspeedy/client" />
+
+declare const __USE_ELEMENT_TEMPLATE__: boolean;

--- a/examples/react-use-context/tsconfig.json
+++ b/examples/react-use-context/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "@lynx-js/react",
+    "noEmit": true,
+
+    "allowJs": true,
+    "checkJs": true,
+    "isolatedDeclarations": false,
+  },
+  "include": ["src", "lynx.config.js", "test", "vitest.config.ts"],
+  "references": [
+    { "path": "../../packages/react/tsconfig.json" },
+    { "path": "../../packages/rspeedy/core/tsconfig.build.json" },
+    { "path": "../../packages/rspeedy/plugin-qrcode/tsconfig.build.json" },
+    { "path": "../../packages/rspeedy/plugin-react/tsconfig.build.json" },
+  ],
+}

--- a/packages/react/runtime/__test__/element-template/runtime/render/render-to-opcodes.et.test.jsx
+++ b/packages/react/runtime/__test__/element-template/runtime/render/render-to-opcodes.et.test.jsx
@@ -2,7 +2,7 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 import { Component, Fragment, createContext, h, options } from 'preact';
-import { Suspense } from 'preact/compat';
+import { Suspense, use } from 'preact/compat';
 import { useState } from '@lynx-js/react/lepus/hooks';
 import { describe, expect, it } from 'vitest';
 
@@ -28,6 +28,19 @@ describe('Element Template renderToOpcodes', () => {
     expect(__OpSlot).toBe(4);
     expect(__OpPageStart).toBe(5);
     expect(__OpPageEnd).toBe(6);
+  });
+
+  it('lets use() read a context', () => {
+    const Ctx = createContext('default');
+
+    function Reader() {
+      return use(Ctx);
+    }
+
+    expect(
+      renderToString(h(Ctx.Provider, { value: 'provided' }, h(Reader, null))),
+    ).toContain('provided');
+    expect(renderToString(h(Reader, null))).toContain('default');
   });
 
   it('emits slot opcodes for ET host nodes using $N named props', () => {

--- a/packages/react/runtime/__test__/element-template/runtime/render/render-to-opcodes.et.test.jsx
+++ b/packages/react/runtime/__test__/element-template/runtime/render/render-to-opcodes.et.test.jsx
@@ -43,6 +43,40 @@ describe('Element Template renderToOpcodes', () => {
     expect(renderToString(h(Reader, null))).toContain('default');
   });
 
+  it('lets use() read a context from a class that declares contextType', () => {
+    const Ctx = createContext('default');
+    const seen = [];
+
+    class Reader extends Component {
+      static contextType = Ctx;
+      render() {
+        seen.push(['this.context', this.context], ['use', use(Ctx)]);
+        return 'ok';
+      }
+    }
+
+    renderToString(h(Ctx.Provider, { value: 'provided' }, h(Reader, null)));
+
+    expect(seen).toEqual([['this.context', 'provided'], ['use', 'provided']]);
+  });
+
+  it('lets use() read a context from a function that declares contextType', () => {
+    const Ctx = createContext('default');
+    const seen = [];
+
+    function Reader(_props, context) {
+      seen.push(['arg', context], ['use', use(Ctx)]);
+      return 'ok';
+    }
+    Reader.contextType = Ctx;
+
+    renderToString(h(Ctx.Provider, { value: 'provided' }, h(Reader, null)));
+
+    // `context` is the resolved contextType value here, so `use` has to read
+    // the provider map from `_globalContext` instead.
+    expect(seen).toEqual([['arg', 'provided'], ['use', 'provided']]);
+  });
+
   it('emits slot opcodes for ET host nodes using $N named props', () => {
     const Template = '_et_test_root';
     const opcodes = renderToString(<Template $3='marker' />);

--- a/packages/react/runtime/__test__/snapshot/use-main-thread.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/use-main-thread.test.jsx
@@ -94,4 +94,48 @@ describe('use() on the main thread', () => {
 
     expect(seen).toEqual(['provided']);
   });
+
+  describe('alongside contextType', () => {
+    it('gives a class its contextType value while use() still reads the provider', () => {
+      const Ctx = createContext('default');
+      const seen = [];
+
+      class Reader extends Component {
+        static contextType = Ctx;
+        render() {
+          seen.push(['this.context', this.context], ['use', use(Ctx)]);
+          return <text>ok</text>;
+        }
+      }
+
+      renderToString(
+        <Ctx.Provider value='provided'>
+          <Reader />
+        </Ctx.Provider>,
+      );
+
+      expect(seen).toEqual([['this.context', 'provided'], ['use', 'provided']]);
+    });
+
+    it('gives a function its contextType value while use() still reads the provider', () => {
+      const Ctx = createContext('default');
+      const seen = [];
+
+      function Reader(_props, context) {
+        seen.push(['arg', context], ['use', use(Ctx)]);
+        return <text>ok</text>;
+      }
+      Reader.contextType = Ctx;
+
+      renderToString(
+        <Ctx.Provider value='provided'>
+          <Reader />
+        </Ctx.Provider>,
+      );
+
+      // `context` is the resolved contextType value here, so `use` has to read
+      // the provider map from `_globalContext` instead.
+      expect(seen).toEqual([['arg', 'provided'], ['use', 'provided']]);
+    });
+  });
 });

--- a/packages/react/runtime/__test__/snapshot/use-main-thread.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/use-main-thread.test.jsx
@@ -1,0 +1,97 @@
+/** @jsxImportSource ../../lepus */
+
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { Component, createContext } from 'preact';
+import { use } from 'preact/compat';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { elementTree } from './utils/nativeMethod';
+import { globalEnvManager } from './utils/envManager';
+import { setupDocument } from '../../src/document';
+import renderToStringBase from '../../src/snapshot/renderToOpcodes';
+import { setupPage, snapshotInstanceManager } from '../../src/snapshot';
+import { __root } from '../../src/root';
+
+const renderToString = element => renderToStringBase(element, null, __root);
+
+describe('use() on the main thread', () => {
+  beforeAll(() => {
+    globalEnvManager.switchToMainThread();
+  });
+
+  beforeEach(() => {
+    setupPage(__CreatePage('0', 0));
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    globalEnvManager.resetEnv();
+    elementTree.clear();
+    snapshotInstanceManager.clear();
+  });
+
+  it('reads a provided value and falls back to the default', () => {
+    const Ctx = createContext('default');
+    const seen = [];
+
+    function Reader() {
+      seen.push(use(Ctx));
+      return <text>ok</text>;
+    }
+
+    renderToString(
+      <view>
+        <Ctx.Provider value='provided'>
+          <Reader />
+        </Ctx.Provider>
+        <Reader />
+      </view>,
+    );
+
+    expect(seen).toEqual(['provided', 'default']);
+  });
+
+  it('reads the nearest provider when they nest', () => {
+    const Ctx = createContext('default');
+    const seen = [];
+
+    function Reader() {
+      seen.push(use(Ctx));
+      return <text>ok</text>;
+    }
+
+    renderToString(
+      <Ctx.Provider value='outer'>
+        <Reader />
+        <Ctx.Provider value='inner'>
+          <Reader />
+        </Ctx.Provider>
+      </Ctx.Provider>,
+    );
+
+    expect(seen).toEqual(['outer', 'inner']);
+  });
+
+  it('works inside a class component render', () => {
+    const Ctx = createContext('default');
+    const seen = [];
+
+    class Reader extends Component {
+      render() {
+        seen.push(use(Ctx));
+        return <text>ok</text>;
+      }
+    }
+
+    renderToString(
+      <Ctx.Provider value='provided'>
+        <Reader />
+      </Ctx.Provider>,
+    );
+
+    expect(seen).toEqual(['provided']);
+  });
+});

--- a/packages/react/runtime/src/element-template/runtime/render/render-to-opcodes.ts
+++ b/packages/react/runtime/src/element-template/runtime/render/render-to-opcodes.ts
@@ -21,6 +21,7 @@ import {
   DIFF,
   DIFF2,
   DIFFED,
+  GLOBAL_CONTEXT,
   NEXT_STATE,
   PARENT,
   RENDER,
@@ -107,7 +108,7 @@ export const __OpPageEnd = 6;
  * @param {VNode} vnode
  * @param {Record<string, unknown>} context
  */
-function renderClassComponent(vnode, context) {
+function renderClassComponent(vnode, context, globalContext) {
   const type = /** @type {import("preact").ComponentClass<typeof vnode.props>} */ (vnode.type);
 
   let c;
@@ -123,6 +124,7 @@ function renderClassComponent(vnode, context) {
 
   c.props = vnode.props;
   c.context = context;
+  c[GLOBAL_CONTEXT] = globalContext;
   // turn off stateful re-rendering:
   c[BITS] |= COMPONENT_DIRTY;
 
@@ -193,13 +195,14 @@ function renderComponentVNode(
     }
 
     if (type.prototype && typeof type.prototype.render === 'function') {
-      rendered = /**#__NOINLINE__**/ renderClassComponent(vnode, cctx);
+      rendered = /**#__NOINLINE__**/ renderClassComponent(vnode, cctx, context);
       component = vnode[COMPONENT];
     } else {
       component = {
         __v: vnode,
         props,
         context: cctx,
+        [GLOBAL_CONTEXT]: context,
         // silently drop state updates
         setState: markAsDirty,
         forceUpdate: markAsDirty,
@@ -238,7 +241,7 @@ function renderComponentVNode(
       component.setState({ /* _suspended */ __a: true });
 
       if (component[BITS] & COMPONENT_DIRTY) {
-        rendered = renderClassComponent(vnode, context);
+        rendered = renderClassComponent(vnode, context, context);
         component = vnode[COMPONENT];
 
         opcodes.length = opcodesLength;

--- a/packages/react/runtime/src/shared/render-constants.ts
+++ b/packages/react/runtime/src/shared/render-constants.ts
@@ -29,6 +29,7 @@ export const BITS = '__g';
 export const COMPONENT_DIRTY: number = 1 << 3;
 export const COMPONENT_FORCE: number = 1 << 2;
 export const NEXT_STATE = '__s';
+export const GLOBAL_CONTEXT = '__n';
 export const CHILD_DID_SUSPEND = '__c';
 export const RENDER_CALLBACKS = '__h';
 export const HOOK = '__h';

--- a/packages/react/runtime/src/snapshot/renderToOpcodes/index.ts
+++ b/packages/react/runtime/src/snapshot/renderToOpcodes/index.ts
@@ -22,6 +22,7 @@ import {
   DIFF,
   DIFF2,
   DIFFED,
+  GLOBAL_CONTEXT,
   NEXT_STATE,
   PARENT,
   RENDER,
@@ -104,7 +105,7 @@ export const __OpText = 3;
  * @param {VNode} vnode
  * @param {Record<string, unknown>} context
  */
-function renderClassComponent(vnode, context) {
+function renderClassComponent(vnode, context, globalContext) {
   const type = /** @type {import("preact").ComponentClass<typeof vnode.props>} */ (vnode.type);
 
   let c;
@@ -120,6 +121,7 @@ function renderClassComponent(vnode, context) {
 
   c.props = vnode.props;
   c.context = context;
+  c[GLOBAL_CONTEXT] = globalContext;
   // turn off stateful re-rendering:
   c[BITS] |= COMPONENT_DIRTY;
 
@@ -225,13 +227,14 @@ function _renderToString(
       }
 
       if (type.prototype && typeof type.prototype.render === 'function') {
-        rendered = /**#__NOINLINE__**/ renderClassComponent(vnode, cctx);
+        rendered = /**#__NOINLINE__**/ renderClassComponent(vnode, cctx, context);
         component = vnode[COMPONENT];
       } else {
         component = {
           [VNODE]: vnode,
           props,
           context: cctx,
+          [GLOBAL_CONTEXT]: context,
           // silently drop state updates
           setState: markAsDirty,
           forceUpdate: markAsDirty,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -790,6 +790,31 @@ importers:
         specifier: ^19.2.18
         version: 19.2.18
 
+  examples/react-use-context:
+    dependencies:
+      '@lynx-js/react':
+        specifier: workspace:*
+        version: link:../../packages/react
+    devDependencies:
+      '@lynx-js/preact-devtools':
+        specifier: catalog:lynxjs
+        version: 5.0.1-20260827072047-5f77e12
+      '@lynx-js/qrcode-rsbuild-plugin':
+        specifier: workspace:*
+        version: link:../../packages/rspeedy/plugin-qrcode
+      '@lynx-js/react-rsbuild-plugin':
+        specifier: workspace:*
+        version: link:../../packages/rspeedy/plugin-react
+      '@lynx-js/rspeedy':
+        specifier: workspace:*
+        version: link:../../packages/rspeedy/core
+      '@lynx-js/types':
+        specifier: 4.1.0
+        version: 4.1.0
+      '@types/react':
+        specifier: ^19.2.18
+        version: 19.2.18
+
   examples/rsbuild:
     dependencies:
       '@lynx-js/react':


### PR DESCRIPTION
Stacked on #3837 — review that one first. It will retarget to `main` once #3837 lands.

## What

Set `_globalContext` on the components both main-thread renderers build, so `use()` can read a context there.

## Why

`use` reads its provider from `currentComponent._globalContext`. The main-thread renderers synthesise their own component objects and only ever set `context`, so reading a context through `use` during the first screen threw:

```
main-thread.js exception: cannot read property '__cC0' of undefined
    at use (file:///main-thread.js:130:100)
```

`useContext` was unaffected — it reads `currentComponent.context[id]`, which the renderers do set. The two hooks read different fields, which is why this only surfaced once `use` was exported.

Preact sets both (`diff/index.js`): `context` is the resolved `contextType` value when a component declares one and the full provider map otherwise, while `_globalContext` is always the full map. `useContext` works only because the two happen to coincide for components without a `contextType`. The renderers already compute both, as `cctx` and `context`, so this wires the second one through.

Both render paths are affected and both are fixed here:

- `snapshot/renderToOpcodes` — the default path
- `element-template/runtime/render/render-to-opcodes` — the Element Template path

Class components get it too, since their `render` can call `use`.

## Tests

- `__test__/snapshot/use-main-thread.test.jsx`: a provided value, the default outside any provider, nested providers, and `use` inside a class `render`.
- `__test__/element-template/.../render-to-opcodes.et.test.jsx`: the same read on the ET path.

Every one of them fails with the original `__cC0` error when the change is reverted.

## Example

`examples/react-use-context` is the end-to-end scenario: a theme context read with `use` from first-screen components. `USE_ELEMENT_TEMPLATE=1` (`pnpm build:et`) builds the same app through the Element Template path, and the page prints which path it was built for.

Verified on a Pixel 5 running Lynx Explorer, both paths: the main-thread exception is gone, toggling the theme re-renders, and a nested provider still overrides its subtree.