### PR TITLE
fix(rsbuild-plugin): stop overwriting a plugin-set CSS source map

### DIFF
--- a/.changeset/sourcemap-plugin-env-order.md
+++ b/.changeset/sourcemap-plugin-env-order.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/rsbuild-plugin": patch
+---
+
+Fix the CSS source map default overwriting the value another plugin had already set. `output.sourceMap.css` was enabled per environment at the default hook order, so under the Rspeedy CLI, where `pluginLynx` is applied after user plugins, a plugin's value was silently discarded.

--- a/packages/rspeedy/core/test/config/output/source-map.test.ts
+++ b/packages/rspeedy/core/test/config/output/source-map.test.ts
@@ -1,9 +1,12 @@
 // Copyright 2026 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
+import type { NormalizedEnvironmentConfig, RsbuildPlugin } from '@rsbuild/core'
 import { describe, expect, test } from '@rstest/core'
 
 import { createRspeedy } from '../../../src/index.js'
+import type { Config } from '../../../src/index.js'
+import { createStubRspeedy } from '../../createStubRspeedy.js'
 
 describe('output.sourceMap', () => {
   test('does not set css source map by default', async () => {
@@ -57,4 +60,82 @@ describe('output.sourceMap', () => {
       js: 'source-map',
     })
   })
+
+  test('enables css source map for lynx by default', async () => {
+    expect(await resolveSourceMap({})).toHaveProperty('css', true)
+  })
+
+  test('keeps css source map off for a non-Lynx environment', async () => {
+    expect(await resolveSourceMap({ environments: { web: {} } }, 'web'))
+      .toHaveProperty('css', false)
+  })
+
+  test('override css source map with modifyRsbuildConfig', async () => {
+    const sourceMap = await resolveSourceMap({
+      plugins: [
+        {
+          name: 'test',
+          setup(api) {
+            api.modifyRsbuildConfig((config, { mergeRsbuildConfig }) =>
+              mergeRsbuildConfig(config, {
+                output: { sourceMap: { css: false } },
+              })
+            )
+          },
+        } satisfies RsbuildPlugin,
+      ],
+    })
+
+    expect(sourceMap).toHaveProperty('css', false)
+  })
+
+  test('override css source map with modifyEnvironmentConfig', async () => {
+    const sourceMap = await resolveSourceMap({
+      plugins: [
+        {
+          name: 'test',
+          setup(api) {
+            api.modifyEnvironmentConfig((config, { mergeEnvironmentConfig }) =>
+              mergeEnvironmentConfig(config, {
+                output: { sourceMap: { css: false } },
+              })
+            )
+          },
+        } satisfies RsbuildPlugin,
+      ],
+    })
+
+    expect(sourceMap).toHaveProperty('css', false)
+  })
 })
+
+async function resolveSourceMap(
+  config: Config,
+  environment = 'lynx',
+): Promise<NormalizedEnvironmentConfig['output']['sourceMap'] | undefined> {
+  let sourceMap: NormalizedEnvironmentConfig['output']['sourceMap'] | undefined
+
+  const rspeedy = await createStubRspeedy({
+    ...config,
+    plugins: [
+      ...config.plugins ?? [],
+      {
+        name: 'probe',
+        setup(api) {
+          api.modifyEnvironmentConfig({
+            handler: (environmentConfig, { name }) => {
+              if (name === environment) {
+                sourceMap = environmentConfig.output.sourceMap
+              }
+            },
+            order: 'post',
+          })
+        },
+      } satisfies RsbuildPlugin,
+    ],
+  })
+
+  await rspeedy.unwrapConfig()
+
+  return sourceMap
+}

--- a/packages/rspeedy/plugin-lynx/src/plugins/sourcemap.plugin.ts
+++ b/packages/rspeedy/plugin-lynx/src/plugins/sourcemap.plugin.ts
@@ -3,6 +3,7 @@
 // LICENSE file in the root directory of this source tree.
 
 import type {
+  EnvironmentConfig,
   RsbuildConfig,
   RsbuildPlugin,
   Rspack,
@@ -20,15 +21,32 @@ export function pluginSourcemap(): RsbuildPlugin {
     name: 'lynx:rsbuild:sourcemap',
     pre: ['lynx:rsbuild:dev'],
     setup(api) {
-      api.modifyEnvironmentConfig((config, { name }) => {
-        if (
-          !isLynx(name)
-          || hasCSSSourceMapConfigured(api.getRsbuildConfig('original'), name)
-          || typeof config.output.sourceMap !== 'object'
-        ) {
-          return
-        }
-        config.output.sourceMap = { ...config.output.sourceMap, css: true }
+      api.modifyRsbuildConfig({
+        handler: (config, { mergeRsbuildConfig }) => {
+          if (hasCSSSourceMapConfigured(api.getRsbuildConfig('original'))) {
+            return config
+          }
+          return mergeRsbuildConfig(config, {
+            output: { sourceMap: { css: true } },
+          })
+        },
+        order: 'pre',
+      })
+
+      api.modifyRsbuildConfig({
+        handler: (config, { mergeRsbuildConfig }) => {
+          const original = api.getRsbuildConfig('original')
+          const environments: Record<string, EnvironmentConfig> = {}
+
+          for (const name of Object.keys(config.environments ?? {})) {
+            if (!isLynx(name) && !hasCSSSourceMapConfigured(original, name)) {
+              environments[name] = { output: { sourceMap: { css: false } } }
+            }
+          }
+
+          return mergeRsbuildConfig(config, { environments })
+        },
+        order: 'post',
       })
 
       api.modifyBundlerChain((chain, { isDev, environment }) => {
@@ -91,10 +109,12 @@ export function pluginSourcemap(): RsbuildPlugin {
 
 function hasCSSSourceMapConfigured(
   config: RsbuildConfig,
-  environment: string,
+  environment?: string,
 ): boolean {
   return [
-    config.environments?.[environment]?.output?.sourceMap,
+    environment === undefined
+      ? undefined
+      : config.environments?.[environment]?.output?.sourceMap,
     config.output?.sourceMap,
   ].some(sourceMap =>
     typeof sourceMap === 'boolean' || sourceMap?.css !== undefined

--- a/packages/rspeedy/plugin-lynx/test/sourcemap.plugin.test.ts
+++ b/packages/rspeedy/plugin-lynx/test/sourcemap.plugin.test.ts
@@ -4,7 +4,7 @@
 import type { AddressInfo } from 'node:net'
 import path from 'node:path'
 
-import type { RsbuildPlugin } from '@rsbuild/core'
+import type { RsbuildConfig, RsbuildPlugin } from '@rsbuild/core'
 import { beforeEach, describe, expect, rstest, test } from '@rstest/core'
 
 import { createStubRsbuild } from './createStubRsbuild.js'
@@ -310,6 +310,69 @@ describe('pluginSourcemap', () => {
           debugIds: false,
         }),
       )
+    })
+  })
+
+  describe('output.sourceMap.css', () => {
+    test('enabled on a Lynx environment by default', async () => {
+      expect(await resolveCss([])).toBe(true)
+    })
+
+    test('left off on a non-Lynx environment', async () => {
+      expect(await resolveCss([], 'web')).toBe(false)
+    })
+
+    test('left off on an environment added by another plugin', async () => {
+      const css = await resolveCss(
+        [
+          {
+            name: 'adds-web',
+            setup(api) {
+              api.modifyRsbuildConfig((config, { mergeRsbuildConfig }) =>
+                mergeRsbuildConfig(config, { environments: { web: {} } })
+              )
+            },
+          } satisfies RsbuildPlugin,
+        ],
+        'web',
+        { lynx: {} },
+      )
+
+      expect(css).toBe(false)
+    })
+
+    test('a plugin can override it with modifyRsbuildConfig', async () => {
+      const css = await resolveCss([
+        {
+          name: 'test',
+          setup(api) {
+            api.modifyRsbuildConfig((config, { mergeRsbuildConfig }) =>
+              mergeRsbuildConfig(config, {
+                output: { sourceMap: { css: false } },
+              })
+            )
+          },
+        } satisfies RsbuildPlugin,
+      ])
+
+      expect(css).toBe(false)
+    })
+
+    test('a plugin can override it with modifyEnvironmentConfig', async () => {
+      const css = await resolveCss([
+        {
+          name: 'test',
+          setup(api) {
+            api.modifyEnvironmentConfig((config, { mergeEnvironmentConfig }) =>
+              mergeEnvironmentConfig(config, {
+                output: { sourceMap: { css: false } },
+              })
+            )
+          },
+        } satisfies RsbuildPlugin,
+      ])
+
+      expect(css).toBe(false)
     })
   })
 
@@ -762,3 +825,35 @@ describe('pluginSourcemap', () => {
     })
   })
 })
+
+async function resolveCss(
+  plugins: RsbuildPlugin[],
+  environment = 'lynx',
+  environments: RsbuildConfig['environments'] = { lynx: {}, web: {} },
+): Promise<unknown> {
+  let css: unknown
+  const rsbuild = await createStubRsbuild({
+    environments,
+    plugins: [
+      ...plugins,
+      {
+        name: 'probe',
+        setup(api) {
+          api.modifyEnvironmentConfig({
+            handler: (config, { name }) => {
+              const { sourceMap } = config.output
+              if (name === environment) {
+                css = typeof sourceMap === 'object' ? sourceMap.css : sourceMap
+              }
+            },
+            order: 'post',
+          })
+        },
+      } satisfies RsbuildPlugin,
+    ],
+  })
+
+  await rsbuild.initConfigs()
+
+  return css
+}


### PR DESCRIPTION
`pluginSourcemap` enables `output.sourceMap.css` on Lynx environments at the default hook order, so it overwrote a value another plugin had already set. It reads the original user config, so config files were unaffected; plugin-set values were silently discarded under the Rspeedy CLI, where `pluginLynx` is applied after user plugins.

Applying the default with `order: 'pre'` makes both CLIs behave the same.

Stacked on #3865.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - CSS source maps are now enabled by default in Lynx environments.
  - CSS source maps remain disabled by default in non-Lynx environments.
  - User-configured CSS source map settings are preserved, allowing plugins to disable or override the default behavior.
  - Configuration now behaves consistently across environments added by plugins.

- **Tests**
  - Added coverage confirming CSS source map defaults across environments and support for plugin overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->