### PR TITLE
fix(webpack): name a lazy bundle's chunks like the entry of their layer

### DIFF
--- a/.changeset/lazy-bundle-chunk-filename.md
+++ b/.changeset/lazy-bundle-chunk-filename.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/template-webpack-plugin": patch
+---
+
+Fix the JavaScript chunk of a lazy bundle ignoring `output.filenameHash`. It is now named like the entry of its layer, so `background.[contenthash:8].js` is emitted next to `main-thread.js` in production, and the chunk of a non-Lynx environment stays in that environment's output root instead of `.lynx/`.

--- a/packages/rspeedy/plugin-react/test/fixtures/lazy-chunk-filename/LazyComponent.tsx
+++ b/packages/rspeedy/plugin-react/test/fixtures/lazy-chunk-filename/LazyComponent.tsx
@@ -1,0 +1,7 @@
+export default function LazyComponent() {
+  return (
+    <view>
+      <text>LazyComponent</text>
+    </view>
+  )
+}

--- a/packages/rspeedy/plugin-react/test/fixtures/lazy-chunk-filename/index.tsx
+++ b/packages/rspeedy/plugin-react/test/fixtures/lazy-chunk-filename/index.tsx
@@ -1,0 +1,13 @@
+import { Suspense, lazy } from '@lynx-js/react'
+
+const LazyComponent = lazy(() => import('./LazyComponent.js'))
+
+export function App() {
+  return (
+    <view>
+      <Suspense fallback={<text>Loading...</text>}>
+        <LazyComponent />
+      </Suspense>
+    </view>
+  )
+}

--- a/packages/rspeedy/plugin-react/test/lazy-chunk-filename.test.ts
+++ b/packages/rspeedy/plugin-react/test/lazy-chunk-filename.test.ts
@@ -1,0 +1,114 @@
+// Copyright 2024 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import fs from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import type { RsbuildConfig } from '@rsbuild/core'
+import { describe, expect, rstest, test } from '@rstest/core'
+
+import { createStubRspeedy as createRspeedy } from './createRspeedy.js'
+
+async function buildLazyBundle(
+  rspeedyConfig: Omit<RsbuildConfig, 'source' | 'plugins'>,
+): Promise<string[]> {
+  const { pluginReactLynx } = await import('../src/pluginReactLynx.js')
+
+  const tmp = await fs.mkdtemp(
+    path.join(tmpdir(), 'rspeedy-react-test-lazy-chunk-filename-'),
+  )
+
+  const rspeedy = await createRspeedy({
+    rspeedyConfig: {
+      ...rspeedyConfig,
+      source: {
+        entry: {
+          main: fileURLToPath(
+            new URL(
+              './fixtures/lazy-chunk-filename/index.tsx',
+              import.meta.url,
+            ),
+          ),
+        },
+      },
+      output: {
+        ...rspeedyConfig.output,
+        distPath: {
+          root: tmp,
+        },
+      },
+      plugins: [pluginReactLynx()],
+    },
+  })
+
+  const result = await rspeedy.build()
+  await result.close()
+
+  const files = await fs.readdir(tmp, { recursive: true })
+  return files
+    .map(file => file.replaceAll('\\', '/'))
+    .filter(file => /(?:background|main-thread)[^/]*\.js$/.test(file))
+    .map(file => file.replace(/\.[0-9a-f]{8}\.js$/, '.[hash].js'))
+    .sort()
+}
+
+describe('lazy bundle chunk filename', () => {
+  test('follows the entry filename hash in production', async () => {
+    rstest.stubEnv('NODE_ENV', 'production')
+
+    try {
+      await expect(buildLazyBundle({})).resolves.toMatchInlineSnapshot(`
+        [
+          ".lynx/lazy-bundle/fixtures_lazy-chunk-filename_LazyComponent.tsx/background.[hash].js",
+          ".lynx/lazy-bundle/fixtures_lazy-chunk-filename_LazyComponent.tsx/main-thread.js",
+          ".lynx/main/background.[hash].js",
+          ".lynx/main/main-thread.js",
+        ]
+      `)
+    } finally {
+      rstest.unstubAllEnvs()
+    }
+  })
+
+  test('has no hash with output.filenameHash: false', async () => {
+    rstest.stubEnv('NODE_ENV', 'production')
+
+    try {
+      await expect(buildLazyBundle({ output: { filenameHash: false } }))
+        .resolves.toMatchInlineSnapshot(`
+        [
+          ".lynx/lazy-bundle/fixtures_lazy-chunk-filename_LazyComponent.tsx/background.js",
+          ".lynx/lazy-bundle/fixtures_lazy-chunk-filename_LazyComponent.tsx/main-thread.js",
+          ".lynx/main/background.js",
+          ".lynx/main/main-thread.js",
+        ]
+      `)
+    } finally {
+      rstest.unstubAllEnvs()
+    }
+  })
+
+  test('stays in the output root of its environment', async () => {
+    rstest.stubEnv('NODE_ENV', 'production')
+
+    try {
+      await expect(buildLazyBundle({ environments: { lynx: {}, web: {} } }))
+        .resolves.toMatchInlineSnapshot(`
+        [
+          ".lynx/lazy-bundle/fixtures_lazy-chunk-filename_LazyComponent.tsx/background.[hash].js",
+          ".lynx/lazy-bundle/fixtures_lazy-chunk-filename_LazyComponent.tsx/main-thread.js",
+          ".lynx/main/background.[hash].js",
+          ".lynx/main/main-thread.js",
+          "lazy-bundle/fixtures_lazy-chunk-filename_LazyComponent.tsx/background.[hash].js",
+          "lazy-bundle/fixtures_lazy-chunk-filename_LazyComponent.tsx/main-thread.js",
+          "main/background.[hash].js",
+          "main/main-thread.js",
+        ]
+      `)
+    } finally {
+      rstest.unstubAllEnvs()
+    }
+  })
+})

--- a/packages/webpack/template-webpack-plugin/src/LynxTemplatePlugin.ts
+++ b/packages/webpack/template-webpack-plugin/src/LynxTemplatePlugin.ts
@@ -536,6 +536,33 @@ export class LynxTemplatePlugin {
 
 const SECTION_MAIN_THREAD = 'main-thread';
 const SECTION_BACKGROUND = 'background';
+
+interface AsyncChunkLayout {
+  name: string;
+  layer: string | undefined;
+}
+
+function shortLayerName(layer: string): string {
+  return layer.split(':').pop()!;
+}
+
+function getEntryFilenameOfLayer(
+  entry: Compiler['options']['entry'],
+  layer: string,
+): string | undefined {
+  if (typeof entry === 'function') {
+    return undefined;
+  }
+  for (const description of Object.values(entry)) {
+    if (
+      description.layer === layer
+      && typeof description.filename === 'string'
+    ) {
+      return description.filename.replace(/\\/g, '/');
+    }
+  }
+  return undefined;
+}
 const SECTION_CSS = 'CSS';
 
 /**
@@ -707,12 +734,31 @@ class LynxTemplatePluginImpl {
       compiler.options.output.chunkFilename = (pathData, assetInfo) => {
         const id = pathData.chunk?.id;
         if (compilation !== undefined && id !== undefined && id !== null) {
-          const layoutName = LynxTemplatePluginImpl.getAsyncChunkLayoutName(
+          const layout = LynxTemplatePluginImpl.#getAsyncChunkLayout(
             compilation,
             id,
           );
-          if (layoutName !== undefined) {
-            return `${prefix}lazy-bundle/${layoutName}.js`;
+          if (layout !== undefined) {
+            const { name, layer } = layout;
+            if (layer === undefined) {
+              return `${prefix}lazy-bundle/${name}.js`;
+            }
+            // A lazy bundle's chunk in a layer mirrors the entry of that layer:
+            // `<root>/main/background.[contenthash:8].js` becomes
+            // `<root>/lazy-bundle/<name>/background.[contenthash:8].js`, so it
+            // follows the same `output.filenameHash` and stays in the same
+            // output root as the entry (a non-Lynx entry is not intermediate).
+            const entryFilename = getEntryFilenameOfLayer(
+              compiler.options.entry,
+              layer,
+            );
+            if (entryFilename === undefined) {
+              return `${prefix}lazy-bundle/${name}/${shortLayerName(layer)}.js`;
+            }
+            const root = path.posix.dirname(path.posix.dirname(entryFilename));
+            return `${root === '.' ? '' : `${root}/`}lazy-bundle/${name}/${
+              path.posix.basename(entryFilename)
+            }`;
           }
         }
         return typeof original === 'function'
@@ -1013,9 +1059,9 @@ class LynxTemplatePluginImpl {
     return lazyBundleNames;
   }
 
-  static #asyncLayoutNames = new WeakMap<
+  static #asyncChunkLayouts = new WeakMap<
     Compilation,
-    Map<string | number, string>
+    Map<string | number, AsyncChunkLayout>
   >();
 
   /**
@@ -1027,10 +1073,25 @@ class LynxTemplatePluginImpl {
     compilation: Compilation,
     chunkId: string | number,
   ): string | undefined {
-    let layoutNames = LynxTemplatePluginImpl.#asyncLayoutNames.get(compilation);
+    const layout = LynxTemplatePluginImpl.#getAsyncChunkLayout(
+      compilation,
+      chunkId,
+    );
+    if (layout === undefined) {
+      return undefined;
+    }
+    const { name, layer } = layout;
+    return layer === undefined ? name : `${name}/${shortLayerName(layer)}`;
+  }
 
-    if (!layoutNames) {
-      layoutNames = new Map<string | number, string>();
+  static #getAsyncChunkLayout(
+    compilation: Compilation,
+    chunkId: string | number,
+  ): AsyncChunkLayout | undefined {
+    let layouts = LynxTemplatePluginImpl.#asyncChunkLayouts.get(compilation);
+
+    if (!layouts) {
+      layouts = new Map<string | number, AsyncChunkLayout>();
       const { chunkGraph } = compilation;
       for (
         const [name, chunkGroups] of Object.entries(
@@ -1054,17 +1115,17 @@ class LynxTemplatePluginImpl {
           let layer: string | undefined;
           for (const module of chunkGraph.getChunkModulesIterable(chunk)) {
             if (module.layer) {
-              layer = String(module.layer).split(':').pop();
+              layer = String(module.layer);
               break;
             }
           }
-          layoutNames.set(chunk.id, layer ? `${name}/${layer}` : name);
+          layouts.set(chunk.id, { name, layer });
         }
       }
-      LynxTemplatePluginImpl.#asyncLayoutNames.set(compilation, layoutNames);
+      LynxTemplatePluginImpl.#asyncChunkLayouts.set(compilation, layouts);
     }
 
-    return layoutNames.get(chunkId);
+    return layouts.get(chunkId);
   }
 
   #getAsyncFilenameTemplate(filename: string) {

--- a/packages/webpack/template-webpack-plugin/test/fixtures/lazy-chunk-filename/entry.js
+++ b/packages/webpack/template-webpack-plugin/test/fixtures/lazy-chunk-filename/entry.js
@@ -1,0 +1,1 @@
+export const lazy = import('./lazy.js');

--- a/packages/webpack/template-webpack-plugin/test/fixtures/lazy-chunk-filename/lazy.js
+++ b/packages/webpack/template-webpack-plugin/test/fixtures/lazy-chunk-filename/lazy.js
@@ -1,0 +1,1 @@
+export default 42;

--- a/packages/webpack/template-webpack-plugin/test/lazy-chunk-filename.test.ts
+++ b/packages/webpack/template-webpack-plugin/test/lazy-chunk-filename.test.ts
@@ -1,0 +1,101 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { rspack } from '@rspack/core';
+import type { Configuration, EntryObject, Stats } from '@rspack/core';
+import { describe, expect, test } from '@rstest/core';
+
+import { LynxEncodePlugin, LynxTemplatePlugin } from '../src/index.js';
+
+const CONTEXT = dirname(fileURLToPath(import.meta.url));
+const ENTRY = './fixtures/lazy-chunk-filename/entry.js';
+
+function runRspack(config: Configuration): Promise<Stats> {
+  const compiler = rspack(config);
+  return new Promise((resolve, reject) => {
+    compiler.run((err, stats) => {
+      if (err) return reject(err);
+      if (!stats) return reject(new Error('rspack returned empty stats'));
+      resolve(stats);
+      compiler.close(() => void 0);
+    });
+  });
+}
+
+async function buildLazyChunks(entry: EntryObject): Promise<string[]> {
+  const stats = await runRspack({
+    context: CONTEXT,
+    mode: 'production',
+    devtool: false,
+    experiments: { layers: true },
+    entry,
+    output: { iife: false, path: mkdtempSync(join(tmpdir(), 'tmpl-lazy-')) },
+    plugins: [
+      new LynxTemplatePlugin({
+        ...LynxTemplatePlugin.defaultOptions,
+        intermediate: '.rspeedy/main',
+      }),
+      new LynxEncodePlugin(),
+    ],
+  });
+  const { assets = [] } = stats.toJson({ assets: true });
+  return assets
+    .map(asset => asset.name)
+    .filter(name => name.includes('lazy-bundle/') && name.endsWith('.js'))
+    .map(name => name.replace(/\.[0-9a-f]{8}\.js$/, '.[hash].js'))
+    .sort();
+}
+
+describe('lazy chunk filename', () => {
+  test('mirrors the filename of the entry in the same layer', async () => {
+    await expect(buildLazyChunks({
+      main: {
+        import: ENTRY,
+        layer: 'test:background',
+        filename: '.rspeedy/main/background.[contenthash:8].js',
+      },
+      'main__main-thread': {
+        import: ENTRY,
+        layer: 'test:main-thread',
+        filename: '.rspeedy/main/main-thread.js',
+      },
+    })).resolves.toMatchInlineSnapshot(`
+      [
+        .rspeedy/lazy-bundle/fixtures_lazy-chunk-filename_lazy.js/background.[hash].js,
+        .rspeedy/lazy-bundle/fixtures_lazy-chunk-filename_lazy.js/main-thread.js,
+      ]
+    `);
+  });
+
+  test('stays in the output root of the entry', async () => {
+    await expect(buildLazyChunks({
+      main: {
+        import: ENTRY,
+        layer: 'test:background',
+        filename: 'main/background.[contenthash:8].js',
+      },
+    })).resolves.toMatchInlineSnapshot(`
+      [
+        lazy-bundle/fixtures_lazy-chunk-filename_lazy.js/background.[hash].js,
+      ]
+    `);
+  });
+
+  test('falls back to the layer name without an entry filename', async () => {
+    await expect(buildLazyChunks({
+      main: {
+        import: ENTRY,
+        layer: 'test:background',
+      },
+    })).resolves.toMatchInlineSnapshot(`
+      [
+        .rspeedy/lazy-bundle/fixtures_lazy-chunk-filename_lazy.js/background.js,
+      ]
+    `);
+  });
+});


### PR DESCRIPTION
A lazy bundle's intermediate JavaScript chunk was hard-coded to `<intermediate>/lazy-bundle/<name>/<layer>.js`, so it ignored `output.filenameHash` while the entry next to it was emitted as `.lynx/main/background.[contenthash:8].js`. The hash matters for the same reason it does on the entry: `lynx.requireModule` caches by path, so two versions of a lazy bundle sharing `/.lynx/lazy-bundle/<name>/background.js` collide.

The chunk is now named like the entry of its layer, both directory and basename: `.lynx/main/background.[contenthash:8].js` gives `.lynx/lazy-bundle/<name>/background.[contenthash:8].js`, and `main-thread.js` stays unhashed as before. This also keeps a non-Lynx environment's lazy chunks in that environment's output root (`lazy-bundle/<name>/…`) rather than writing them into `.lynx/`, where they silently overwrote the Lynx build's chunk of the same name.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed lazy-loaded JavaScript bundle filenames so they consistently follow configured filename hash settings, including when hashing is disabled.
  * Lazy bundle chunks now retain the expected directory structure and layer-specific naming in production builds.
  * Fixed multi-environment builds so each lazy bundle is emitted to its respective environment’s output directory rather than a shared fallback directory.
  * Improved filename handling for lazy chunks when custom entry paths or content-hash patterns are configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->