### PR TITLE
fix(web-core): register page element ID for event dispatch

### DIFF
--- a/.changeset/gentle-pants-fall.md
+++ b/.changeset/gentle-pants-fall.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/web-core": patch
+---
+
+Fix page child events being dispatched as component events by registering the page element unique ID in the Web host.

--- a/.github/web-core-element-event-listeners.instructions.md
+++ b/.github/web-core-element-event-listeners.instructions.md
@@ -7,3 +7,5 @@ Invoke function callbacks registered through `__AddEventListener` one microtask 
 Events whose Web Components attach native listeners through `enableEvent` must be included in `ELEMENT_REACTIVE_EVENTS`; otherwise ReactLynx stores the handler but never invokes the component's event enablement hook.
 
 Reactive event registration can arrive before its Web Component is upgraded. Preserve the `enableEvent` and `disableEvent` call order through `customElements.whenDefined()` instead of dropping optional method calls made before the definition loads.
+
+Register the page's actual unique ID with the WASM context in `__CreatePage`. Both ordinary and global cross-thread event dispatch use it to route page children through `publishEvent` rather than `publicComponentEvent`; regression tests must create children with the page's unique ID as their parent component ID, not the sentinel `0`.

--- a/packages/web-platform/web-core/tests/element-apis.spec.ts
+++ b/packages/web-platform/web-core/tests/element-apis.spec.ts
@@ -1673,6 +1673,28 @@ describe('Element APIs', () => {
     expect(mtsBinding.publishEvent).toBeCalledTimes(1);
   });
 
+  test.each(['bindevent', 'global-bindevent'])(
+    '%s on a page child publishes a page event',
+    (eventType) => {
+      const page = mtsGlobalThis.__CreatePage('0', 0);
+      const child = mtsGlobalThis.__CreateView(
+        mtsGlobalThis.__GetElementUniqueID(page),
+      );
+      mtsGlobalThis.__AppendElement(page, child);
+      mtsGlobalThis.__AddEvent(child, eventType, 'tap', 'handler');
+      mtsGlobalThis.__FlushElementTree();
+
+      child.dispatchEvent(new window.Event('click', { bubbles: true }));
+
+      const { backgroundThread } = mtsBinding.lynxViewInstance;
+      expect(backgroundThread.publishEvent).toHaveBeenCalledWith(
+        'handler',
+        expect.any(Object),
+      );
+      expect(backgroundThread.publicComponentEvent).not.toHaveBeenCalled();
+    },
+  );
+
   test('publicComponentEvent', () => {
     rstest.spyOn(mtsBinding, 'addEventListener');
     rstest.spyOn(mtsBinding, 'publishEvent');

--- a/packages/web-platform/web-core/ts/client/mainthread/elementAPIs/createElementAPI.ts
+++ b/packages/web-platform/web-core/ts/client/mainthread/elementAPIs/createElementAPI.ts
@@ -298,6 +298,7 @@ export function createElementAPI(
         componentCSSID,
         componentID,
       );
+      wasmContext.set_page_element_unique_id(dom[uniqueIdSymbol]);
       if (config_default_overflow_visible) {
         dom.setAttribute(lynxDefaultOverflowVisibleAttribute, 'true');
       }


### PR DESCRIPTION
Register the page element's unique ID in the Web host's `__CreatePage`. Without this registration, events from elements whose parent component is the page are sent to `publicComponentEvent` with the page component ID instead of `publishEvent`.

The runtime fix is one line and covers both ordinary and global cross-thread event dispatch. Adds regression coverage for both paths and a patch changeset for `@lynx-js/web-core`.

Validation:
- `pnpm install --frozen-lockfile`
- `pnpm turbo build`: 73 tasks passed.
- Web Core Rstest suite: 25 files, 442 tests passed. Both new regressions fail with the fix removed.
- `pnpm turbo api-extractor -- --local`: 26 tasks passed; no API report changes.
- `pnpm dprint check`
- Biome on Git-tracked files: passed with 3 existing warnings. Plain `pnpm biome check` also scans ignored build artifacts and fails on those generated files.
- Changeset status and changeset heading validation passed.
- Commit hooks passed (ESLint, Biome, dprint). `NODE_OPTIONS=--max-old-space-size=32768 pnpm eslint . --ignore-pattern '**/.rstack/**'`: passed with 0 errors and 17 existing warnings. Plain `pnpm eslint .` reports 111 parsing errors, all in generated `.rstack` declarations.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed event handling for page child elements so bubbled and global events are dispatched as page events instead of component events.

* **Tests**
  * Added coverage for standard and global event handlers on page children, including verification of cross-thread event dispatch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->