### PR TITLE
chore(renovate): remove the PR rate limits

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -7,6 +7,7 @@
     "helpers:pinGitHubActionDigests",
     // Delay npm updates by 3 days so risky or unpublished releases have time to surface.
     "security:minimumReleaseAgeNpm",
+    ":disableRateLimiting",
   ],
 
   // Exclude `examples` from "config:recommended"
@@ -30,14 +31,6 @@
   ],
 
   "labels": ["bot:renovate"],
-
-  // Raise the open-PR limits above Renovate's defaults (prConcurrentLimit: 10,
-  // prHourlyLimit: 2). This repo has enough active dependencies that a short
-  // triage lag lets the open-PR count reach 10, after which Renovate stops
-  // opening any new PR and parks every update as "Rate-Limited" on the
-  // Dependency Dashboard -- making it look like Renovate has stopped working.
-  "prConcurrentLimit": 20,
-  "prHourlyLimit": 4,
 
   // Auto-generate a changeset for the dependency bump (see the script). Renovate
   // only updates lockfiles and never installs the repo's dependencies, so install


### PR DESCRIPTION
Renovate parked pnpm 12 and other updates as "Rate-Limited" for weeks because the pipeline only runs on demand and `prHourlyLimit: 4` let each run open a handful of PRs. Disable the limits like lynx/rspeedy does with `:disableRateLimiting`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated automated update scheduling to remove limits on the number and frequency of proposed updates.
  - No changes to product functionality or the end-user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->