### PR TITLE
fix(web): preserve native modules before element upgrade

### DIFF
--- a/.changeset/quiet-views-preserve.md
+++ b/.changeset/quiet-views-preserve.md
@@ -1,0 +1,5 @@
+---
+'@lynx-js/web-core': patch
+---
+
+Preserve `nativeModulesMap` assigned to a `<lynx-view>` before the custom element is defined or upgraded, so custom native modules remain available when the view initializes.

--- a/.github/web-core-property-upgrade.instructions.md
+++ b/.github/web-core-property-upgrade.instructions.md
@@ -1,0 +1,5 @@
+---
+applyTo: "packages/web-platform/web-core/ts/client/mainthread/LynxView.ts,packages/web-platform/web-core/tests/lynx-view.spec.ts"
+---
+
+Preserve properties assigned to an unresolved `<lynx-view>` before custom element upgrade. Use a private backing field with public accessors and replay pre-upgrade own properties through `#upgradeProperty` before rendering. Keep public properties discoverable with the `in` operator on fresh elements for framework property detection. Cover both connected elements upgraded by `customElements.define` and detached elements upgraded by `customElements.upgrade` in regression tests.

--- a/packages/web-platform/web-core/tests/lynx-view.spec.ts
+++ b/packages/web-platform/web-core/tests/lynx-view.spec.ts
@@ -1,0 +1,88 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import {
+  afterAll,
+  beforeAll,
+  describe,
+  expect,
+  rstest,
+  test,
+} from '@rstest/core';
+import { JSDOM } from 'jsdom';
+import type { LynxViewElement } from '../ts/client/mainthread/LynxView.js';
+
+// Property upgrades do not require a template, worker, or WASM runtime.
+rstest.mock('../ts/client/mainthread/TemplateManager.js', () => ({
+  templateManager: {},
+}));
+rstest.mock('../ts/client/mainthread/LynxViewInstance.js', () => ({
+  LynxViewInstance: class {},
+}));
+
+const { window } = new JSDOM(undefined, { url: 'http://localhost/' });
+const { document, customElements } = window;
+let LynxView: typeof LynxViewElement;
+
+beforeAll(async () => {
+  rstest.stubGlobal('document', document);
+  rstest.stubGlobal('HTMLElement', window.HTMLElement);
+  rstest.stubGlobal('customElements', customElements);
+  ({ LynxViewElement: LynxView } = await import(
+    '../ts/client/mainthread/LynxView.js'
+  ));
+});
+
+afterAll(() => {
+  window.close();
+  rstest.unstubAllGlobals();
+});
+
+describe('LynxView nativeModulesMap', () => {
+  test.each([true, false])(
+    'preserves properties assigned before upgrade (connected: %s)',
+    (connected) => {
+      const tag = `lynx-view-upgrade-${connected}`;
+      const element = document.createElement(tag) as LynxViewElement;
+      const modules = { MyModule: '/my-module.js' };
+      element.nativeModulesMap = modules;
+      if (connected) {
+        document.body.appendChild(element);
+      }
+
+      class UpgradedLynxView extends LynxView {}
+      customElements.define(tag, UpgradedLynxView);
+      customElements.upgrade(element);
+
+      expect(element).toBeInstanceOf(UpgradedLynxView);
+      expect(element.nativeModulesMap).toBe(modules);
+
+      document.body.appendChild(element);
+      expect(element.nativeModulesMap).toBe(modules);
+      element.remove();
+    },
+  );
+
+  test('defaults to undefined when no modules were assigned', () => {
+    const element = document.createElement('lynx-view') as LynxViewElement;
+    expect(element.nativeModulesMap).toBeUndefined();
+  });
+
+  test('exposes the property for framework property detection', () => {
+    const element = document.createElement('lynx-view') as LynxViewElement;
+    expect('nativeModulesMap' in element).toBe(true);
+  });
+
+  test('allows assigning, replacing, and clearing modules after upgrade', () => {
+    const element = document.createElement('lynx-view') as LynxViewElement;
+    const initial = { MyModule: '/my-module.js' };
+    const replacement = { OtherModule: '/other-module.js' };
+
+    element.nativeModulesMap = initial;
+    expect(element.nativeModulesMap).toBe(initial);
+    element.nativeModulesMap = replacement;
+    expect(element.nativeModulesMap).toBe(replacement);
+    element.nativeModulesMap = undefined;
+    expect(element.nativeModulesMap).toBeUndefined();
+  });
+});

--- a/packages/web-platform/web-core/ts/client/mainthread/LynxView.ts
+++ b/packages/web-platform/web-core/ts/client/mainthread/LynxView.ts
@@ -93,6 +93,7 @@ export class LynxViewElement extends HTMLElement {
   #connected = false;
   #url?: string;
 
+  #nativeModulesMap?: NativeModulesMap;
   /**
    * @public
    * @property nativeModulesMap
@@ -100,7 +101,12 @@ export class LynxViewElement extends HTMLElement {
    * A `LynxConsoleModule` whose factory returns a Console-like object provides
    * the lexical `console` for this view's background bundles.
    */
-  nativeModulesMap: NativeModulesMap | undefined;
+  get nativeModulesMap(): NativeModulesMap | undefined {
+    return this.#nativeModulesMap;
+  }
+  set nativeModulesMap(val: NativeModulesMap | undefined) {
+    this.#nativeModulesMap = val;
+  }
 
   /**
    * @param
@@ -576,6 +582,7 @@ export class LynxViewElement extends HTMLElement {
    * @private
    */
   connectedCallback() {
+    this.#upgradeProperty('nativeModulesMap');
     this.#upgradeProperty('url');
     this.#upgradeProperty('src');
     this.#upgradeProperty('globalProps');


### PR DESCRIPTION
Fixes #3559.

Setting `nativeModulesMap` on an unresolved `<lynx-view>` currently loses the value when the custom element upgrades, because its public class field initializes to `undefined`.

Store the map in a private field with public accessors and replay pre-upgrade properties through the existing `#upgradeProperty` helper before rendering. This preserves early assignments while keeping the property discoverable on newly created elements for framework property binding. Assigning, replacing, and clearing the map remain supported.

Add regression coverage for connected and detached upgrades, the default value, property detection, and subsequent assignments, plus a patch changeset.

## Validation

- Regression reproduced on the original implementation: both pre-upgrade cases fail because the map becomes `undefined`.
- `pnpm exec rstest run --project web-platform/web-core lynx-view.spec.ts`: 5 tests passed after the full build.
- Isolated Chromium smoke check against the actual component source: connected/detached upgrades, property detection, and assignment/replacement/clearing passed. Template and worker runtime collaborators were stubbed; this is not a full card-rendering E2E test.
- Changed-file dprint and source ESLint checks passed; commit hooks passed.
- `pnpm turbo build`: all 73 tasks passed on the final changes.
- `pnpm turbo api-extractor -- --local`: all 26 tasks passed; no tracked API report changes.
- Changeset status and changeset Markdown validation passed.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved custom native modules assigned to `<lynx-view>` elements before they are initialized or upgraded.
  - Ensured native module mappings remain available for both connected and detached elements.
  - Improved handling of native module mappings, including assignment, replacement, and clearing.
  - Exposed the property consistently for framework property detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->