### PR TITLE
feat: show cache token for genui playground

### DIFF
--- a/packages/genui/playground/src/components/PreviewPanel.tsx
+++ b/packages/genui/playground/src/components/PreviewPanel.tsx
@@ -739,6 +739,7 @@ export function PreviewPanel(props: PreviewPanelProps) {
     if (previewSource.kind === 'a2ui') {
       const useClientPayloadStore = shouldUseClientPayloadStore();
       const hasPayload = hasShareableA2UIRenderPayload(previewSource)
+        || previewSource.liveAction === true
         || useClientPayloadStore;
       if (!hasPayload) {
         localMessagesPayloadCache.clear();

--- a/packages/genui/playground/src/pages/chat/ChatController.tsx
+++ b/packages/genui/playground/src/pages/chat/ChatController.tsx
@@ -1057,7 +1057,7 @@ export function ChatController<
     ]);
     resetLivePreviewDelivery();
     setCurrentOutput(null);
-    setCurrentPreviewOutput(null);
+    setCurrentPreviewOutput(adapter.preview.initialOutput?.() ?? null);
     setCurrentPreviewPayloadUrls(null);
     setUsage({ ...EMPTY_CHAT_TOKEN_USAGE });
     metricsRef.current = {};
@@ -1636,6 +1636,33 @@ export function ChatController<
                   <span className='chatTokenUsageItem'>
                     Prompt {formatTokenCount(usage.promptTokens)}
                   </span>
+                  <span
+                    className='chatTokenUsageItem'
+                    title={usage.cachedTokens === undefined
+                      ? 'Cache read usage was not reported for every model call.'
+                      : 'Input tokens read from the prompt cache, as a percentage of Prompt. Included in Prompt and Total.'}
+                  >
+                    Cached {usage.cachedTokens === undefined
+                      ? '—'
+                      : formatTokenCount(usage.cachedTokens)}
+                    {usage.cachedTokens !== undefined && usage.promptTokens > 0
+                      ? ` (${
+                        (usage.cachedTokens / usage.promptTokens * 100).toFixed(
+                          1,
+                        )
+                      }%)`
+                      : null}
+                  </span>
+                  {usage.cacheWriteTokens === undefined
+                    ? null
+                    : (
+                      <span
+                        className='chatTokenUsageItem'
+                        title='Input tokens written to the prompt cache. Included in Prompt and Total.'
+                      >
+                        Cache write {formatTokenCount(usage.cacheWriteTokens)}
+                      </span>
+                    )}
                   <span className='chatTokenUsageItem'>
                     Output {formatTokenCount(usage.completionTokens)}
                   </span>

--- a/packages/genui/playground/src/pages/chat/ChatPage.css
+++ b/packages/genui/playground/src/pages/chat/ChatPage.css
@@ -359,12 +359,14 @@
 .chatTokenUsageBadge {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
+  flex-wrap: wrap;
+  gap: 6px 8px;
+  max-width: 100%;
   min-height: 26px;
   margin-left: auto;
-  padding: 0 10px;
+  padding: 4px 10px;
   border: 1px solid var(--geist-border);
-  border-radius: 999px;
+  border-radius: 14px;
   background: var(--geist-surface);
   color: var(--geist-secondary);
   font-family: var(--geist-mono);

--- a/packages/genui/playground/src/pages/chat/a2ui.ts
+++ b/packages/genui/playground/src/pages/chat/a2ui.ts
@@ -583,6 +583,7 @@ export const A2UI_CHAT_ADAPTER = {
   },
   preview: {
     delivery: 'live-message',
+    initialOutput: (): A2UIOutput => [],
     source(output, context) {
       if (!output) return undefined;
       return {

--- a/packages/genui/playground/src/pages/chat/adapters.test.ts
+++ b/packages/genui/playground/src/pages/chat/adapters.test.ts
@@ -407,7 +407,12 @@ describe('chat protocol adapters', () => {
       event: 'done',
       data: {
         validation: { messages: finalMessages },
-        usage: { inputTokens: 2, outputTokens: 3, totalTokens: 5 },
+        usage: {
+          inputTokens: 2,
+          outputTokens: 3,
+          totalTokens: 5,
+          cachedInputTokens: 1,
+        },
         preview: {
           messagesUrl: 'https://example.com/messages.json',
           actionMocksUrl: 'https://example.com/actions.json',
@@ -419,7 +424,12 @@ describe('chat protocol adapters', () => {
     expect(done.emissions).toEqual([
       {
         type: 'usage',
-        usage: { promptTokens: 2, completionTokens: 3, totalTokens: 5 },
+        usage: {
+          promptTokens: 2,
+          completionTokens: 3,
+          totalTokens: 5,
+          cachedTokens: 1,
+        },
       },
       {
         type: 'previewPayload',
@@ -458,7 +468,11 @@ describe('chat protocol adapters', () => {
     const done = reduceOpenUIStream(state, {
       event: 'done',
       data: {
-        usage: { prompt_tokens: 4, completion_tokens: 6 },
+        usage: {
+          prompt_tokens: 4,
+          completion_tokens: 6,
+          prompt_tokens_details: { cached_tokens: 2 },
+        },
       },
     });
     const output = {
@@ -469,7 +483,12 @@ describe('chat protocol adapters', () => {
       { type: 'progress', text: output.rawText },
       {
         type: 'usage',
-        usage: { promptTokens: 4, completionTokens: 6, totalTokens: 10 },
+        usage: {
+          promptTokens: 4,
+          completionTokens: 6,
+          totalTokens: 10,
+          cachedTokens: 2,
+        },
       },
       { type: 'final', output },
     ]);
@@ -1007,4 +1026,13 @@ describe('chat protocol adapters', () => {
       });
     }
   });
+});
+
+test('A2UI can boot an empty live preview before any model output', () => {
+  const output = A2UI_CHAT_ADAPTER.preview.initialOutput();
+  expect(A2UI_CHAT_ADAPTER.preview.source(output, {
+    protocol: PROTOCOLS.a2ui,
+    theme: 'light',
+    previewPayloadUrls: null,
+  })).toMatchObject({ kind: 'a2ui', messages: [], liveAction: true });
 });

--- a/packages/genui/playground/src/pages/chat/livePreviewDelivery.test.ts
+++ b/packages/genui/playground/src/pages/chat/livePreviewDelivery.test.ts
@@ -211,3 +211,21 @@ describe('live preview delivery', () => {
     }]);
   });
 });
+
+test('a preview that boots before the first output delivers its first delta immediately', () => {
+  expect(prepareLivePreviewOutputs(null, [])).toEqual([]);
+  const delivered: unknown[] = [];
+  const pending: { type: 'A2UI_LIVE_MESSAGES'; output: string[] }[] = [];
+  queueOrDeliverLivePreviewOutput(pending, {
+    type: 'A2UI_LIVE_MESSAGES',
+    output: ['first'],
+  }, (item) => {
+    delivered.push(item);
+    return true;
+  });
+  expect(pending).toEqual([]);
+  expect(delivered).toEqual([{
+    type: 'A2UI_LIVE_MESSAGES',
+    output: ['first'],
+  }]);
+});

--- a/packages/genui/playground/src/pages/chat/shared.test.ts
+++ b/packages/genui/playground/src/pages/chat/shared.test.ts
@@ -7,6 +7,8 @@ import {
   CUSTOM_PROVIDER_BASE_URL,
   CUSTOM_PROVIDER_ID,
   CUSTOM_PROVIDER_MODEL,
+  EMPTY_CHAT_TOKEN_USAGE,
+  addTokenUsage,
   assertProviderRequestTarget,
   createChatRequestInit,
   getChatEndpoint,
@@ -34,6 +36,113 @@ describe('shared chat helpers', () => {
       completionTokens: 3,
       totalTokens: 5,
     });
+  });
+
+  test.each([
+    { prompt_tokens_details: { cached_tokens: 1024, cache_write_tokens: 512 } },
+    { input_tokens_details: { cached_tokens: 1024, cache_write_tokens: 512 } },
+    { cachedInputTokens: 1024, cacheWriteTokens: 512 },
+    { inputTokenDetails: { cacheReadTokens: 1024, cacheWriteTokens: 512 } },
+    { cache_read_input_tokens: 1024, cache_creation_input_tokens: 512 },
+  ])('reads cache usage without adding it to token totals: %j', (details) => {
+    expect(parseTokenUsage({
+      inputTokens: 2048,
+      outputTokens: 128,
+      ...details,
+    })).toEqual({
+      promptTokens: 2048,
+      completionTokens: 128,
+      totalTokens: 2176,
+      cachedTokens: 1024,
+      cacheWriteTokens: 512,
+    });
+  });
+
+  test('parses nested AI SDK totals and cache reads and writes', () => {
+    expect(parseTokenUsage({
+      inputTokens: { total: 2048, cacheRead: 1024, cacheWrite: 512 },
+      outputTokens: { total: 128 },
+    })).toEqual({
+      promptTokens: 2048,
+      completionTokens: 128,
+      totalTokens: 2176,
+      cachedTokens: 1024,
+      cacheWriteTokens: 512,
+    });
+  });
+
+  test('distinguishes reported cache misses from absent or invalid usage', () => {
+    const base = { inputTokens: 2048, outputTokens: 128 };
+    expect(parseTokenUsage({
+      ...base,
+      input_tokens_details: { cached_tokens: 0, cache_write_tokens: 2048 },
+    })).toMatchObject({ cachedTokens: 0, cacheWriteTokens: 2048 });
+    for (
+      const cached_tokens of [
+        undefined,
+        null,
+        '1024',
+        -1,
+        Number.NaN,
+        Number.POSITIVE_INFINITY,
+      ]
+    ) {
+      expect(parseTokenUsage({
+        ...base,
+        input_tokens_details: { cached_tokens },
+      })).not.toHaveProperty('cachedTokens');
+    }
+  });
+
+  test('accumulates cache counts across calls using the empty usage identity', () => {
+    const first = {
+      promptTokens: 2048,
+      completionTokens: 128,
+      totalTokens: 2176,
+      cachedTokens: 1024,
+      cacheWriteTokens: 512,
+    };
+    expect(addTokenUsage(EMPTY_CHAT_TOKEN_USAGE, first)).toEqual(first);
+    expect(addTokenUsage(first, {
+      promptTokens: 4096,
+      completionTokens: 256,
+      totalTokens: 4352,
+      cachedTokens: 0,
+      cacheWriteTokens: 4096,
+    })).toEqual({
+      promptTokens: 6144,
+      completionTokens: 384,
+      totalTokens: 6528,
+      cachedTokens: 1024,
+      cacheWriteTokens: 4608,
+    });
+  });
+
+  test('keeps aggregate cache reads unknown if any call omits them', () => {
+    const reported = {
+      promptTokens: 2048,
+      completionTokens: 128,
+      totalTokens: 2176,
+      cachedTokens: 1024,
+      cacheWriteTokens: 0,
+    };
+    const missing = {
+      promptTokens: 4096,
+      completionTokens: 256,
+      totalTokens: 4352,
+      cacheWriteTokens: 4096,
+    };
+    const expected = {
+      promptTokens: 6144,
+      completionTokens: 384,
+      totalTokens: 6528,
+      cacheWriteTokens: 4096,
+    };
+    expect(addTokenUsage(reported, missing)).toEqual(expected);
+    expect(addTokenUsage(missing, reported)).toEqual(expected);
+    expect(addTokenUsage(expected, reported)).not.toHaveProperty(
+      'cachedTokens',
+    );
   });
 
   test('rejects redirects for credential-bearing chat requests', () => {

--- a/packages/genui/playground/src/pages/chat/shared.ts
+++ b/packages/genui/playground/src/pages/chat/shared.ts
@@ -375,15 +375,42 @@ export const CHAT_PROVIDER_SETTINGS_ADAPTER = {
   badge: compactProviderLabel,
 } satisfies ChatSettingsAdapter<ProviderSettings>;
 
+function readTokenCount(value: unknown): number | undefined {
+  const candidate = value && typeof value === 'object'
+    ? (value as Record<string, unknown>).total
+    : value;
+  return typeof candidate === 'number' && Number.isFinite(candidate)
+      && candidate >= 0
+    ? candidate
+    : undefined;
+}
+
+function findCacheTokenCount(
+  value: unknown,
+  keys: readonly string[],
+): number | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return undefined;
+  }
+  const record = value as Record<string, unknown>;
+  for (const key of keys) {
+    const count = readTokenCount(record[key]);
+    if (count !== undefined) return count;
+  }
+  for (const nested of Object.values(record)) {
+    const count = findCacheTokenCount(nested, keys);
+    if (count !== undefined) return count;
+  }
+  return undefined;
+}
+
 export function parseTokenUsage(value: unknown): ChatTokenUsage | null {
-  if (!value || typeof value !== 'object') return null;
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
   const record = value as Record<string, unknown>;
   const pickNumber = (...keys: string[]): number => {
     for (const key of keys) {
-      const candidate = record[key];
-      if (typeof candidate === 'number' && Number.isFinite(candidate)) {
-        return candidate;
-      }
+      const count = readTokenCount(record[key]);
+      if (count !== undefined) return count;
     }
     return 0;
   };
@@ -405,17 +432,52 @@ export function parseTokenUsage(value: unknown): ChatTokenUsage | null {
   if (promptTokens === 0 && completionTokens === 0 && totalTokens === 0) {
     return null;
   }
-  return { promptTokens, completionTokens, totalTokens };
+  const cachedTokens = findCacheTokenCount(record, [
+    'cached_tokens',
+    'cachedTokens',
+    'cached_input_tokens',
+    'cachedInputTokens',
+    'cacheReadTokens',
+    'cacheRead',
+    'cache_read_input_tokens',
+  ]);
+  const cacheWriteTokens = findCacheTokenCount(record, [
+    'cache_write_tokens',
+    'cacheWriteTokens',
+    'cacheWrite',
+    'cache_creation_input_tokens',
+  ]);
+  return {
+    promptTokens,
+    completionTokens,
+    totalTokens,
+    ...(cachedTokens === undefined ? {} : { cachedTokens }),
+    ...(cacheWriteTokens === undefined ? {} : { cacheWriteTokens }),
+  };
 }
 
 export function addTokenUsage(
   current: ChatTokenUsage,
   next: ChatTokenUsage,
 ): ChatTokenUsage {
+  const addCacheTokens = (
+    key: 'cachedTokens' | 'cacheWriteTokens',
+  ): number | undefined => {
+    // Missing usage from any model call must not become a reported cache miss.
+    if (
+      (current.totalTokens > 0 && current[key] === undefined)
+      || (next.totalTokens > 0 && next[key] === undefined)
+    ) return undefined;
+    return (current[key] ?? 0) + (next[key] ?? 0);
+  };
+  const cachedTokens = addCacheTokens('cachedTokens');
+  const cacheWriteTokens = addCacheTokens('cacheWriteTokens');
   return {
     promptTokens: current.promptTokens + next.promptTokens,
     completionTokens: current.completionTokens + next.completionTokens,
     totalTokens: current.totalTokens + next.totalTokens,
+    ...(cachedTokens === undefined ? {} : { cachedTokens }),
+    ...(cacheWriteTokens === undefined ? {} : { cacheWriteTokens }),
   };
 }
 

--- a/packages/genui/playground/src/pages/chat/type.ts
+++ b/packages/genui/playground/src/pages/chat/type.ts
@@ -32,6 +32,8 @@ export interface ChatTokenUsage {
   promptTokens: number;
   completionTokens: number;
   totalTokens: number;
+  cachedTokens?: number;
+  cacheWriteTokens?: number;
 }
 
 export type ChatMessageKind =
@@ -177,6 +179,8 @@ export interface ChatPreviewContext {
 
 export interface ChatPreviewAdapter<TOutput> {
   delivery: 'reload' | 'live-message';
+  /** Boot a live renderer while the agent is still preparing its first output. */
+  initialOutput?: () => TOutput;
   source: (
     output: TOutput | null,
     context: ChatPreviewContext,

--- a/packages/genui/server/AGENTS.md
+++ b/packages/genui/server/AGENTS.md
@@ -47,6 +47,18 @@ export GENUI_MODEL_CONFIG_JSON='{
   lower of that target and the configured model ceiling.
 - `reasoningEffort` is optional per model.
 
+For generation latency, keep static instructions/catalogs ahead of conversation
+history and the latest request. Prompt Cache behavior follows the upstream
+provider's defaults. GenUI reports returned cache usage without adding routing
+keys, cache options, or explicit breakpoints to model requests. Provider caching
+is independent of the process-local Agent instance cache.
+
+Compare cold and warm requests with the same model, catalog, tool availability,
+and reasoning settings. The stream logs report `upstream.first_chunk`,
+`protocol.first_messages`, cumulative `parseTotalMs`, and final cached-token
+counts/ratios. Measure the preview's paint separately: cache-hit counts and
+parser microbenchmarks alone do not establish end-to-end latency improvements.
+
 `GENUI_MODEL_CONFIG_JSON` is optional when the request supplies a complete
 custom provider with `model`, `apiKey`, and `baseURL`. Partial custom provider
 values are ignored rather than inheriting a server-owned credential. A

--- a/packages/genui/server/agent/a2ui-stream-parser.ts
+++ b/packages/genui/server/agent/a2ui-stream-parser.ts
@@ -135,31 +135,8 @@ function containsUntrustedOpenURL(
   );
 }
 
-function sniffUpdateComponentsSurfaceId(buffer: string): string | null {
-  const updateIndex = buffer.lastIndexOf('"updateComponents"');
-  if (updateIndex === -1) return null;
-  const fragment = buffer.slice(updateIndex);
-  const match = /"surfaceId"\s*:\s*"([^"\\]*(?:\\.[^"\\]*)*)"/u.exec(
-    fragment,
-  );
-  if (!match) return null;
-  try {
-    return JSON.parse(`"${match[1]}"`) as string;
-  } catch {
-    return null;
-  }
-}
-
-function placeholderId(id: string): string {
-  return `loading_${id}`;
-}
-
 function createPlaceholderComponent(id: string): ComponentRecord {
-  return {
-    id: placeholderId(id),
-    component: 'Loading',
-    variant: 'block',
-  };
+  return { id, component: 'Loading', variant: 'block' };
 }
 
 function createSurfaceLoadingMessage(surfaceId: string): A2UIMessage {
@@ -215,109 +192,52 @@ function collectChildRefs(component: ComponentRecord): string[] {
   return refs;
 }
 
-function replaceMissingChildRefs(
-  component: ComponentRecord,
-  seen: Map<string, ComponentRecord>,
-  placeholders: Map<string, ComponentRecord>,
-): ComponentRecord {
-  const next = { ...component };
-
-  const replaceRef = (id: string) => {
-    if (seen.has(id)) return id;
-    const placeholder = createPlaceholderComponent(id);
-    placeholders.set(placeholder.id, placeholder);
-    return placeholder.id;
-  };
-
-  if (typeof next.child === 'string') {
-    next.child = replaceRef(next.child);
-  }
-  if (typeof next.trigger === 'string') {
-    next.trigger = replaceRef(next.trigger);
-  }
-  if (typeof next.content === 'string') {
-    next.content = replaceRef(next.content);
-  }
-  if (Array.isArray(next.children)) {
-    const children = next.children as unknown[];
-    next.children = children.map((item) =>
-      typeof item === 'string' ? replaceRef(item) : item
-    );
-  } else if (isRecord(next.children)) {
-    const children = { ...next.children };
-    if (typeof children.componentId === 'string') {
-      children.componentId = replaceRef(children.componentId);
-    }
-    const template = children.template;
-    if (isRecord(template) && typeof template.componentId === 'string') {
-      children.template = {
-        ...template,
-        componentId: replaceRef(template.componentId),
-      };
-    }
-    next.children = children;
-  }
-  if (Array.isArray(next.tabs)) {
-    const tabs = next.tabs as unknown[];
-    next.tabs = tabs.map((tab) => {
-      if (!isRecord(tab) || typeof tab.child !== 'string') return tab;
-      return { ...tab, child: replaceRef(tab.child) };
-    });
-  }
-
-  return next;
+interface JsonFrame {
+  start: number;
+  kind: 'array' | 'object';
+  role:
+    | 'messages'
+    | 'message'
+    | 'update'
+    | 'components'
+    | 'component'
+    | 'other';
+  key: string;
+  expectingKey: boolean;
+  surfaceId?: string;
 }
 
-function buildReachableComponentSnapshot(
-  seen: Map<string, ComponentRecord>,
-  options: { placeholders: boolean },
-): ComponentRecord[] {
-  const root = seen.get(ROOT_COMPONENT_ID);
-  if (!root) return [...seen.values()];
+function childFrameRole(
+  frame: JsonFrame,
+  kind: JsonFrame['kind'],
+): JsonFrame['role'] {
+  if (frame.role === 'messages' && kind === 'object') return 'message';
+  if (
+    frame.role === 'message' && frame.key === 'updateComponents'
+    && kind === 'object'
+  ) return 'update';
+  if (
+    frame.role === 'update' && frame.key === 'components' && kind === 'array'
+  ) return 'components';
+  if (frame.role === 'components' && kind === 'object') return 'component';
+  return 'other';
+}
 
-  const reachableIds = new Set<string>();
-  const visit = (id: string) => {
-    if (reachableIds.has(id)) return;
-    const component = seen.get(id);
-    if (!component) return;
-    reachableIds.add(id);
-    for (const childId of collectChildRefs(component)) {
-      visit(childId);
-    }
-  };
-  visit(root.id);
-
-  const placeholders = new Map<string, ComponentRecord>();
-  const components: ComponentRecord[] = [];
-  for (const component of seen.values()) {
-    if (!reachableIds.has(component.id)) continue;
-    components.push(
-      options.placeholders
-        ? replaceMissingChildRefs(component, seen, placeholders)
-        : component,
-    );
-  }
-  if (options.placeholders) components.push(...placeholders.values());
-  return components;
+interface SurfaceComponents {
+  seen: Map<string, ComponentRecord>;
+  dirty: Set<string>;
+  reachable: Set<string>;
+  yielded: Map<string, string>;
 }
 
 export class A2UIProtocolMessageStreamParser {
   private buffer = '';
   private cursor = 0;
-  private depth = 0;
-  private inArray = false;
   private inString = false;
   private escaped = false;
-  private itemStart = -1;
-  private objectStack: number[] = [];
-  private seenComponentsBySurface = new Map<
-    string,
-    Map<string, ComponentRecord>
-  >();
-  private yieldedComponentContentBySurface = new Map<
-    string,
-    Map<string, string>
-  >();
+  private stringStart = 0;
+  private frames: JsonFrame[] = [];
+  private surfaces = new Map<string, SurfaceComponents>();
   private createdSurfaceIds = new Set<string>();
 
   public constructor(
@@ -330,10 +250,9 @@ export class A2UIProtocolMessageStreamParser {
   public push(chunk: string): A2UIMessage[] {
     this.buffer += chunk;
     const messages: A2UIMessage[] = [];
-
     for (let i = this.cursor; i < this.buffer.length; i++) {
       const ch = this.buffer[i];
-
+      const frame = this.frames.at(-1);
       if (this.inString) {
         if (this.escaped) {
           this.escaped = false;
@@ -341,136 +260,181 @@ export class A2UIProtocolMessageStreamParser {
           this.escaped = true;
         } else if (ch === '"') {
           this.inString = false;
-        }
-        continue;
-      }
-
-      if (ch === '"') {
-        this.inString = true;
-        continue;
-      }
-
-      if (!this.inArray) {
-        if (ch === '[') {
-          this.inArray = true;
-          this.depth = 1;
-        }
-        continue;
-      }
-
-      if (ch === '{' || ch === '[') {
-        this.depth++;
-        if (this.depth === 2 && ch === '{') {
-          this.itemStart = i;
-        }
-        if (ch === '{') {
-          this.objectStack.push(i);
-        }
-        continue;
-      }
-
-      if (ch !== '}' && ch !== ']') continue;
-
-      const objectStart = ch === '}' ? this.objectStack.pop() : undefined;
-      if (objectStart !== undefined) {
-        this.pushComponentMessage(objectStart, i, messages);
-      }
-
-      if (this.depth === 2 && ch === '}' && this.itemStart !== -1) {
-        const candidate = this.buffer.slice(this.itemStart, i + 1);
-        try {
-          const parsed = JSON.parse(candidate) as unknown;
-          if (isA2UIMessage(parsed)) {
-            if ('createSurface' in parsed && parsed.createSurface) {
-              this.createdSurfaceIds.add(parsed.createSurface.surfaceId);
-              messages.push(parsed);
-              messages.push(
-                createSurfaceLoadingMessage(parsed.createSurface.surfaceId),
-              );
-            } else if (!isUpdateComponentsMessage(parsed)) {
-              messages.push(parsed);
+          if (frame?.kind === 'object') {
+            if (frame.expectingKey) {
+              frame.key = this.parse(this.stringStart, i) as string;
+              frame.expectingKey = false;
+            } else if (frame.role === 'update' && frame.key === 'surfaceId') {
+              const value = this.parse(this.stringStart, i);
+              if (typeof value === 'string') frame.surfaceId = value;
             }
           }
-        } catch {
-          // Keep scanning. Final validation still owns complete-response errors.
         }
-        this.itemStart = -1;
+        continue;
       }
-
-      this.depth--;
-      if (this.depth <= 0) {
-        this.inArray = false;
-        this.depth = 0;
-        this.objectStack = [];
+      if (!frame) {
+        if (ch === '[') this.openFrame(i, 'array', 'messages');
+        continue;
+      }
+      if (ch === '"') {
+        this.inString = true;
+        this.stringStart = i;
+      } else if (ch === ',' && frame.kind === 'object') {
+        frame.expectingKey = true;
+        frame.key = '';
+      } else if (ch === '{' || ch === '[') {
+        const kind = ch === '{' ? 'object' : 'array';
+        const role = childFrameRole(frame, kind);
+        this.openFrame(i, kind, role);
+      } else if (ch === '}' || ch === ']') {
+        this.frames.pop();
+        if (frame.role === 'component') {
+          const update = this.frames.at(-2);
+          if (update?.surfaceId) {
+            this.addComponent(update.surfaceId, this.parse(frame.start, i));
+          }
+        } else if (frame.role === 'message') {
+          this.completeMessage(this.parse(frame.start, i), messages);
+        }
       }
     }
+    this.flushComponents(messages);
 
+    // Retain only the unfinished message. Completed messages and tool phases
+    // must not make later component parsing repeatedly scan the full response.
+    const keepFrom =
+      this.frames.find((frame) => frame.role === 'message')?.start
+        ?? this.buffer.length;
+    this.buffer = this.buffer.slice(keepFrom);
+    for (const frame of this.frames) frame.start -= keepFrom;
+    this.stringStart -= keepFrom;
     this.cursor = this.buffer.length;
     return messages;
   }
 
-  private pushComponentMessage(
+  private openFrame(
     start: number,
-    end: number,
-    messages: A2UIMessage[],
+    kind: JsonFrame['kind'],
+    role: JsonFrame['role'],
   ): void {
-    const componentsIndex = this.buffer.lastIndexOf('"components"', start);
-    if (componentsIndex === -1) return;
-    const updateIndex = this.buffer.lastIndexOf(
-      '"updateComponents"',
-      componentsIndex,
-    );
-    if (updateIndex === -1) return;
+    this.frames.push({
+      start,
+      kind,
+      role,
+      key: '',
+      expectingKey: kind === 'object',
+    });
+  }
 
-    const between = this.buffer.slice(componentsIndex, start);
-    if (!between.includes('[')) return;
-
-    let parsed: unknown;
+  private parse(start: number, end: number): unknown {
     try {
-      parsed = JSON.parse(this.buffer.slice(start, end + 1)) as unknown;
+      return JSON.parse(this.buffer.slice(start, end + 1)) as unknown;
     } catch {
+      // Whole-response validation still owns malformed model output.
+      return undefined;
+    }
+  }
+
+  private completeMessage(value: unknown, messages: A2UIMessage[]): void {
+    if (!isA2UIMessage(value)) return;
+    if (isUpdateComponentsMessage(value)) {
+      // Also handle legal JSON with surfaceId after components. A component is
+      // only streamed early when its enclosing update has already identified it.
+      for (const component of value.updateComponents.components) {
+        this.addComponent(value.updateComponents.surfaceId, component);
+      }
+      this.flushComponents(messages);
       return;
     }
-    if (!isA2UIComponent(parsed)) return;
+    // Preserve component/data-model ordering even when one model chunk contains
+    // several protocol messages or suspended/resumed arrays.
+    this.flushComponents(messages);
+    if ('createSurface' in value && value.createSurface) {
+      const id = value.createSurface.surfaceId;
+      this.surfaces.delete(id);
+      this.createdSurfaceIds.add(id);
+      messages.push(value, createSurfaceLoadingMessage(id));
+    } else {
+      if ('deleteSurface' in value && value.deleteSurface) {
+        const id = value.deleteSurface.surfaceId;
+        this.surfaces.delete(id);
+        this.createdSurfaceIds.delete(id);
+      }
+      messages.push(value);
+    }
+  }
 
-    const surfaceId = sniffUpdateComponentsSurfaceId(
-      this.buffer.slice(0, start),
-    );
-    if (!surfaceId) return;
-    const renderable = toStreamRenderableComponent(
-      parsed,
+  private addComponent(surfaceId: string, value: unknown): void {
+    if (!isA2UIComponent(value)) return;
+    const component = toStreamRenderableComponent(
+      value,
       this.options.isImageSourceAllowed,
       this.options.isOpenUrlAllowed,
-    );
-    const seen = this.seenComponentsBySurface.get(surfaceId)
-      ?? new Map<string, ComponentRecord>();
-    seen.set(renderable.id, renderable as ComponentRecord);
-    this.seenComponentsBySurface.set(surfaceId, seen);
-
-    const components = buildReachableComponentSnapshot(seen, {
-      placeholders: this.createdSurfaceIds.has(surfaceId),
-    });
-    if (components.length === 0) return;
-
-    const yielded = this.yieldedComponentContentBySurface.get(surfaceId)
-      ?? new Map<string, string>();
-    const changedComponents = components.filter((component) => {
-      const content = stableStringify(component);
-      return yielded.get(component.id) !== content;
-    });
-    if (changedComponents.length === 0) return;
-
-    for (const component of changedComponents) {
-      yielded.set(component.id, stableStringify(component));
+    ) as ComponentRecord;
+    let state = this.surfaces.get(surfaceId);
+    if (!state) {
+      state = {
+        seen: new Map(),
+        dirty: new Set(),
+        reachable: new Set(),
+        yielded: new Map(),
+      };
+      this.surfaces.set(surfaceId, state);
     }
-    this.yieldedComponentContentBySurface.set(surfaceId, yielded);
+    state.seen.set(component.id, component);
+    state.dirty.add(component.id);
+  }
 
-    messages.push({
-      version: 'v0.9',
-      updateComponents: {
-        surfaceId,
-        components: changedComponents,
-      },
-    });
+  private flushComponents(messages: A2UIMessage[]): void {
+    for (const [surfaceId, state] of this.surfaces) {
+      if (state.dirty.size === 0) continue;
+      const reachable = new Set<string>();
+      const pending = state.seen.has(ROOT_COMPONENT_ID)
+        ? [ROOT_COMPONENT_ID]
+        : [...state.seen.keys()];
+      while (pending.length > 0) {
+        const id = pending.pop()!;
+        if (reachable.has(id)) continue;
+        const component = state.seen.get(id);
+        if (!component) continue;
+        reachable.add(id);
+        pending.push(...collectChildRefs(component));
+      }
+      for (const id of reachable) {
+        if (!state.reachable.has(id)) state.dirty.add(id);
+      }
+      state.reachable = reachable;
+      const placeholders = new Map<string, ComponentRecord>();
+      const candidates: ComponentRecord[] = [];
+      for (const id of state.dirty) {
+        if (!reachable.has(id)) continue;
+        const component = state.seen.get(id)!;
+        candidates.push(component);
+        if (this.createdSurfaceIds.has(surfaceId)) {
+          for (const child of collectChildRefs(component)) {
+            if (!state.seen.has(child)) {
+              // Keep the real child id: its eventual definition replaces the
+              // Loading resource without rewriting/resending its parent.
+              placeholders.set(child, createPlaceholderComponent(child));
+            }
+          }
+        }
+      }
+      state.dirty.clear();
+      candidates.push(...placeholders.values());
+      const changed: ComponentRecord[] = [];
+      for (const component of candidates) {
+        const content = stableStringify(component);
+        if (state.yielded.get(component.id) === content) continue;
+        state.yielded.set(component.id, content);
+        changed.push(component);
+      }
+      if (changed.length > 0) {
+        messages.push({
+          version: 'v0.9',
+          updateComponents: { surfaceId, components: changed },
+        });
+      }
+    }
   }
 }

--- a/packages/genui/server/app/a2ui/stream/route.ts
+++ b/packages/genui/server/app/a2ui/stream/route.ts
@@ -210,6 +210,8 @@ async function postA2UIStream(req: Request) {
           let streamedText = '';
           let chunkCount = 0;
           let firstChunkLogged = false;
+          let firstMessagesLogged = false;
+          let parseTotalMs = 0;
 
           log('upstream.stream.started');
 
@@ -225,15 +227,27 @@ async function postA2UIStream(req: Request) {
             }
             streamedText += chunk;
             if (!enqueue('delta', { text: chunk })) break;
+            const parseStartedAt = performance.now();
             const newMessages = protocolParser.push(chunk);
+            const parseDurationMs = performance.now() - parseStartedAt;
+            parseTotalMs += parseDurationMs;
             if (newMessages.length > 0) {
               streamedMessages.push(...newMessages);
               enqueue('message', { messages: newMessages });
+              if (!firstMessagesLogged) {
+                firstMessagesLogged = true;
+                log('protocol.first_messages', {
+                  durationSinceConnectStartedMs: performance.now()
+                    - connectStartedAt,
+                  parseTotalMs,
+                });
+              }
               log('protocol.messages', {
                 chunkCount,
                 newMessageCount: newMessages.length,
                 streamedMessageCount: streamedMessages.length,
                 streamedTextLength: streamedText.length,
+                parseDurationMs,
               });
             }
           }
@@ -243,6 +257,7 @@ async function postA2UIStream(req: Request) {
             chunkCount,
             streamedTextLength: streamedText.length,
             streamedMessageCount: streamedMessages.length,
+            parseTotalMs,
           });
 
           let { text: finalText, usage, finishReason } = await finalize();

--- a/packages/genui/server/app/common/usage.ts
+++ b/packages/genui/server/app/common/usage.ts
@@ -23,6 +23,8 @@ function findCachedTokens(value: unknown): number | undefined {
     ?? readNumberProperty(value, 'cachedTokens')
     ?? readNumberProperty(value, 'cached_input_tokens')
     ?? readNumberProperty(value, 'cachedInputTokens')
+    ?? readNumberProperty(value, 'cacheReadTokens')
+    ?? readNumberProperty(value, 'cacheRead')
     ?? readNumberProperty(value, 'cache_read_input_tokens');
   if (direct !== undefined) return direct;
 
@@ -48,11 +50,15 @@ export interface UsageMetrics {
 export function extractUsageMetrics(usage: unknown): UsageMetrics {
   if (!isRecord(usage)) return {};
 
-  const inputTokens = readNumberProperty(usage, 'inputTokens')
+  const inputTokens = (isRecord(usage.inputTokens)
+    ? readNumberProperty(usage.inputTokens, 'total')
+    : readNumberProperty(usage, 'inputTokens'))
     ?? readNumberProperty(usage, 'input_tokens')
     ?? readNumberProperty(usage, 'promptTokens')
     ?? readNumberProperty(usage, 'prompt_tokens');
-  const outputTokens = readNumberProperty(usage, 'outputTokens')
+  const outputTokens = (isRecord(usage.outputTokens)
+    ? readNumberProperty(usage.outputTokens, 'total')
+    : readNumberProperty(usage, 'outputTokens'))
     ?? readNumberProperty(usage, 'output_tokens')
     ?? readNumberProperty(usage, 'completionTokens')
     ?? readNumberProperty(usage, 'completion_tokens');

--- a/packages/genui/server/test/a2ui-stream-parser.test.ts
+++ b/packages/genui/server/test/a2ui-stream-parser.test.ts
@@ -1,0 +1,158 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { describe, expect, test } from '@rstest/core';
+
+import { A2UIProtocolMessageStreamParser } from '../agent/a2ui-stream-parser.js';
+import type { A2UIMessage } from '../agent/a2ui-validator.js';
+
+const create = {
+  version: 'v0.9',
+  createSurface: { surfaceId: 's', catalogId: 'test' },
+};
+const root = { id: 'root', component: 'Column', children: ['title'] };
+const title = {
+  id: 'title',
+  component: 'Text',
+  text: 'Hello \\"世界\\" [ { } ]',
+};
+const update = (components: unknown[], surfaceId = 's') => ({
+  version: 'v0.9',
+  updateComponents: { surfaceId, components },
+});
+
+function components(messages: A2UIMessage[]) {
+  return messages.flatMap((message) =>
+    'updateComponents' in message ? message.updateComponents.components : []
+  );
+}
+
+function latest(messages: A2UIMessage[]) {
+  return Object.fromEntries(
+    components(messages).map((component) => [component.id, component]),
+  );
+}
+
+describe('A2UI incremental parsing', () => {
+  test.each([1, 2, 7, 64, 8192])(
+    'handles escaped strings with %i character chunks',
+    (size) => {
+      const parser = new A2UIProtocolMessageStreamParser();
+      const source = '```json\n'
+        + JSON.stringify([create, update([root, title])]) + '\n```';
+      const messages: A2UIMessage[] = [];
+      for (let i = 0; i < source.length; i += size) {
+        messages.push(
+          ...parser.push(source.slice(i, i + size)),
+        );
+      }
+      expect(latest(messages)).toMatchObject({ root, title });
+      expect(messages.filter((message) => 'createSurface' in message))
+        .toHaveLength(1);
+    },
+  );
+
+  test('renders a complete component before its message ends without resending its parent', () => {
+    const parser = new A2UIProtocolMessageStreamParser();
+    parser.push(JSON.stringify([create]));
+    const first = parser.push(
+      '[{"version":"v0.9","updateComponents":{"surfaceId":"s","components":['
+        + JSON.stringify(root),
+    );
+    expect(components(first)).toEqual([root, {
+      id: 'title',
+      component: 'Loading',
+      variant: 'block',
+    }]);
+    const second = parser.push(',' + JSON.stringify(title));
+    expect(components(second)).toEqual([title]);
+    expect(parser.push(']}}]')).toEqual([]);
+  });
+
+  test('does not parse component-shaped data or nested component props as protocol updates', () => {
+    const parser = new A2UIProtocolMessageStreamParser();
+    const data = {
+      version: 'v0.9',
+      updateDataModel: { surfaceId: 's', value: { components: [title] } },
+    };
+    const decorated = {
+      ...root,
+      metadata: { id: 'fake', component: 'Text', text: 'not UI' },
+    };
+    const messages = parser.push(
+      JSON.stringify([create, update([decorated]), data]),
+    );
+    expect(
+      components(messages).some((component) =>
+        component.id === 'fake'
+        || component.id === 'title' && component.component === 'Text'
+      ),
+    ).toBe(false);
+    expect(messages.at(-1)).toEqual(data);
+  });
+
+  test('supports reordered keys and never uses a previous message surface id', () => {
+    const parser = new A2UIProtocolMessageStreamParser();
+    parser.push(
+      JSON.stringify([
+        update(
+          [{ id: 'root', component: 'Text', text: 'previous' }],
+          'previous',
+        ),
+      ]),
+    );
+    const messages = parser.push(
+      JSON.stringify([{
+        updateComponents: { components: [title], surfaceId: 'next' },
+        version: 'v0.9',
+      }]),
+    );
+    expect(messages).toEqual([update([title], 'next')]);
+  });
+
+  test('preserves data update order and streams independently resumed arrays', () => {
+    const parser = new A2UIProtocolMessageStreamParser();
+    parser.push(JSON.stringify([create, update([root, title])]));
+    const data = {
+      version: 'v0.9',
+      updateDataModel: { surfaceId: 's', value: { title: 'New title' } },
+    };
+    const boundTitle = { ...title, text: { path: '/title' } };
+    const result = parser.push(JSON.stringify([data, update([boundTitle])]));
+    expect(result).toEqual([data, update([boundTitle])]);
+    expect(parser.push(JSON.stringify([update([boundTitle])]))).toEqual([]);
+  });
+
+  test('clears component state when a surface is deleted and recreated', () => {
+    const parser = new A2UIProtocolMessageStreamParser();
+    parser.push(JSON.stringify([create, update([root, title])]));
+    const result = parser.push(JSON.stringify([
+      { version: 'v0.9', deleteSurface: { surfaceId: 's' } },
+      create,
+      update([root]),
+    ]));
+    expect(latest(result).title).toEqual({
+      id: 'title',
+      component: 'Loading',
+      variant: 'block',
+    });
+    expect(components(parser.push(JSON.stringify([update([title])])))).toEqual([
+      title,
+    ]);
+  });
+
+  test('emits newly reachable descendants and handles cyclic references', () => {
+    const parser = new A2UIProtocolMessageStreamParser();
+    parser.push(JSON.stringify([create, update([{ ...root, children: [] }])]));
+    expect(parser.push(JSON.stringify([update([title])]))).toEqual([]);
+    expect(latest(parser.push(JSON.stringify([update([root])])))).toMatchObject(
+      { root, title },
+    );
+    expect(() =>
+      parser.push(
+        JSON.stringify([update([{ ...root, children: ['root', 'title'] }])]),
+      )
+    ).not.toThrow();
+  });
+});

--- a/packages/genui/server/test/usage.test.ts
+++ b/packages/genui/server/test/usage.test.ts
@@ -1,0 +1,61 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { describe, expect, test } from '@rstest/core';
+
+import { extractUsageMetrics } from '../app/common/usage.js';
+
+describe('prompt cache usage metrics', () => {
+  test.each([
+    {
+      inputTokens: 2048,
+      outputTokens: 128,
+      totalTokens: 2176,
+      cachedInputTokens: 1024,
+    },
+    {
+      input_tokens: 2048,
+      output_tokens: 128,
+      total_tokens: 2176,
+      input_tokens_details: { cached_tokens: 1024 },
+    },
+    {
+      prompt_tokens: 2048,
+      completion_tokens: 128,
+      total_tokens: 2176,
+      prompt_tokens_details: { cached_tokens: 1024 },
+    },
+    {
+      inputTokens: { total: 2048, cacheRead: 1024 },
+      outputTokens: { total: 128 },
+      totalTokens: 2176,
+    },
+    {
+      inputTokens: 2048,
+      outputTokens: 128,
+      totalTokens: 2176,
+      inputTokenDetails: { cacheReadTokens: 1024 },
+    },
+  ])(
+    'preserves cached token counts across SDK/provider formats: %j',
+    (usage) => {
+      expect(extractUsageMetrics(usage)).toEqual({
+        inputTokens: 2048,
+        outputTokens: 128,
+        totalTokens: 2176,
+        cachedTokens: 1024,
+        cachedTokenRatio: 0.5,
+      });
+    },
+  );
+
+  test('distinguishes a cold cache from an unreported cache count', () => {
+    expect(
+      extractUsageMetrics({ inputTokens: 2048, cachedInputTokens: 0 })
+        .cachedTokenRatio,
+    ).toBe(0);
+    expect(extractUsageMetrics({ inputTokens: 2048 }).cachedTokens)
+      .toBeUndefined();
+  });
+});


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Live previews can now start with an empty state and display the first output immediately.
  - Previews with live actions can generate shareable links without additional content.
  - Chat token usage now reports cached tokens and cache writes, including cache percentages when available.
  - Preview adapters can provide an initial output.

- **Bug Fixes**
  - Improved streaming behavior for incremental A2UI updates, including placeholders, nested content, and surface changes.

- **Documentation**
  - Added guidance for understanding prompt caching and measuring streaming performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
