### PR TITLE
fix(rsbuild-plugin): stop overwriting plugin-set CSS output config

### DIFF
--- a/.changeset/output-plugin-env-order.md
+++ b/.changeset/output-plugin-env-order.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/rsbuild-plugin": patch
+---
+
+Fix the CSS output defaults overwriting the values another plugin had already set. `output.distPath.css`, `output.filename.css` and `output.legalComments` were merged per environment at the default hook order, so under the Rspeedy CLI, where `pluginLynx` is applied after user plugins, a plugin's value was silently discarded.

--- a/packages/rspeedy/core/test/config/output/css.test.ts
+++ b/packages/rspeedy/core/test/config/output/css.test.ts
@@ -1,0 +1,137 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import type { RsbuildPlugin, Rspack } from '@rsbuild/core'
+import { describe, expect, test } from '@rstest/core'
+
+import { createStubRspeedy } from '../../createStubRspeedy.js'
+
+function getCssExtractOptions(
+  config: Rspack.Configuration,
+): { filename?: string, chunkFilename?: string } {
+  const plugin = config.plugins?.find(
+    (plugin) => plugin?.constructor?.name === 'CssExtractRspackPlugin',
+  )
+  return (plugin as unknown as {
+    options: { filename?: string, chunkFilename?: string }
+  }).options
+}
+
+describe('output.css', () => {
+  test('defaults', async () => {
+    const rspeedy = await createStubRspeedy({})
+
+    const { filename, chunkFilename } = getCssExtractOptions(
+      await rspeedy.unwrapConfig(),
+    )
+
+    expect(filename).toBe('.lynx/[name]/[name].css')
+    expect(chunkFilename).toBe('.lynx/async/[name]/[name].css')
+  })
+
+  test('override with plugin using modifyEnvironmentConfig', async () => {
+    const rspeedy = await createStubRspeedy({
+      plugins: [
+        {
+          name: 'test',
+          setup(api) {
+            api.modifyEnvironmentConfig((config, { mergeEnvironmentConfig }) =>
+              mergeEnvironmentConfig(config, {
+                output: {
+                  distPath: { css: 'plugin-css' },
+                  filename: { css: 'plugin/[name].css' },
+                },
+              })
+            )
+          },
+        } satisfies RsbuildPlugin,
+      ],
+    })
+
+    const { filename, chunkFilename } = getCssExtractOptions(
+      await rspeedy.unwrapConfig(),
+    )
+
+    expect(filename).toBe('plugin-css/plugin/[name].css')
+    expect(chunkFilename).toBe('plugin-css/async/plugin/[name].css')
+  })
+
+  test('override with plugin using modifyRsbuildConfig', async () => {
+    const rspeedy = await createStubRspeedy({
+      plugins: [
+        {
+          name: 'test',
+          setup(api) {
+            api.modifyRsbuildConfig((config, { mergeRsbuildConfig }) =>
+              mergeRsbuildConfig(config, {
+                output: {
+                  distPath: { css: 'plugin-css' },
+                  filename: { css: 'plugin/[name].css' },
+                },
+              })
+            )
+          },
+        } satisfies RsbuildPlugin,
+      ],
+    })
+
+    const { filename, chunkFilename } = getCssExtractOptions(
+      await rspeedy.unwrapConfig(),
+    )
+
+    expect(filename).toBe('plugin-css/plugin/[name].css')
+    expect(chunkFilename).toBe('plugin-css/async/plugin/[name].css')
+  })
+
+  test('keeps the user config', async () => {
+    const rspeedy = await createStubRspeedy({
+      output: { filename: { css: 'user/[name].css' } },
+    })
+
+    const { filename } = getCssExtractOptions(await rspeedy.unwrapConfig())
+
+    expect(filename).toBe('.lynx/user/[name].css')
+  })
+
+  test('an environment wins over the root', async () => {
+    const rspeedy = await createStubRspeedy({
+      output: { filename: { css: 'root/[name].css' } },
+      environments: {
+        lynx: { output: { filename: { css: 'lynx/[name].css' } } },
+      },
+    })
+
+    const { filename } = getCssExtractOptions(await rspeedy.unwrapConfig())
+
+    expect(filename).toBe('.lynx/lynx/[name].css')
+  })
+
+  test('override legalComments with plugin', async () => {
+    let legalComments
+    const rspeedy = await createStubRspeedy({
+      plugins: [
+        {
+          name: 'test',
+          setup(api) {
+            api.modifyEnvironmentConfig((config, { mergeEnvironmentConfig }) =>
+              mergeEnvironmentConfig(config, {
+                output: { legalComments: 'linked' },
+              })
+            )
+            api.modifyEnvironmentConfig({
+              handler: (config) => {
+                legalComments = config.output.legalComments
+              },
+              order: 'post',
+            })
+          },
+        } satisfies RsbuildPlugin,
+      ],
+    })
+
+    await rspeedy.unwrapConfig()
+
+    expect(legalComments).toBe('linked')
+  })
+})

--- a/packages/rspeedy/plugin-lynx/src/plugins/output.plugin.ts
+++ b/packages/rspeedy/plugin-lynx/src/plugins/output.plugin.ts
@@ -2,11 +2,9 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
-import type { RsbuildConfig, RsbuildPlugin } from '@rsbuild/core'
+import type { RsbuildPlugin } from '@rsbuild/core'
 
 import { getLynxConfig } from '../config.js'
-
-type OutputConfig = NonNullable<RsbuildConfig['output']>
 
 export function pluginOutput(): RsbuildPlugin {
   return {
@@ -30,50 +28,29 @@ export function pluginOutput(): RsbuildPlugin {
         )
       )
 
-      api.modifyEnvironmentConfig(
-        (config, { name, mergeEnvironmentConfig }) => {
-          const original = api.getRsbuildConfig('original')
-          // A value set on the environment wins over the same value set at the
-          // root, which is how Rsbuild merges the two.
-          const outputs = [
-            original.environments?.[name]?.output,
-            original.output,
-          ]
-          return mergeEnvironmentConfig(config, {
+      api.modifyRsbuildConfig({
+        handler: (config, { mergeRsbuildConfig }) => {
+          const { output } = api.getRsbuildConfig('original')
+          return mergeRsbuildConfig(config, {
             output: {
               distPath: {
                 // We override the default value of Rsbuild(`static/css`) here.
                 // Since all the CSS should be encoded into the template in
                 // Lynx.
-                css: pick(outputs, (output) =>
-                  typeof output.distPath === 'object'
-                    ? output.distPath.css
-                    : undefined) ?? getLynxConfig(api).resolveIntermediateDir(),
+                css: (typeof output?.distPath === 'object'
+                  ? output.distPath.css
+                  : undefined) ?? getLynxConfig(api).resolveIntermediateDir(),
               },
               filename: {
-                css: pick(outputs, (output) =>
-                  output.filename?.css)
-                  ?? '[name]/[name].css',
+                css: output?.filename?.css ?? '[name]/[name].css',
               },
               // A Lynx bundle has nowhere to link a separate license file to.
-              legalComments: pick(outputs, (output) =>
-                output.legalComments)
-                ?? 'none',
+              legalComments: output?.legalComments ?? 'none',
             },
           })
         },
-      )
+        order: 'pre',
+      })
     },
   }
-}
-
-function pick<T>(
-  outputs: (OutputConfig | undefined)[],
-  get: (output: OutputConfig) => T | undefined,
-): T | undefined {
-  for (const output of outputs) {
-    const value = output === undefined ? undefined : get(output)
-    if (value !== undefined) return value
-  }
-  return undefined
 }

--- a/packages/rspeedy/plugin-lynx/test/output.plugin.test.ts
+++ b/packages/rspeedy/plugin-lynx/test/output.plugin.test.ts
@@ -1,6 +1,7 @@
 // Copyright 2026 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
+import type { RsbuildPlugin } from '@rsbuild/core'
 import { describe, expect, test } from '@rstest/core'
 
 import { createStubRsbuild } from './createStubRsbuild.js'
@@ -76,6 +77,55 @@ describe('pluginOutput', () => {
     const config = await rsbuild.unwrapConfig({ action: 'build' })
 
     expect(config.output?.environment?.const).toBe(true)
+  })
+
+  test('a plugin can override the CSS output defaults', async () => {
+    const rsbuild = await createStubRsbuild({
+      mode: 'production',
+      plugins: [
+        {
+          name: 'test',
+          setup(api) {
+            api.modifyRsbuildConfig((config, { mergeRsbuildConfig }) =>
+              mergeRsbuildConfig(config, {
+                output: {
+                  distPath: { css: 'plugin-css' },
+                  filename: { css: 'plugin/[name].css' },
+                },
+              })
+            )
+          },
+        } satisfies RsbuildPlugin,
+      ],
+    })
+    const config = await rsbuild.unwrapConfig({ action: 'build' })
+
+    expect(findCssExtractFilename(config.plugins)).toBe(
+      'plugin-css/plugin/[name].css',
+    )
+  })
+
+  test('a plugin can override the CSS output defaults per environment', async () => {
+    const rsbuild = await createStubRsbuild({
+      mode: 'production',
+      plugins: [
+        {
+          name: 'test',
+          setup(api) {
+            api.modifyEnvironmentConfig((config, { mergeEnvironmentConfig }) =>
+              mergeEnvironmentConfig(config, {
+                output: { filename: { css: 'plugin/[name].css' } },
+              })
+            )
+          },
+        } satisfies RsbuildPlugin,
+      ],
+    })
+    const config = await rsbuild.unwrapConfig({ action: 'build' })
+
+    expect(findCssExtractFilename(config.plugins)).toBe(
+      '.lynx/plugin/[name].css',
+    )
   })
 
   test('honors output.filename.css set on an environment', async () => {


### PR DESCRIPTION
`output.distPath.css`, `output.filename.css` and `output.legalComments` were merged at the default hook order, so they overwrote values another plugin had already set. Under the Rspeedy CLI, where `pluginLynx` is applied after user plugins, the plugin's value was silently discarded; under the Rsbuild CLI it survived.

Applying them with `order: 'pre'` makes both CLIs behave the same.

Stacked on #3843.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - CSS output settings configured by plugins are now preserved and correctly applied.
  - Custom CSS paths, filenames, and legal comment settings now take effect reliably.

- **Tests**
  - Added coverage for default CSS output paths and plugin-provided CSS configuration overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->