### PR TITLE
fix: variable is not defined in generated xml

### DIFF
--- a/.github/genui-lynx-xml.instructions.md
+++ b/.github/genui-lynx-xml.instructions.md
@@ -70,3 +70,41 @@ dependency-derived and local override invariants with package tests. Verify the
 built output has no runtime Markdown imports. Include the package config in the
 root Rstest project list and validate it with `pnpm exec rstest run -c
 rstest.config.ts --project genui/lynx-xml`.
+
+Keep the original successful `html_fragment_to_main_thread_script` input in the
+same per-run RequestContext as its generated script. Return only that original
+string to clients as `metadata.xmlFragment` alongside the final `text`, including
+in the SSE `done` event; omit `xmlFragment` when no conversion ran. Preserve whitespace
+and XML entities exactly, keep generated-script registry details out of metadata,
+and keep the model-visible tool result limited to bindings and
+the placeholder. Also expose the exact final model text as `metadata.modelOutput`
+before placeholder expansion, declaration insertion, binding repair, or envelope
+normalization. Include it even when no fragment conversion ran, using accumulated
+text deltas only when the provider does not return final text. The shared text-stream route may forward optional result metadata
+without depending on Lynx XML types or mixing it into text deltas.
+
+When the server inserts generated fragment code inside `renderPage()`, request
+script-scoped node generation. Keep node assignments at the placeholder and add
+one combined `var node0, node1, ...;` declaration outside the function at the
+start of the main-thread script, after any directive prologue. Preserve directive
+semantics, including automatic semicolons, and support eager rendering; ordinary converter calls keep local
+`const` declarations by default. Returned bindings must work from external event,
+update, and destroy handlers after rendering. Cover this by executing an assembled
+script with deterministic Element PAPI mocks, including re-render and node13 access.
+
+XML ids do not declare JavaScript variables. Tell the model to use binding-map
+values in every handler and update, and that the placeholder already appends the
+fragment roots. At final assembly, resolve undeclared XML-id references against
+the per-run bindings using JavaScript parsing and lexical scope analysis in the
+headless Lynx XML package. Preserve declared aliases, local bindings, property
+keys, strings, comments, and shorthand keys. Reject rewrites captured by a local
+nodeN binding. Do not create globals for arbitrary XML ids or rewrite identifiers
+with a text regex. Cover initial updates and tap-driven updates with executable,
+model-free weather regressions.
+
+Keep `eslint-scope` external in the intermediate Lynx XML ESM build; the GenUI
+server bundles it and its CommonJS dependencies once in the final executable.
+Embedding that runtime in the library and bundling it again can overwrite the
+server's module table. Validate dependency and bundling changes by starting the
+built server on an ephemeral local port and requesting a model-free route,
+in addition to source-level converter tests.

--- a/.github/genui-playground.instructions.md
+++ b/.github/genui-playground.instructions.md
@@ -172,3 +172,20 @@ Keep `PreviewPanel` unaware of LazyComponent payload structure. It should select
 For the A2UI `LazyComponent` catalog component, load ReactLynx standalone lazy bundle URLs with `import(url, { with: { type: 'component' } })`. In web rendering, use `webUrl` only when `SystemInfo.platform === 'web'`; if `webUrl` is absent, show the mobile-scan fallback instead of trying to load the native `url` in Lynx for Web.
 
 Keep Bench database migration and persistence in `packages/genui/playground/src/storage/benchRepo.ts`, with schema upgrades in the existing `storage/db.ts`. Keep Bench history types, normalization, React hooks, and Bench-specific tests in `packages/genui/playground/src/pages/bench`. Upgrade the existing database without replacing conversation stores. Import legacy `a2ui-bench-history` localStorage records and the fallback report selection in one transaction; remove the legacy copy only after commit, and do not overwrite existing database IDs. Wait for hydration before enabling Bench mutations, serialize writes against the last successful snapshot, and apply record-level deltas so another tab’s unrelated entries survive. Keep report selection tab-local in sessionStorage, notify detail tabs after committed writes, and open the blank detail tab synchronously before awaiting database writes.
+
+For Lynx XML results, read the optional SSE `done.metadata.xmlFragment` as display-only
+artifact data. Offer a separate XML Fragment view alongside the final Source using
+the shared artifact viewer and Copy control. Preserve the original string and
+persist it as `lynxXmlFragment` in local and shared assistant history so reopened
+conversations retain the switch. Keep it out of runtime preview sources and model
+conversation inputs; older results and local examples without it show only Source.
+
+Offer Raw and Formatted display modes for XML Fragment through the shared artifact
+viewer. Copy the text currently displayed, derive formatted text only in the
+Playground, and persist only the original fragment. Support multiple roots and
+mixed text; malformed legacy fragments must remain readable in Raw mode.
+
+Show `done.metadata.modelOutput` as a separate Model Output artifact view without
+trimming or normalizing it. Persist it as `lynxXmlModelOutput` in local and shared
+assistant history. Keep it out of preview sources and model request history;
+older results without this metadata must not fabricate it from expanded Source.

--- a/packages/genui/lynx-xml/README.md
+++ b/packages/genui/lynx-xml/README.md
@@ -56,5 +56,25 @@ const { bindings, javascript } = generateMainThreadScriptResult(
 );
 ```
 
+For handlers defined outside `renderPage()`, pass `{ nodeScope: 'script' }` as
+the second argument. The result then includes `declarations` containing hoisted
+one `var node0, node1, ...;` declaration. Place it at the start of the main-thread
+script, after any directives such as `"use strict"`, and put
+`javascript` inside `renderPage()` after creating `page` and `pageId`. The GenUI
+server's conversion tool handles this assembly automatically. Nodes are assigned
+on each render; handlers may use the returned bindings after rendering and must
+not redeclare or shadow those names. Omitting the option keeps the original local
+`const` declaration behavior.
+
+Bindings map XML ids to JavaScript variable names: `{ cityText: 'node5' }`
+means updates should reference `node5`. Setting an XML id does not declare
+`cityText`. When assembling the script, consumers may
+call `resolveFragmentBindings(javascript, bindings, declarations)` to insert the
+combined declaration after directives and convert undeclared XML-id
+references into generated node references. The server does this before delivery.
+The resolver preserves locally declared variables and property names, and rejects
+references whose generated node name is shadowed. Fragment roots are already
+appended to `page`; do not append them again after inserting the fragment.
+
 The package intentionally has no model-provider, agent-runtime, or renderer
 dependencies. Consumers own those integration concerns.

--- a/packages/genui/lynx-xml/package.json
+++ b/packages/genui/lynx-xml/package.json
@@ -27,11 +27,15 @@
   },
   "dependencies": {
     "@lynx-js/skill-vanilla-lynx": "0.2.0",
+    "acorn": "^8.17.0",
+    "acorn-walk": "^8.3.5",
+    "eslint-scope": "^8.4.0",
     "fast-xml-parser": "^5.11.1"
   },
   "devDependencies": {
     "@rslib/core": "catalog:rslib",
     "@rstest/core": "catalog:rstest",
+    "@types/eslint-scope": "^3.7.7",
     "@types/node": "^24.13.3"
   },
   "engines": {

--- a/packages/genui/lynx-xml/rslib.config.ts
+++ b/packages/genui/lynx-xml/rslib.config.ts
@@ -14,6 +14,8 @@ const config: RslibConfig = defineConfig({
       syntax: 'es2022',
       output: {
         autoExternal: false,
+        // Bundle CommonJS dependencies only in the consuming server executable.
+        externals: ['eslint-scope'],
       },
       dts: {
         bundle: true,

--- a/packages/genui/lynx-xml/src/fragment-bindings.ts
+++ b/packages/genui/lynx-xml/src/fragment-bindings.ts
@@ -1,0 +1,83 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { parse } from 'acorn';
+import { full } from 'acorn-walk';
+import { analyze } from 'eslint-scope';
+
+/** Resolve undeclared XML-id references without changing user-defined bindings. */
+export function resolveFragmentBindings(
+  javascript: string,
+  bindings: Readonly<Record<string, string>>,
+  declarations = '',
+): string {
+  const parseOptions = {
+    ecmaVersion: 2022,
+    sourceType: 'script',
+    ranges: true,
+  } as const;
+  let ast = parse(javascript, parseOptions);
+  if (declarations) {
+    // Keep directives first, including those terminated by automatic semicolons.
+    let offset = 0;
+    for (const statement of ast.body) {
+      if (
+        statement.type !== 'ExpressionStatement' || !('directive' in statement)
+      ) break;
+      offset = statement.end;
+    }
+    const prefix = javascript.slice(0, offset);
+    const terminator = offset > 0 && !prefix.endsWith(';') ? ';' : '';
+    javascript = `${prefix}${terminator}\n${declarations}\n${
+      javascript.slice(offset)
+    }`;
+    ast = parse(javascript, parseOptions);
+  }
+  const scopes = analyze(ast, {
+    ecmaVersion: 2022,
+    sourceType: 'script',
+    optimistic: true,
+  });
+  const globalScope = scopes.globalScope;
+  if (!globalScope) return javascript;
+
+  // Shorthand keys must retain their public name, including destructuring.
+  const shorthandOffsets = new Set<number>();
+  full(ast, node => {
+    if (node.type === 'Property' && node.shorthand) {
+      shorthandOffsets.add(node.value.start);
+    }
+  });
+  const edits = new Map<number, { end: number; text: string }>();
+  for (const reference of globalScope.through) {
+    const { identifier } = reference;
+    if (!Object.hasOwn(bindings, identifier.name)) continue;
+    const target = bindings[identifier.name]!;
+    // Bind only to generated, script-scoped nodes. A local nodeN declaration
+    // would capture a rewritten reference and silently update the wrong node.
+    let scope = reference.from;
+    while (scope.upper && !scope.set.has(target)) scope = scope.upper;
+    if (scope !== globalScope || !globalScope.set.has(target)) {
+      throw new Error(
+        `XML id "${identifier.name}" cannot reference shadowed or missing node "${target}"`,
+      );
+    }
+    const range = identifier.range;
+    if (!range) {
+      throw new Error('Fragment binding reference is missing its range');
+    }
+    const [start, end] = range;
+    edits.set(start, {
+      end,
+      text: shorthandOffsets.has(start)
+        ? `${javascript.slice(start, end)}: ${target}`
+        : target,
+    });
+  }
+  let resolved = javascript;
+  for (const [start, { end, text }] of [...edits].sort(([a], [b]) => b - a)) {
+    resolved = resolved.slice(0, start) + text + resolved.slice(end);
+  }
+  return resolved;
+}

--- a/packages/genui/lynx-xml/src/html-fragment.ts
+++ b/packages/genui/lynx-xml/src/html-fragment.ts
@@ -39,11 +39,19 @@ interface GeneratorState {
   bindings: Map<string, string>;
   lines: string[];
   nextNodeIndex: number;
+  nodeScope: 'render' | 'script';
+}
+
+export interface GenerateMainThreadScriptOptions {
+  /** Script scope exposes nodes to handlers declared outside renderPage(). */
+  nodeScope?: 'render' | 'script';
 }
 
 export interface GeneratedMainThreadScript {
   bindings: Record<string, string>;
   javascript: string;
+  /** Hoisted script-level declarations, to be placed outside renderPage(). */
+  declarations?: string;
 }
 
 type OrderedXmlNode = Record<string, unknown>;
@@ -82,7 +90,9 @@ function appendText(
 
   const node = `node${state.nextNodeIndex++}`;
   state.lines.push(
-    `const ${node} = __CreateText(pageId);`,
+    `${
+      state.nodeScope === 'script' ? '' : 'const '
+    }${node} = __CreateText(pageId);`,
     `__AppendElement(${node}, __CreateRawText(${javascriptString(text)}));`,
     `__AppendElement(${parent}, ${node});`,
   );
@@ -154,7 +164,11 @@ function appendParsedNode(
   }
 
   const node = `node${state.nextNodeIndex++}`;
-  state.lines.push(`const ${node} = ${createElementExpression(tagName)};`);
+  state.lines.push(
+    `${state.nodeScope === 'script' ? '' : 'const '}${node} = ${
+      createElementExpression(tagName)
+    };`,
+  );
 
   const attributes = parsedNode[ATTRIBUTE_NODE_NAME];
   if (attributes && typeof attributes === 'object') {
@@ -175,6 +189,7 @@ function appendParsedNode(
 /** Generate Element PAPI calls and stable id-to-node bindings. */
 export function generateMainThreadScriptResult(
   xmlFragment: string,
+  options: GenerateMainThreadScriptOptions = {},
 ): GeneratedMainThreadScript {
   if (!xmlFragment.trim()) throw new Error('XML fragment must not be empty');
   if (xmlFragment.length > MAX_XML_FRAGMENT_LENGTH) {
@@ -203,6 +218,7 @@ export function generateMainThreadScriptResult(
     bindings: new Map(),
     lines: [],
     nextNodeIndex: 0,
+    nodeScope: options.nodeScope ?? 'render',
   };
   for (const child of children) {
     if (!child || typeof child !== 'object' || Array.isArray(child)) {
@@ -216,6 +232,16 @@ export function generateMainThreadScriptResult(
   return {
     bindings: Object.fromEntries(state.bindings),
     javascript: state.lines.join('\n'),
+    ...(state.nodeScope === 'script'
+      ? {
+        declarations: `var ${
+          Array.from(
+            { length: state.nextNodeIndex },
+            (_, index) => `node${index}`,
+          ).join(', ')
+        };`,
+      }
+      : {}),
   };
 }
 

--- a/packages/genui/lynx-xml/src/index.ts
+++ b/packages/genui/lynx-xml/src/index.ts
@@ -15,4 +15,8 @@ export {
   generateMainThreadScriptResult,
   MAX_XML_FRAGMENT_LENGTH,
 } from './html-fragment.js';
-export type { GeneratedMainThreadScript } from './html-fragment.js';
+export type {
+  GeneratedMainThreadScript,
+  GenerateMainThreadScriptOptions,
+} from './html-fragment.js';
+export { resolveFragmentBindings } from './fragment-bindings.js';

--- a/packages/genui/lynx-xml/src/prompt.ts
+++ b/packages/genui/lynx-xml/src/prompt.ts
@@ -24,7 +24,9 @@ export const LYNX_XML_HTML_FRAGMENT_TOOL_INSTRUCTIONS =
 - Draft the initial static Lynx element tree as one well-formed XML fragment, then call html_fragment_to_main_thread_script exactly once with that fragment. Give every node needed by event handlers or dynamic updates a unique id attribute.
 - The tool returns an opaque placeholder comment and a bindings map from XML ids to generated node variable names. It does not return the generated JavaScript.
 - Copy the placeholder exactly, without quoting or rewriting it, onto its own line inside renderPage() after page and pageId exist. The server replaces it with the generated Element PAPI statements after model generation.
-- Write event handlers and dynamic updates after the placeholder. Refer to generated nodes only through the returned bindings and do not redeclare those node variable names.
+- The server declares generated node variables at main-thread script scope and assigns them inside renderPage(). Event handlers, updatePage(), and destroyLifetime() may use the returned bindings after rendering, even when declared outside renderPage(). Do not access them before the initial render, invent node names, or redeclare/shadow them with const, let, var, or function parameters.
+- Use the VALUES of the bindings map as JavaScript references: for {"cityText":"node5","currentTemp":"node15"}, write setText(node5, ...) and setText(node15, ...). XML ids are strings, not JavaScript variables; __SetID does not declare cityText or currentTemp. Apply this rule inside helpers, arrays, event handlers, and lifecycle callbacks too.
+- The placeholder already appends every fragment root to page. Do not append those roots again after the placeholder.
 - The tool handles element creation, literal text, classes, IDs, inline styles, datasets, attributes, and child order. Write state, event handlers, dynamic updates, lifecycle registration, and cleanup yourself.
 - Do not put style, script, lynx, page, or raw-text elements in the fragment. Keep CSS in the artifact's style block and bind events in main-thread JavaScript.`;
 

--- a/packages/genui/lynx-xml/test/fragment-bindings.test.ts
+++ b/packages/genui/lynx-xml/test/fragment-bindings.test.ts
@@ -1,0 +1,83 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { runInNewContext } from 'node:vm';
+
+import { describe, expect, test } from '@rstest/core';
+
+import { resolveFragmentBindings } from '../src/fragment-bindings.js';
+
+describe('resolveFragmentBindings', () => {
+  test('prepends a combined declaration while preserving directives without semicolons', () => {
+    const source =
+      '// leading comment\n"use custom";\n"use strict"\nfunction strict() { return this; }\nresult = strict();';
+    const resolved = resolveFragmentBindings(source, {}, 'var node0, node1;');
+    expect(resolved).toContain('"use strict";\nvar node0, node1;');
+    const context = { result: 'pending' };
+    runInNewContext(resolved, context);
+    expect(context.result).toBeUndefined();
+  });
+  test('resolves only free references and preserves shorthand property keys', () => {
+    const source = `
+var node5 = { text: "Shanghai" };
+var node15 = { text: "26°" };
+const weather = { cityText: "cityText" };
+// cityText is an XML id.
+function local(cityText) { return { cityText }; }
+function block() { let currentTemp = "local"; return currentTemp; }
+function hoisted() { return cityText; var cityText; }
+const object = { cityText, currentTemp };
+const computed = { [cityText.text]: currentTemp.text };
+const template = \`cityText: \${cityText.text}\`;
+result = [object, computed, template, local("local"), block(), hoisted(), weather.cityText];
+`;
+    const resolved = resolveFragmentBindings(source, {
+      cityText: 'node5',
+      currentTemp: 'node15',
+    });
+    expect(resolved).toContain(
+      'const object = { cityText: node5, currentTemp: node15 };',
+    );
+    expect(resolved).toContain('// cityText is an XML id.');
+    expect(resolved).toContain(
+      'function local(cityText) { return { cityText }; }',
+    );
+    const context = { result: undefined };
+    runInNewContext(resolved, context);
+    expect(context.result).toEqual([
+      { cityText: { text: 'Shanghai' }, currentTemp: { text: '26°' } },
+      { Shanghai: '26°' },
+      'cityText: Shanghai',
+      { cityText: 'local' },
+      'local',
+      undefined,
+      'cityText',
+    ]);
+  });
+
+  test('preserves explicit global aliases and unrelated unknown identifiers', () => {
+    const source =
+      `var node5; var cityText; function update() { return cityText || unknown; }`;
+    expect(resolveFragmentBindings(source, { cityText: 'node5' })).toBe(source);
+    expect(resolveFragmentBindings('toString();', {})).toBe('toString();');
+  });
+
+  test('handles writes and destructuring defaults without renaming keys', () => {
+    const source =
+      `var node5; ({ cityText = "fallback" } = {}); result = { cityText };`;
+    const resolved = resolveFragmentBindings(source, { cityText: 'node5' });
+    const context = { result: undefined };
+    runInNewContext(resolved, context);
+    expect(context.result).toEqual({ cityText: 'fallback' });
+  });
+
+  test('rejects target capture by a local node variable', () => {
+    expect(() =>
+      resolveFragmentBindings(
+        'var node5; function update(node5) { return cityText; }',
+        { cityText: 'node5' },
+      )
+    ).toThrow('shadowed or missing node "node5"');
+  });
+});

--- a/packages/genui/lynx-xml/test/html-fragment.test.ts
+++ b/packages/genui/lynx-xml/test/html-fragment.test.ts
@@ -41,6 +41,22 @@ __AppendElement(node0, node1);
 __AppendElement(page, node0);`);
   });
 
+  test('separates hoisted node declarations from render assignments when requested', () => {
+    const result = generateMainThreadScriptResult(
+      '<view>content<text id="dateText">Today</text></view>',
+      { nodeScope: 'script' },
+    );
+    expect(result.bindings).toEqual({ dateText: 'node2' });
+    expect(result.declarations).toBe('var node0, node1, node2;');
+    expect(result.javascript).not.toContain('const node');
+    expect(result.javascript).toContain('node0 = __CreateView(pageId);');
+    expect(result.javascript).toContain('node1 = __CreateText(pageId);');
+    expect(result.javascript).toContain('node2 = __CreateText(pageId);');
+    expect(generateMainThreadScriptResult('<view/>')).not.toHaveProperty(
+      'declarations',
+    );
+  });
+
   test('supports multiple roots, text content, and generic element tags', () => {
     expect(
       generateMainThreadScript(

--- a/packages/genui/lynx-xml/test/prompt.test.ts
+++ b/packages/genui/lynx-xml/test/prompt.test.ts
@@ -38,7 +38,19 @@ describe('buildLynxXmlSystemPrompt', () => {
       'bindings map',
     );
     expect(LYNX_XML_HTML_FRAGMENT_TOOL_SYSTEM_PROMPT).toContain(
+      'main-thread script scope',
+    );
+    expect(LYNX_XML_HTML_FRAGMENT_TOOL_SYSTEM_PROMPT).toContain(
+      'Do not access them before the initial render',
+    );
+    expect(LYNX_XML_HTML_FRAGMENT_TOOL_SYSTEM_PROMPT).toContain(
       'It does not return the generated JavaScript',
+    );
+    expect(LYNX_XML_HTML_FRAGMENT_TOOL_SYSTEM_PROMPT).toContain(
+      'Use the VALUES of the bindings map',
+    );
+    expect(LYNX_XML_HTML_FRAGMENT_TOOL_SYSTEM_PROMPT).toContain(
+      'Do not append those roots again',
     );
   });
 

--- a/packages/genui/playground/package.json
+++ b/packages/genui/playground/package.json
@@ -31,7 +31,8 @@
     "qrcode": "^1.5.4",
     "react": "19.2.8",
     "react-dom": "19.2.8",
-    "vaul": "^1.1.2"
+    "vaul": "^1.1.2",
+    "xml-formatter": "^3.7.0"
   },
   "devDependencies": {
     "@lynx-js/config-rsbuild-plugin": "workspace:*",

--- a/packages/genui/playground/src/hooks/useConversation.ts
+++ b/packages/genui/playground/src/hooks/useConversation.ts
@@ -29,6 +29,8 @@ import type {
 export interface ModelChatMessage {
   role: 'user' | 'assistant' | 'system';
   content: string;
+  lynxXmlFragment?: string;
+  lynxXmlModelOutput?: string;
   previewPayloadUrls?: PreviewPayloadUrls;
   previewMetrics?: PreviewPerformanceMetrics;
 }
@@ -49,6 +51,8 @@ interface ConversationHotState {
 export interface RecordTurnInput {
   userMessage: ModelChatMessage;
   assistantContent: string;
+  lynxXmlFragment?: string;
+  lynxXmlModelOutput?: string;
   a2uiMessages: unknown[];
   previewMessages?: unknown[];
   previewPayloadUrls?: PreviewPayloadUrls | null;
@@ -228,6 +232,12 @@ function toPersistedMessages(
     seq: index,
     role: message.role,
     content: message.content,
+    ...(message.lynxXmlFragment
+      ? { lynxXmlFragment: message.lynxXmlFragment }
+      : {}),
+    ...(message.lynxXmlModelOutput
+      ? { lynxXmlModelOutput: message.lynxXmlModelOutput }
+      : {}),
     previewPayloadUrls: message.previewPayloadUrls,
     previewMetrics: clonePreviewPerformanceMetrics(message.previewMetrics),
     createdAt: now + index,
@@ -240,6 +250,12 @@ function fromPersistedMessages(
   return messages.map((message) => ({
     role: message.role,
     content: message.content,
+    ...(message.lynxXmlFragment
+      ? { lynxXmlFragment: message.lynxXmlFragment }
+      : {}),
+    ...(message.lynxXmlModelOutput
+      ? { lynxXmlModelOutput: message.lynxXmlModelOutput }
+      : {}),
     previewPayloadUrls: message.previewPayloadUrls,
     previewMetrics: clonePreviewPerformanceMetrics(message.previewMetrics),
   }));
@@ -474,6 +490,12 @@ export function useConversation(
           messages: doc.messages.map((message) => ({
             role: message.role,
             content: message.content,
+            ...(message.lynxXmlFragment
+              ? { lynxXmlFragment: message.lynxXmlFragment }
+              : {}),
+            ...(message.lynxXmlModelOutput
+              ? { lynxXmlModelOutput: message.lynxXmlModelOutput }
+              : {}),
             previewPayloadUrls: message.previewPayloadUrls,
             previewMetrics: clonePreviewPerformanceMetrics(
               message.previewMetrics,
@@ -559,6 +581,12 @@ export function useConversation(
         {
           role: 'assistant' as const,
           content: input.assistantContent,
+          ...(input.lynxXmlFragment
+            ? { lynxXmlFragment: input.lynxXmlFragment }
+            : {}),
+          ...(input.lynxXmlModelOutput
+            ? { lynxXmlModelOutput: input.lynxXmlModelOutput }
+            : {}),
           previewPayloadUrls: input.previewPayloadUrls ?? undefined,
           previewMetrics: clonePreviewPerformanceMetrics(input.previewMetrics),
         },

--- a/packages/genui/playground/src/pages/chat/ChatController.tsx
+++ b/packages/genui/playground/src/pages/chat/ChatController.tsx
@@ -399,6 +399,7 @@ function ArtifactViewer(props: {
   onCopy: (text: string) => void;
 }) {
   const { artifact, onCopy } = props;
+  const [showFormatted, setShowFormatted] = useState(false);
   const [activeViewId, setActiveViewId] = useState(
     () => artifact.views[0]?.id ?? '',
   );
@@ -411,6 +412,9 @@ function ArtifactViewer(props: {
   }, [activeViewId, artifact.views]);
 
   if (!activeView) return null;
+  const displayedText = showFormatted
+    ? activeView.formattedText ?? activeView.text
+    : activeView.text;
   return (
     <div className='chatGeneratedJson chatArtifact'>
       <div className='chatGeneratedJsonTitle chatArtifactHeader'>
@@ -439,17 +443,45 @@ function ArtifactViewer(props: {
               </div>
             )
             : null}
-          <button
-            type='button'
-            className='chatJsonCopyButton'
-            onClick={() => onCopy(activeView.text)}
-          >
-            Copy
-          </button>
         </div>
       </div>
+      <div className='chatArtifactCodeToolbar'>
+        {activeView.formattedText === undefined
+          ? <span className='chatArtifactCodeLabel'>{activeView.label}</span>
+          : (
+            <div
+              className='chatArtifactFormatSwitch'
+              role='group'
+              aria-label={`${activeView.label} formatting`}
+            >
+              <button
+                type='button'
+                className='chatArtifactFormatButton'
+                aria-pressed={!showFormatted}
+                onClick={() => setShowFormatted(false)}
+              >
+                Raw
+              </button>
+              <button
+                type='button'
+                className='chatArtifactFormatButton'
+                aria-pressed={showFormatted}
+                onClick={() => setShowFormatted(true)}
+              >
+                Formatted
+              </button>
+            </div>
+          )}
+        <button
+          type='button'
+          className='chatJsonCopyButton chatArtifactCopyButton'
+          onClick={() => onCopy(displayedText)}
+        >
+          Copy
+        </button>
+      </div>
       <pre className='chatMessageChunkJson chatArtifactCodeBlock'>
-        {activeView.text}
+        {displayedText}
       </pre>
     </div>
   );

--- a/packages/genui/playground/src/pages/chat/ChatPage.css
+++ b/packages/genui/playground/src/pages/chat/ChatPage.css
@@ -1717,6 +1717,67 @@
   font-size: 11px;
 }
 
+.chatArtifactCodeToolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 0 10px;
+  min-height: 36px;
+  border-bottom: 1px solid
+    color-mix(in srgb, var(--geist-border) 55%, transparent);
+  background: var(--geist-surface);
+}
+
+.chatArtifactFormatSwitch {
+  display: flex;
+  align-self: stretch;
+  gap: 14px;
+}
+
+.chatArtifactFormatButton {
+  padding: 0 2px;
+  border: 0;
+  border-bottom: 2px solid transparent;
+  background: transparent;
+  color: var(--geist-secondary);
+  font-family: var(--geist-mono);
+  font-size: 11px;
+  cursor: pointer;
+}
+
+.chatArtifactFormatButton:hover,
+.chatArtifactFormatButton[aria-pressed="true"] {
+  color: var(--geist-foreground);
+}
+
+.chatArtifactFormatButton[aria-pressed="true"] {
+  border-bottom-color: var(--geist-foreground);
+}
+
+.chatArtifactFormatButton:focus-visible,
+.chatArtifactCopyButton:focus-visible {
+  outline: 2px solid var(--geist-accent);
+  outline-offset: 2px;
+}
+
+.chatArtifactCodeLabel {
+  color: var(--geist-secondary);
+  font-family: var(--geist-mono);
+  font-size: 11px;
+}
+
+.chatArtifactCopyButton {
+  border-color: transparent;
+  background: transparent;
+  color: var(--geist-secondary);
+  font-weight: 500;
+}
+
+.chatArtifactCopyButton:hover {
+  color: var(--geist-foreground);
+}
+
 .chatArtifactCodeBlock {
   max-height: 360px;
   margin: 0;

--- a/packages/genui/playground/src/pages/chat/adapters.test.ts
+++ b/packages/genui/playground/src/pages/chat/adapters.test.ts
@@ -605,6 +605,104 @@ describe('chat protocol adapters', () => {
     ).toBe(VALID_HTML);
   });
 
+  test('keeps the original XML fragment as a separate artifact view and persists it', () => {
+    const xmlFragment = '\n<view>\n  <text>杭州 &amp; 天气</text>\n</view>\n';
+    const modelOutput = `\n\`\`\`xml\n${VALID_LYNX_XML}\n\`\`\`\n`;
+    const output = { source: VALID_LYNX_XML, xmlFragment, modelOutput };
+    const done = LYNX_XML_CHAT_ADAPTER.stream.reduce(
+      LYNX_XML_CHAT_ADAPTER.stream.initial(),
+      {
+        event: 'done',
+        data: { text: VALID_LYNX_XML, metadata: { xmlFragment, modelOutput } },
+      },
+    );
+    expect(done.emissions).toEqual([{ type: 'final', output }]);
+    expect(LYNX_XML_CHAT_ADAPTER.stream.finish(done.state)).toEqual(output);
+    expect(
+      LYNX_XML_CHAT_ADAPTER.stream.fromJson({
+        text: VALID_LYNX_XML,
+        metadata: { xmlFragment, modelOutput },
+      }).emissions,
+    ).toEqual([{ type: 'final', output }]);
+    expect(LYNX_XML_CHAT_ADAPTER.preview.artifact(output).views).toEqual([
+      { id: 'source', label: 'Source', text: VALID_LYNX_XML, language: 'text' },
+      {
+        id: 'xml-fragment',
+        label: 'XML Fragment',
+        text: xmlFragment,
+        formattedText: '<view>\n  <text>杭州 &amp; 天气</text>\n</view>',
+        language: 'text',
+      },
+      {
+        id: 'model-output',
+        label: 'Model Output',
+        text: modelOutput,
+        language: 'text',
+      },
+    ]);
+    const saved = LYNX_XML_CHAT_ADAPTER.persist(output);
+    expect(saved.assistantContent).toBe(VALID_LYNX_XML);
+    expect(saved.lynxXmlFragment).toBe(xmlFragment);
+    expect(saved.lynxXmlModelOutput).toBe(modelOutput);
+    const history = [{
+      role: 'assistant' as const,
+      content: saved.assistantContent,
+      lynxXmlFragment: xmlFragment,
+      lynxXmlModelOutput: modelOutput,
+    }];
+    expect(
+      LYNX_XML_CHAT_ADAPTER.hydrate({
+        history,
+        previewMessages: [],
+        previewPayloadUrls: null,
+      }).output,
+    ).toEqual(output);
+    const request = LYNX_XML_CHAT_ADAPTER.createRequest({
+      prompt: 'Change the city',
+      conversation: { history, dataModel: {} },
+      settings: createDefaultProviderSettings(),
+      host: {
+        origin: 'http://localhost:3000',
+        hostname: 'localhost',
+        protocol: 'http:',
+        search: '',
+        baseUrl: '/',
+      },
+      signal: new AbortController().signal,
+    });
+    expect(JSON.stringify(request.body)).not.toContain('lynxXmlFragment');
+    expect(JSON.stringify(request.body)).not.toContain('lynxXmlModelOutput');
+    expect(LYNX_XML_CHAT_ADAPTER.preview.source(output, {
+      protocol: PROTOCOLS['lynx-xml'],
+      theme: 'light',
+      previewPayloadUrls: null,
+    })).not.toHaveProperty('modelOutput');
+    expect(
+      JSON.stringify(
+        LYNX_XML_CHAT_ADAPTER.preview.source(output, {
+          protocol: PROTOCOLS['lynx-xml'],
+          theme: 'light',
+          previewPayloadUrls: null,
+        }),
+      ),
+    ).not.toContain('xmlFragment');
+  });
+
+  test.each([undefined, {}, { xmlFragment: 42 }])(
+    'keeps legacy or invalid fragment metadata out of the artifact views: %j',
+    (metadata) => {
+      const result = LYNX_XML_CHAT_ADAPTER.stream.fromJson({
+        text: VALID_LYNX_XML,
+        metadata,
+      });
+      const output = LYNX_XML_CHAT_ADAPTER.stream.finish(result.state)!;
+      expect(output).toEqual({ source: VALID_LYNX_XML });
+      expect(LYNX_XML_CHAT_ADAPTER.preview.artifact(output).views).toHaveLength(
+        1,
+      );
+    },
+  );
+
   test('rejects an incomplete final HTML response', () => {
     expect(() =>
       HTML_CHAT_ADAPTER.stream.fromJson({

--- a/packages/genui/playground/src/pages/chat/format-xml-fragment.test.ts
+++ b/packages/genui/playground/src/pages/chat/format-xml-fragment.test.ts
@@ -1,0 +1,21 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { expect, test } from '@rstest/core';
+
+import { formatXmlFragment } from './format-xml-fragment.js';
+
+test('formats multiple roots while preserving entities and mixed text', () => {
+  expect(
+    formatXmlFragment(
+      '<view><text>A &amp; B</text></view><text>Hello <text>world</text>!</text>',
+    ),
+  ).toBe(
+    '<view>\n  <text>A &amp; B</text>\n</view>\n<text>Hello <text>world</text>!</text>',
+  );
+});
+
+test('leaves malformed fragments available only as raw source', () => {
+  expect(formatXmlFragment('<view><text>incomplete')).toBeUndefined();
+});

--- a/packages/genui/playground/src/pages/chat/format-xml-fragment.ts
+++ b/packages/genui/playground/src/pages/chat/format-xml-fragment.ts
@@ -1,0 +1,26 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import xmlFormat from 'xml-formatter';
+
+/** Derive a display-only version, allowing multiple fragment roots. */
+export function formatXmlFragment(source: string): string | undefined {
+  const open = '<genui-fragment>';
+  const close = '</genui-fragment>';
+  try {
+    const formatted = xmlFormat(`${open}${source}${close}`, {
+      indentation: '  ',
+      lineSeparator: '\n',
+      collapseContent: true,
+      strictMode: true,
+    });
+    const inner = formatted.slice(open.length, -close.length);
+    return inner.startsWith('\n')
+      ? inner.slice(1).replace(/\n$/u, '').replace(/^ {2}/gmu, '')
+      : inner;
+  } catch {
+    // Older or incomplete artifacts must still expose their exact raw source.
+    return undefined;
+  }
+}

--- a/packages/genui/playground/src/pages/chat/lynx-xml.ts
+++ b/packages/genui/playground/src/pages/chat/lynx-xml.ts
@@ -2,6 +2,7 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
+import { formatXmlFragment } from './format-xml-fragment.js';
 import {
   CHAT_PROVIDER_SETTINGS_ADAPTER,
   getChatEndpoint,
@@ -25,11 +26,12 @@ import type { LynxXmlScenario } from '../demos/lynx-xml.js';
 
 export interface LynxXmlOutput {
   source: string;
+  xmlFragment?: string;
+  modelOutput?: string;
 }
 
-export interface LynxXmlStreamState {
+export interface LynxXmlStreamState extends LynxXmlOutput {
   generatedText: string;
-  source: string;
 }
 
 const DOCTYPE = '<!doctype lynx>';
@@ -109,7 +111,19 @@ function requireCompleteOutput(value: unknown, fallback = ''): LynxXmlOutput {
   if (!isCompleteLynxXmlSource(source)) {
     throw new Error('The agent returned an incomplete Lynx XML artifact');
   }
-  return { source };
+  const xmlFragment = isRecord(value) && isRecord(value.metadata)
+      && typeof value.metadata.xmlFragment === 'string'
+    ? value.metadata.xmlFragment
+    : undefined;
+  const modelOutput = isRecord(value) && isRecord(value.metadata)
+      && typeof value.metadata.modelOutput === 'string'
+    ? value.metadata.modelOutput
+    : undefined;
+  return {
+    source,
+    ...(xmlFragment ? { xmlFragment } : {}),
+    ...(modelOutput ? { modelOutput } : {}),
+  };
 }
 
 function streamStep(
@@ -156,7 +170,7 @@ export const LYNX_XML_STREAM = {
     if (usage) emissions.push({ type: 'usage', usage });
     emissions.push({ type: 'final', output });
     return streamStep(
-      { generatedText: output.source, source: output.source },
+      { generatedText: output.source, ...output },
       emissions,
     );
   },
@@ -167,13 +181,17 @@ export const LYNX_XML_STREAM = {
     if (usage) emissions.push({ type: 'usage', usage });
     emissions.push({ type: 'final', output });
     return streamStep(
-      { generatedText: output.source, source: output.source },
+      { generatedText: output.source, ...output },
       emissions,
     );
   },
   finish(state: LynxXmlStreamState): LynxXmlOutput | null {
     return isCompleteLynxXmlSource(state.source)
-      ? { source: state.source }
+      ? {
+        source: state.source,
+        ...(state.xmlFragment ? { xmlFragment: state.xmlFragment } : {}),
+        ...(state.modelOutput ? { modelOutput: state.modelOutput } : {}),
+      }
       : null;
   },
   error: normalizeError,
@@ -237,7 +255,16 @@ function hydrate(
     if (message.role !== 'assistant') continue;
     const source = extractLynxXmlSource(message.content);
     if (!isCompleteLynxXmlSource(source)) continue;
-    output = { source };
+    output = {
+      source,
+      ...(typeof message.lynxXmlFragment === 'string' && message.lynxXmlFragment
+        ? { xmlFragment: message.lynxXmlFragment }
+        : {}),
+      ...(typeof message.lynxXmlModelOutput === 'string'
+          && message.lynxXmlModelOutput
+        ? { modelOutput: message.lynxXmlModelOutput }
+        : {}),
+    };
     messages.push(
       pendingLocalTitle
         ? localExampleStatus(pendingLocalTitle)
@@ -255,21 +282,47 @@ function hydrate(
 }
 
 function createArtifact(output: LynxXmlOutput): ChatArtifact {
+  const formattedFragment = output.xmlFragment
+    ? formatXmlFragment(output.xmlFragment)
+    : undefined;
   return {
     title: 'Generated Lynx XML Artifact',
     meta: `.lynxml · ${formatCharacterCount(output.source)}`,
-    views: [{
-      id: 'source',
-      label: 'Source',
-      text: output.source,
-      language: 'text',
-    }],
+    views: [
+      {
+        id: 'source',
+        label: 'Source',
+        text: output.source,
+        language: 'text',
+      },
+      ...(output.xmlFragment
+        ? [{
+          id: 'xml-fragment',
+          label: 'XML Fragment',
+          text: output.xmlFragment,
+          ...(formattedFragment === undefined
+            ? {}
+            : { formattedText: formattedFragment }),
+          language: 'text' as const,
+        }]
+        : []),
+      ...(output.modelOutput
+        ? [{
+          id: 'model-output',
+          label: 'Model Output',
+          text: output.modelOutput,
+          language: 'text' as const,
+        }]
+        : []),
+    ],
   };
 }
 
 function persistOutput(output: LynxXmlOutput): ChatTurnPersistence {
   return {
     assistantContent: output.source,
+    ...(output.xmlFragment ? { lynxXmlFragment: output.xmlFragment } : {}),
+    ...(output.modelOutput ? { lynxXmlModelOutput: output.modelOutput } : {}),
     a2uiMessages: [],
     previewMessages: [],
   };
@@ -300,7 +353,13 @@ export const LYNX_XML_CHAT_ADAPTER = {
       body: {
         resourceId: 'lynx-xml-create',
         messages: [{ role: 'user', content: prompt }],
-        conversation,
+        conversation: {
+          ...conversation,
+          history: conversation.history.map(({ role, content }) => ({
+            role,
+            content,
+          })),
+        },
         ...toProviderRequestOptions(settings),
       },
     };

--- a/packages/genui/playground/src/pages/chat/type.ts
+++ b/packages/genui/playground/src/pages/chat/type.ts
@@ -64,6 +64,7 @@ export interface ChatArtifactView {
   id: string;
   label: string;
   text: string;
+  formattedText?: string;
   language: 'text' | 'json';
 }
 
@@ -103,6 +104,8 @@ export interface ChatStreamAdapter<TState, TOutput> {
 
 export interface ChatTurnPersistence {
   assistantContent: string;
+  lynxXmlFragment?: string;
+  lynxXmlModelOutput?: string;
   a2uiMessages: unknown[];
   previewMessages: unknown[];
   previewPayloadUrls?: PreviewPayloadUrls | null;

--- a/packages/genui/playground/src/storage/conversationRepo.ts
+++ b/packages/genui/playground/src/storage/conversationRepo.ts
@@ -227,6 +227,12 @@ export async function importConversation(
     seq: index,
     role: message.role,
     content: message.content,
+    ...(message.lynxXmlFragment
+      ? { lynxXmlFragment: message.lynxXmlFragment }
+      : {}),
+    ...(message.lynxXmlModelOutput
+      ? { lynxXmlModelOutput: message.lynxXmlModelOutput }
+      : {}),
     previewPayloadUrls: message.previewPayloadUrls,
     previewMetrics: message.previewMetrics,
     createdAt: now + index,

--- a/packages/genui/playground/src/storage/sharedConversation.test.ts
+++ b/packages/genui/playground/src/storage/sharedConversation.test.ts
@@ -3,9 +3,54 @@
 // LICENSE file in the root directory of this source tree.
 import { describe, expect, test } from '@rstest/core';
 
-import { resolveSharedConversationProtocol } from './sharedConversation.js';
+import {
+  isSharedConversationDoc,
+  resolveSharedConversationProtocol,
+  serializeConversation,
+} from './sharedConversation.js';
 
 describe('shared conversation protocol metadata', () => {
+  test('preserves the original Lynx XML fragment in shared history', () => {
+    const xmlFragment = '\n<text>杭州 &amp; 天气</text>\n';
+    const modelOutput = '\n<!doctype lynx>original model output\n';
+    const doc = serializeConversation({
+      meta: {
+        id: 'xml',
+        title: 'Weather',
+        protocol: 'lynx-xml',
+        createdAt: 1,
+        updatedAt: 1,
+        messageCount: 1,
+        previewText: '',
+      },
+      messages: [{
+        conversationId: 'xml',
+        seq: 0,
+        role: 'assistant',
+        content: '<!doctype lynx>final</lynx>',
+        lynxXmlFragment: xmlFragment,
+        lynxXmlModelOutput: modelOutput,
+        createdAt: 1,
+      }],
+      snapshot: null,
+    }, 'lynx-xml');
+    expect(doc.messages[0]?.lynxXmlFragment).toBe(xmlFragment);
+    expect(doc.messages[0]?.lynxXmlModelOutput).toBe(modelOutput);
+    expect(
+      isSharedConversationDoc({
+        ...doc,
+        messages: [{ ...doc.messages[0], lynxXmlModelOutput: 42 }],
+      }),
+    ).toBe(false);
+    expect(isSharedConversationDoc(doc)).toBe(true);
+    expect(
+      isSharedConversationDoc({
+        ...doc,
+        messages: [{ ...doc.messages[0], lynxXmlFragment: 42 }],
+      }),
+    ).toBe(false);
+  });
+
   test('treats legacy shared conversations without protocol as A2UI', () => {
     expect(resolveSharedConversationProtocol({})).toBe('a2ui');
   });

--- a/packages/genui/playground/src/storage/sharedConversation.ts
+++ b/packages/genui/playground/src/storage/sharedConversation.ts
@@ -18,6 +18,8 @@ export const SHARED_CONVERSATION_KIND = 'a2ui-conversation';
 export interface SharedConversationMessage {
   role: 'user' | 'assistant' | 'system';
   content: string;
+  lynxXmlFragment?: string;
+  lynxXmlModelOutput?: string;
   previewPayloadUrls?: PreviewPayloadUrls;
   previewMetrics?: PreviewPerformanceMetrics;
 }
@@ -57,6 +59,12 @@ export function serializeConversation(
         role: message.role,
         content: message.content,
       };
+      if (message.lynxXmlFragment) {
+        next.lynxXmlFragment = message.lynxXmlFragment;
+      }
+      if (message.lynxXmlModelOutput) {
+        next.lynxXmlModelOutput = message.lynxXmlModelOutput;
+      }
       if (message.previewPayloadUrls) {
         next.previewPayloadUrls = message.previewPayloadUrls;
       }
@@ -100,6 +108,10 @@ function isSharedConversationMessage(
       || message.role === 'assistant'
       || message.role === 'system')
     && typeof message.content === 'string'
+    && (message.lynxXmlFragment === undefined
+      || typeof message.lynxXmlFragment === 'string')
+    && (message.lynxXmlModelOutput === undefined
+      || typeof message.lynxXmlModelOutput === 'string')
   );
 }
 

--- a/packages/genui/playground/src/storage/types.ts
+++ b/packages/genui/playground/src/storage/types.ts
@@ -37,6 +37,8 @@ export interface PersistedMessage {
   seq: number;
   role: 'user' | 'assistant' | 'system';
   content: string;
+  lynxXmlFragment?: string;
+  lynxXmlModelOutput?: string;
   previewPayloadUrls?: PreviewPayloadUrls;
   previewMetrics?: PreviewPerformanceMetrics;
   createdAt: number;

--- a/packages/genui/server/AGENTS.md
+++ b/packages/genui/server/AGENTS.md
@@ -216,6 +216,18 @@ as a missing XML tag. The final artifact must start with lowercase
 thread script, and end with `</lynx>`. Keep generated UI on Element PAPI; do
 not route it through ReactLynx, JSX, OpenUI, or A2UI.
 
+The SSE `done` payload optionally includes `metadata.xmlFragment`, containing
+the exact original XML passed to `html_fragment_to_main_thread_script` before
+conversion. It is separate from `text`, which remains the complete expanded and
+validated `.lynxml` artifact. `xmlFragment` is omitted when the tool was not used.
+The service's `generateRaw` result exposes the same metadata. Tool inputs are
+request-scoped and are not added to text deltas or the model-visible tool result.
+
+`metadata.modelOutput` preserves the exact final model text before placeholder
+expansion, node declarations, binding repair, and document normalization. Return
+it from streaming finalization and `generateRaw`, even without fragment conversion.
+It is client-facing display metadata and must not be fed back into model history.
+
 ## HTML Generation
 
 `POST /html/stream` uses a dedicated HTML agent and the shared text SSE route

--- a/packages/genui/server/agent/lynx-xml/html-fragment-to-main-thread-script-tool.ts
+++ b/packages/genui/server/agent/lynx-xml/html-fragment-to-main-thread-script-tool.ts
@@ -9,6 +9,7 @@ import { z } from 'zod';
 import {
   MAX_XML_FRAGMENT_LENGTH,
   generateMainThreadScriptResult,
+  resolveFragmentBindings,
 } from '@lynx-js/genui-lynx-xml';
 import type { GeneratedMainThreadScript } from '@lynx-js/genui-lynx-xml';
 
@@ -19,7 +20,14 @@ const FRAGMENT_SCRIPT_PLACEHOLDER_PATTERN =
 const FRAGMENT_SCRIPT_PLACEHOLDER_IN_SOURCE_PATTERN =
   /\/\*__GENUI_HTML_FRAGMENT_[0-9a-f-]{36}__\*\//gu;
 
+export interface HtmlFragmentScriptMetadata extends Record<string, unknown> {
+  xmlFragment: string;
+}
+
 interface FragmentScriptReplacement {
+  bindings: Record<string, string>;
+  declarations: string;
+  xmlFragment: string;
   javascript: string;
   placeholder: string;
 }
@@ -44,6 +52,15 @@ export function createHtmlFragmentScriptRunScope(): HtmlFragmentScriptRunScope {
   >();
   requestContext.set(FRAGMENT_SCRIPT_RUN_STATE_KEY, { replacements: [] });
   return { requestContext };
+}
+
+/** Expose only the original converter input as client-facing metadata. */
+export function getHtmlFragmentScriptMetadata(
+  scope: HtmlFragmentScriptRunScope,
+): HtmlFragmentScriptMetadata | undefined {
+  const replacement = scope.requestContext.get(FRAGMENT_SCRIPT_RUN_STATE_KEY)
+    .replacements[0];
+  return replacement ? { xmlFragment: replacement.xmlFragment } : undefined;
 }
 
 /** Count exact, non-overlapping occurrences of a value. */
@@ -107,6 +124,28 @@ export function resolveHtmlFragmentScriptPlaceholders(
       replacement.javascript,
     );
   }
+  const declarations = state.replacements.map((replacement) =>
+    replacement.declarations
+  ).filter(Boolean).join('\n');
+  if (declarations) {
+    const scriptStart = resolved.indexOf('<script thread="main">');
+    const scriptEnd = resolved.indexOf('</script>', scriptStart);
+    if (scriptStart === -1 || scriptEnd === -1) {
+      throw new Error(
+        'Fragment node declarations require a complete main-thread script',
+      );
+    }
+    const scriptBodyStart = scriptStart + '<script thread="main">'.length;
+    const javascript = resolveFragmentBindings(
+      resolved.slice(scriptBodyStart, scriptEnd),
+      Object.fromEntries(
+        state.replacements.flatMap(item => Object.entries(item.bindings)),
+      ),
+      declarations,
+    );
+    resolved = resolved.slice(0, scriptBodyStart) + javascript
+      + resolved.slice(scriptEnd);
+  }
   return resolved;
 }
 
@@ -114,6 +153,7 @@ export function resolveHtmlFragmentScriptPlaceholders(
 function registerHtmlFragmentScript(
   requestContext: RequestContext<FragmentScriptRequestContextValues>,
   generated: GeneratedMainThreadScript,
+  xmlFragment: string,
 ): { bindings: Record<string, string>; placeholder: string } {
   const state = requestContext.get(FRAGMENT_SCRIPT_RUN_STATE_KEY);
   if (!state) {
@@ -128,6 +168,9 @@ function registerHtmlFragmentScript(
   const placeholder = `/*__GENUI_HTML_FRAGMENT_${crypto.randomUUID()}__*/`;
   requestContext.set(FRAGMENT_SCRIPT_RUN_STATE_KEY, {
     replacements: [...state.replacements, {
+      bindings: generated.bindings,
+      xmlFragment,
+      declarations: generated.declarations ?? '',
       javascript: generated.javascript,
       placeholder,
     }],
@@ -146,13 +189,16 @@ const outputSchema = z.object({
     'An opaque comment marker to copy exactly once onto its own line inside renderPage(). The server replaces it with generated Element PAPI JavaScript after model generation.',
   ),
   bindings: z.record(z.string(), z.string().regex(/^node\d+$/u)).describe(
-    'A map from XML id attributes to generated JavaScript node variable names for event handlers and updates.',
+    'A map from XML id attributes to generated JavaScript node variable names. Use the VALUES in handlers and updates: {"cityText":"node5"} means setText(node5, ...), not setText(cityText, ...). XML ids do not declare variables.',
   ),
 });
 
 const requestContextSchema = z.object({
   [FRAGMENT_SCRIPT_RUN_STATE_KEY]: z.object({
     replacements: z.array(z.object({
+      bindings: z.record(z.string(), z.string().regex(/^node\d+$/u)),
+      xmlFragment: z.string().min(1).max(MAX_XML_FRAGMENT_LENGTH),
+      declarations: z.string(),
       javascript: z.string().min(1),
       placeholder: z.string().regex(FRAGMENT_SCRIPT_PLACEHOLDER_PATTERN),
     })).max(1),
@@ -164,7 +210,7 @@ export function createHtmlFragmentToMainThreadScriptTool() {
   return createTool({
     id: 'html_fragment_to_main_thread_script',
     description:
-      'Convert one HTML-like, well-formed XML fragment into server-held Element PAPI JavaScript. Returns only an opaque placeholder to copy exactly once onto its own line inside renderPage(), plus bindings from XML id attributes to generated node variables. The server replaces the placeholder after model generation, so never expand or rewrite it. Event handlers and lifecycle code remain the agent\'s responsibility.',
+      'Convert one HTML-like, well-formed XML fragment into server-held Element PAPI JavaScript. Returns only an opaque placeholder to copy exactly once onto its own line inside renderPage(), plus bindings from XML id attributes to generated node variables. The server replaces the placeholder after model generation, and adds hoisted script-level node declarations, so handlers outside renderPage() can use the bindings after rendering. Never expand the placeholder or redeclare the returned node variables. Event handlers and lifecycle code remain the agent\'s responsibility.',
     inputSchema,
     outputSchema,
     requestContextSchema,
@@ -173,7 +219,8 @@ export function createHtmlFragmentToMainThreadScriptTool() {
         context.requestContext as RequestContext<
           FragmentScriptRequestContextValues
         >,
-        generateMainThreadScriptResult(xmlFragment),
+        generateMainThreadScriptResult(xmlFragment, { nodeScope: 'script' }),
+        xmlFragment,
       ),
   });
 }

--- a/packages/genui/server/app/common/text-stream-route.ts
+++ b/packages/genui/server/app/common/text-stream-route.ts
@@ -40,6 +40,7 @@ interface TextStreamingService {
       text: string | undefined;
       usage: unknown;
       finishReason: unknown;
+      metadata?: Record<string, unknown>;
     }>;
   }>;
 }
@@ -208,7 +209,7 @@ async function postTextStream(req: Request, config: TextStreamRouteOptions) {
             streamedTextLength: streamedText.length,
           });
 
-          const { text, usage, finishReason } = await finalize();
+          const { text, usage, finishReason, metadata } = await finalize();
           resultMetadata = { finishReason, usage };
           generationController.signal.throwIfAborted();
           const rawFinalText = text ?? streamedText;
@@ -240,6 +241,7 @@ async function postTextStream(req: Request, config: TextStreamRouteOptions) {
           enqueue('done', {
             ok: true,
             text: finalText,
+            ...(metadata ? { metadata } : {}),
             usage,
             finishReason,
           });

--- a/packages/genui/server/service/lynx-xml/lynx-xml-agent.ts
+++ b/packages/genui/server/service/lynx-xml/lynx-xml-agent.ts
@@ -5,9 +5,12 @@
 import { initializeArkImageGenerationRunScope } from '../../agent/common/ark-image-generation-tool.js';
 import {
   createHtmlFragmentScriptRunScope,
+  getHtmlFragmentScriptMetadata,
   resolveHtmlFragmentScriptPlaceholders,
 } from '../../agent/lynx-xml/html-fragment-to-main-thread-script-tool.js';
-import type { HtmlFragmentScriptRunScope } from '../../agent/lynx-xml/html-fragment-to-main-thread-script-tool.js';
+import type {
+  HtmlFragmentScriptRunScope,
+} from '../../agent/lynx-xml/html-fragment-to-main-thread-script-tool.js';
 import { createLynxXmlAgent } from '../../agent/lynx-xml/lynx-xml-agent.js';
 import type { LynxXmlAgent } from '../../agent/lynx-xml/lynx-xml-agent.js';
 import { pickAgentCapabilityConfig } from '../common/agent-capabilities.js';
@@ -35,6 +38,11 @@ import type {
 } from '../common/types.js';
 
 export type LynxXmlChatOptions = ChatOptions;
+
+export interface LynxXmlGenerationMetadata extends Record<string, unknown> {
+  modelOutput: string;
+  xmlFragment?: string;
+}
 
 export const LYNX_XML_MAX_OUTPUT_TOKENS = 16_384;
 
@@ -151,6 +159,7 @@ export default class LynxXmlAgentService {
       text: string | undefined;
       usage: unknown;
       finishReason: unknown;
+      metadata: LynxXmlGenerationMetadata;
     }>;
   }> {
     const buildConversationStartedAt = performance.now();
@@ -184,6 +193,10 @@ export default class LynxXmlAgentService {
         return {
           ...result,
           text: resolveHtmlFragmentScriptPlaceholders(scope, rawText),
+          metadata: {
+            ...getHtmlFragmentScriptMetadata(scope),
+            modelOutput: rawText,
+          },
         };
       },
     };
@@ -194,7 +207,12 @@ export default class LynxXmlAgentService {
     opts: LynxXmlChatOptions = {},
     conversation?: ConversationContext,
     abortSignal?: AbortSignal,
-  ): Promise<{ text: string; usage: unknown; finishReason: unknown }> {
+  ): Promise<{
+    text: string;
+    usage: unknown;
+    finishReason: unknown;
+    metadata: LynxXmlGenerationMetadata;
+  }> {
     abortSignal?.throwIfAborted();
     const agent = await this.getAgent(opts);
     abortSignal?.throwIfAborted();
@@ -207,6 +225,10 @@ export default class LynxXmlAgentService {
     return {
       ...generated,
       text: resolveHtmlFragmentScriptPlaceholders(scope, generated.text),
+      metadata: {
+        ...getHtmlFragmentScriptMetadata(scope),
+        modelOutput: generated.text,
+      },
     };
   }
 }

--- a/packages/genui/server/test/built-server.test.ts
+++ b/packages/genui/server/test/built-server.test.ts
@@ -1,0 +1,68 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { spawn } from 'node:child_process';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { expect, test } from '@rstest/core';
+
+test(
+  'starts the built server and serves metadata without model credentials',
+  async () => {
+    const child = spawn(process.execPath, [
+      resolve(dirname(fileURLToPath(import.meta.url)), '../dist/index.js'),
+    ], {
+      env: {
+        ...process.env,
+        GENUI_MODEL_CONFIG_JSON: '{}',
+        GENUI_HTTP2: '0',
+        LYNX_USE_HOST: '127.0.0.1',
+        LYNX_USE_PORT: '0',
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let output = '';
+    const closed = new Promise<void>(resolve =>
+      child.once('close', () => resolve())
+    );
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      const url = await new Promise<string>((resolve, reject) => {
+        timer = setTimeout(
+          () => reject(new Error(`Server startup timed out:\n${output}`)),
+          10_000,
+        );
+        child.once('error', reject);
+        child.once(
+          'exit',
+          code => reject(new Error(`Server exited with ${code}:\n${output}`)),
+        );
+        child.stderr.on('data', (chunk: Buffer) => {
+          output += chunk.toString();
+        });
+        child.stdout.on('data', (chunk: Buffer) => {
+          output += chunk.toString();
+          const address = /server listening on (http:\/\/127\.0\.0\.1:\d+)/u
+            .exec(output)?.[1];
+          if (address) {
+            resolve(address);
+          }
+        });
+      });
+      const response = await fetch(`${url}/mcp-apps/metadata`, {
+        signal: AbortSignal.timeout(5_000),
+      });
+      expect(response.status).toBe(200);
+      expect(await response.json()).toMatchObject({
+        protocolVersion: '2025-11-25',
+      });
+    } finally {
+      clearTimeout(timer);
+      child.kill('SIGKILL');
+      await closed;
+    }
+  },
+  20_000,
+);

--- a/packages/genui/server/test/html-fragment-to-main-thread-script-tool.test.ts
+++ b/packages/genui/server/test/html-fragment-to-main-thread-script-tool.test.ts
@@ -2,11 +2,14 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
-import { describe, expect, test } from '@rstest/core';
+import { runInNewContext } from 'node:vm';
+
+import { describe, expect, rstest, test } from '@rstest/core';
 
 import {
   createHtmlFragmentScriptRunScope,
   createHtmlFragmentToMainThreadScriptTool,
+  getHtmlFragmentScriptMetadata,
   resolveHtmlFragmentScriptPlaceholders,
 } from '../agent/lynx-xml/html-fragment-to-main-thread-script-tool.js';
 
@@ -30,24 +33,30 @@ async function executeFragmentTool(
 
 describe('HTML fragment to main-thread script tool', () => {
   test('returns an opaque placeholder and id-to-node bindings', async () => {
-    const { output, scope } = await executeFragmentTool(
-      '<view id="root"><text id="label">Hello</text></view>',
-    );
+    const xmlFragment =
+      '\n  <view id="root"><text id="label">Hello &amp; 你好</text></view>\n';
+    const { output, scope } = await executeFragmentTool(xmlFragment);
+    expect(getHtmlFragmentScriptMetadata(scope)).toEqual({ xmlFragment });
 
     expect(output.placeholder).toMatch(
       /^\/\*__GENUI_HTML_FRAGMENT_[0-9a-f-]{36}__\*\/$/u,
     );
     expect(output.bindings).toEqual({ root: 'node0', label: 'node1' });
     expect(Object.hasOwn(output, 'javascript')).toBe(false);
+    expect(Object.hasOwn(output, 'xmlFragment')).toBe(false);
 
-    const artifact = `function renderPage() {
+    const artifact = `<script thread="main">
+function renderPage() {
   const page = __CreatePage("0", 0);
   const pageId = __GetElementUniqueID(page);
   ${output.placeholder}
   __AddEventListener(node1, "tap", onTap, {});
-}`;
+}
+</script>`;
     const resolved = resolveHtmlFragmentScriptPlaceholders(scope, artifact);
-    expect(resolved).toContain('const node0 = __CreateView(pageId);');
+    expect(resolved).toContain('node0 = __CreateView(pageId);');
+    expect(resolved).not.toContain('const node0');
+    expect(resolved).toMatch(/^<script thread="main">\s*var node0, node1;/u);
     expect(resolved).toContain('__SetID(node1, "label");');
     expect(resolved).toContain(
       '__AddEventListener(node1, "tap", onTap, {});',
@@ -59,6 +68,14 @@ describe('HTML fragment to main-thread script tool', () => {
     const first = await executeFragmentTool('<view id="first"/>');
     const second = await executeFragmentTool('<view id="second"/>');
 
+    expect(getHtmlFragmentScriptMetadata(createHtmlFragmentScriptRunScope()))
+      .toBeUndefined();
+    expect(getHtmlFragmentScriptMetadata(first.scope)).toEqual({
+      xmlFragment: '<view id="first"/>',
+    });
+    expect(getHtmlFragmentScriptMetadata(second.scope)).toEqual({
+      xmlFragment: '<view id="second"/>',
+    });
     expect(first.output.placeholder).not.toBe(second.output.placeholder);
     expect(() =>
       resolveHtmlFragmentScriptPlaceholders(
@@ -89,6 +106,141 @@ describe('HTML fragment to main-thread script tool', () => {
       { requestContext: first.scope.requestContext } as never,
     )).rejects.toThrow('may only be called once per agent run');
   });
+
+  test('lets external handlers access node13 after rendering and after a re-render', async () => {
+    const xmlFragment = `<view>${
+      Array.from({ length: 13 }, (_, index) =>
+        `<text id="item${index}">示例数据</text>`).join('')
+    }</view>`;
+    const { output, scope } = await executeFragmentTool(xmlFragment);
+    expect(output.bindings.item12).toBe('node13');
+    const artifact = `<script thread="main">
+"use strict";
+function onRefreshTap() {
+  __SetAttribute(node13, "text", "刚刚刷新");
+}
+function renderPage() {
+  const page = __CreatePage("0", 0);
+  const pageId = __GetElementUniqueID(page);
+  ${output.placeholder}
+}
+function updatePage() { onRefreshTap(); }
+function destroyLifetime() { __SetAttribute(node13, "destroyed", true); }
+renderPage();
+onRefreshTap();
+renderPage();
+updatePage();
+destroyLifetime();
+</script>`;
+    const resolved = resolveHtmlFragmentScriptPlaceholders(scope, artifact);
+    const updates: { node: object; name: string; value: unknown }[] = [];
+    const noop = rstest.fn();
+    const script = resolved.slice(
+      '<script thread="main">'.length,
+      resolved.indexOf('</script>'),
+    );
+    expect(script.trimStart()).toMatch(/^"use strict";/u);
+    expect(script.trimStart()).toMatch(/^"use strict";\s*var node0, node1, /u);
+    runInNewContext(script, {
+      __CreatePage: () => ({}),
+      __GetElementUniqueID: () => 0,
+      __CreateView: () => ({}),
+      __CreateText: () => ({}),
+      __CreateRawText: () => ({}),
+      __SetID: noop,
+      __AppendElement: noop,
+      __SetAttribute: (node: object, name: string, value: unknown) => {
+        updates.push({ node, name, value });
+      },
+    });
+    expect(updates.map(({ name, value }) => ({ name, value }))).toEqual([
+      { name: 'text', value: '刚刚刷新' },
+      { name: 'text', value: '刚刚刷新' },
+      { name: 'destroyed', value: true },
+    ]);
+    expect(updates[0]?.node).not.toBe(updates[1]?.node);
+    expect(updates[1]?.node).toBe(updates[2]?.node);
+  });
+
+  test.each([
+    ['cityText', 'temperatureText', 'todayRange'],
+    ['currentUnit', 'currentTemp', 'temp0'],
+  ])(
+    'resolves weather ids %s, %s, %s through render, tap, update and destroy',
+    async (labelId, temperatureId, rangeId) => {
+      const xmlFragment =
+        `<view id="unitToggle"><text id="${labelId}">Shanghai</text><text id="${temperatureId}">26°</text><text id="${rangeId}">30° / 22°</text></view>`;
+      const { output, scope } = await executeFragmentTool(xmlFragment);
+      const artifact = `<script thread="main">
+"use strict";
+let fahrenheit = false;
+function setText(node, value) {
+  __ReplaceElements(node, [__CreateRawText(value)], __GetChildren(node));
+}
+function applyUnit() {
+  setText(${labelId}, fahrenheit ? "Fahrenheit" : "Celsius");
+  setText(${temperatureId}, fahrenheit ? "79°" : "26°");
+  const ranges = [${rangeId}];
+  setText(ranges[0], fahrenheit ? "86° / 72°" : "30° / 22°");
+}
+function onTap() { fahrenheit = !fahrenheit; applyUnit(); __FlushElementTree(); }
+function renderPage() {
+  const page = __CreatePage("0", 0);
+  const pageId = __GetElementUniqueID(page);
+  ${output.placeholder}
+  __AddEventListener(unitToggle, "tap", onTap, {});
+  applyUnit();
+}
+function updatePage() { fahrenheit = false; applyUnit(); }
+function destroyLifetime() { __RemoveEventListener(unitToggle, "tap", onTap, {}); }
+renderPage();
+</script>`;
+      const resolved = resolveHtmlFragmentScriptPlaceholders(scope, artifact);
+      interface Node {
+        children: unknown[];
+      }
+      const nodes = new Map<string, Node>();
+      const createNode = (): Node => ({ children: [] });
+      const listeners = new Map<Node, () => void>();
+      const flush = rstest.fn();
+      const context = {
+        __CreatePage: createNode,
+        __CreateView: createNode,
+        __CreateText: createNode,
+        __CreateRawText: (text: string) => text,
+        __GetElementUniqueID: () => 0,
+        __SetID: (node: Node, id: string) => nodes.set(id, node),
+        __AppendElement: (parent: Node, child: unknown) =>
+          parent.children.push(child),
+        __GetChildren: (node: Node) => node.children,
+        __ReplaceElements: (node: Node, children: unknown[]) => {
+          node.children = children;
+        },
+        __AddEventListener: (
+          node: Node,
+          _event: string,
+          callback: () => void,
+        ) => listeners.set(node, callback),
+        __RemoveEventListener: (node: Node) => listeners.delete(node),
+        __FlushElementTree: flush,
+      };
+      const script = resolved.slice(
+        '<script thread="main">'.length,
+        resolved.indexOf('</script>'),
+      );
+      runInNewContext(script, context);
+      expect(nodes.get(temperatureId)?.children).toEqual(['26°']);
+      listeners.get(nodes.get('unitToggle')!)!();
+      expect(nodes.get(labelId)?.children).toEqual(['Fahrenheit']);
+      expect(nodes.get(temperatureId)?.children).toEqual(['79°']);
+      expect(nodes.get(rangeId)?.children).toEqual(['86° / 72°']);
+      expect(flush).toHaveBeenCalledTimes(1);
+      runInNewContext('updatePage(); destroyLifetime();', context);
+      expect(nodes.get(temperatureId)?.children).toEqual(['26°']);
+      expect(listeners.size).toBe(0);
+      expect(getHtmlFragmentScriptMetadata(scope)).toEqual({ xmlFragment });
+    },
+  );
 
   test('exposes the converter as a Mastra tool', () => {
     expect(createHtmlFragmentToMainThreadScriptTool().id).toBe(

--- a/packages/genui/server/test/lynx-xml-fragment-placeholder.test.ts
+++ b/packages/genui/server/test/lynx-xml-fragment-placeholder.test.ts
@@ -47,6 +47,7 @@ beforeEach(() => {
 describe('Lynx XML fragment placeholder delivery', () => {
   test('keeps scripts request-scoped and expands only the final text', async () => {
     const placeholders: string[] = [];
+    const fragments: string[] = [];
     const tool = createHtmlFragmentToMainThreadScriptTool();
     const execute = tool.execute;
     if (!execute) throw new Error('fragment tool execute is missing');
@@ -59,8 +60,11 @@ describe('Lynx XML fragment placeholder delivery', () => {
           requestContext: HtmlFragmentScriptRunScope['requestContext'];
         },
       ) => {
+        const xmlFragment =
+          `<view id="button"><text>Tap ${fragments.length}</text></view>`;
+        fragments.push(xmlFragment);
         const output = await execute(
-          { xmlFragment: '<view id="button"><text>Tap</text></view>' },
+          { xmlFragment },
           { requestContext: options.requestContext } as never,
         ) as FragmentToolOutput;
         const buttonBinding = output.bindings.button;
@@ -88,17 +92,65 @@ describe('Lynx XML fragment placeholder delivery', () => {
     const secondStreamedText = await collect(second.textStream);
     const secondFinal = await second.finalize();
 
+    expect(firstFinal.metadata).toEqual({
+      xmlFragment: fragments[0],
+      modelOutput: firstStreamedText,
+    });
+    expect(secondFinal.metadata).toEqual({
+      xmlFragment: fragments[1],
+      modelOutput: secondStreamedText,
+    });
     expect(createLynxXmlAgent).toHaveBeenCalledTimes(1);
     expect(placeholders).toHaveLength(2);
     expect(placeholders[0]).not.toBe(placeholders[1]);
     expect(firstStreamedText).toContain(placeholders[0]);
     expect(secondStreamedText).toContain(placeholders[1]);
-    expect(firstFinal.text).toContain('const node0 = __CreateView(pageId);');
+    expect(firstFinal.text).toContain('node0 = __CreateView(pageId);');
     expect(firstFinal.text).toContain(
       '__AddEventListener(node0, "tap", onTap, {});',
     );
-    expect(secondFinal.text).toContain('const node0 = __CreateView(pageId);');
+    expect(secondFinal.text).toContain('node0 = __CreateView(pageId);');
     expect(firstFinal.text).not.toContain('__GENUI_HTML_FRAGMENT_');
     expect(secondFinal.text).not.toContain('__GENUI_HTML_FRAGMENT_');
+  });
+  test('returns original model output with and without fragment conversion', async () => {
+    const xmlFragment = '<view id="button"><text>Original</text></view>';
+    const execute = createHtmlFragmentToMainThreadScriptTool().execute;
+    if (!execute) throw new Error('fragment tool execute is missing');
+    let calls = 0;
+    let modelOutput = '';
+    rstest.mocked(createLynxXmlAgent).mockReturnValue({
+      agent: {
+        generate: async (
+          _messages: unknown,
+          options: HtmlFragmentScriptRunScope,
+        ) => {
+          if (calls++ > 0) {
+            return { text: 'no conversion', finishReason: 'stop' };
+          }
+          const output = await execute({ xmlFragment }, {
+            requestContext: options.requestContext,
+          } as never) as FragmentToolOutput;
+          modelOutput = `\n${
+            modelArtifact(output.placeholder, output.bindings.button!)
+          }\n`;
+          return {
+            text: modelOutput,
+            finishReason: 'stop',
+          };
+        },
+      },
+      model: 'test-model',
+    } as never);
+    const service = new LynxXmlAgentService();
+    const first = await service.generateRaw([]);
+    expect(first.metadata).toEqual({ xmlFragment, modelOutput });
+    expect(first.text).toContain('node0 = __CreateView(pageId);');
+    expect(first.text).not.toContain('__GENUI_HTML_FRAGMENT_');
+    const withoutConversion = await service.generateRaw([]);
+    expect(withoutConversion.metadata).toEqual({
+      modelOutput: 'no conversion',
+    });
+    expect(createLynxXmlAgent).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/genui/server/test/lynx-xml-stream.test.ts
+++ b/packages/genui/server/test/lynx-xml-stream.test.ts
@@ -22,6 +22,7 @@ interface MockLynxXmlService {
       text: string;
       usage: unknown;
       finishReason: string;
+      metadata?: Record<string, unknown>;
     }>;
   }>;
 }
@@ -31,50 +32,66 @@ type GlobalWithLynxXmlService = typeof globalThis & {
 };
 
 describe('Lynx XML stream route', () => {
-  test('streams deltas and normalizes the final artifact', async () => {
-    const global = globalThis as GlobalWithLynxXmlService;
-    const previous = global.__LYNX_XML_AGENT_SERVICE__;
-    global.__LYNX_XML_AGENT_SERVICE__ = {
-      streamAsAsyncIterable() {
-        return Promise.resolve({
-          textStream: Readable.from(['```xml\n', ARTIFACT]),
-          finalize: () =>
-            Promise.resolve({
-              text: `Generated artifact:\n${ARTIFACT}\n\`\`\``,
-              usage: { inputTokens: 3, outputTokens: 5 },
-              finishReason: 'stop',
-            }),
-        });
-      },
-    };
-
-    try {
-      const response = await app.request('/lynx-xml/stream', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'x-forwarded-for': '203.0.113.47',
+  test.each([undefined, {
+    xmlFragment: '<view>\n  <text>Hello &amp; 你好</text>\n</view>',
+    modelOutput: '<!doctype lynx>\n<!-- original model response -->',
+  }])(
+    'streams deltas and passes optional metadata alongside the normalized artifact: %j',
+    async (metadata) => {
+      const global = globalThis as GlobalWithLynxXmlService;
+      const previous = global.__LYNX_XML_AGENT_SERVICE__;
+      global.__LYNX_XML_AGENT_SERVICE__ = {
+        streamAsAsyncIterable() {
+          return Promise.resolve({
+            textStream: Readable.from(['```xml\n', ARTIFACT]),
+            finalize: () =>
+              Promise.resolve({
+                text: `Generated artifact:\n${ARTIFACT}\n\`\`\``,
+                usage: { inputTokens: 3, outputTokens: 5 },
+                finishReason: 'stop',
+                ...(metadata ? { metadata } : {}),
+              }),
+          });
         },
-        body: JSON.stringify({
-          messages: [{ role: 'user', content: 'Create a counter' }],
-        }),
-      });
-      expect(response.status).toBe(200);
-      expect(response.headers.get('content-type')).toContain(
-        'text/event-stream',
-      );
-      const body = await response.text();
-      expect(body).toContain('event: delta\ndata: {"text":"```xml\\n"}');
-      expect(body).toContain(`"text":${JSON.stringify(ARTIFACT)}`);
-      expect(body).toContain('event: done');
-      expect(body).toContain(
-        '"usage":{"inputTokens":3,"outputTokens":5}',
-      );
-      expect(body).not.toContain('Generated artifact:');
-    } finally {
-      global.__LYNX_XML_AGENT_SERVICE__ = previous;
-    }
-  });
+      };
+
+      try {
+        const response = await app.request('/lynx-xml/stream', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'x-forwarded-for': '203.0.113.47',
+          },
+          body: JSON.stringify({
+            messages: [{ role: 'user', content: 'Create a counter' }],
+          }),
+        });
+        expect(response.status).toBe(200);
+        expect(response.headers.get('content-type')).toContain(
+          'text/event-stream',
+        );
+        const body = await response.text();
+        expect(body).toContain('event: delta\ndata: {"text":"```xml\\n"}');
+        expect(body).toContain(`"text":${JSON.stringify(ARTIFACT)}`);
+        expect(body).toContain('event: done');
+        expect(body).toContain(
+          '"usage":{"inputTokens":3,"outputTokens":5}',
+        );
+        expect(body).not.toContain('Generated artifact:');
+        const doneFrame = body.split('\n\n').find((frame) =>
+          frame.startsWith('event: done\n')
+        );
+        expect(doneFrame).toBeDefined();
+        const done = JSON.parse(
+          doneFrame!.slice('event: done\ndata: '.length),
+        ) as Record<string, unknown>;
+        if (metadata) expect(done.metadata).toEqual(metadata);
+        else expect(done).not.toHaveProperty('metadata');
+      } finally {
+        global.__LYNX_XML_AGENT_SERVICE__ = previous;
+      }
+    },
+  );
 
   test('reports token-limit metadata when the final artifact is incomplete', async () => {
     const global = globalThis as GlobalWithLynxXmlService;

--- a/packages/genui/server/turbo.json
+++ b/packages/genui/server/turbo.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "outputs": ["dist/**"]
+    }
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1175,6 +1175,15 @@ importers:
       '@lynx-js/skill-vanilla-lynx':
         specifier: 0.2.0
         version: 0.2.0
+      acorn:
+        specifier: ^8.17.0
+        version: 8.17.0
+      acorn-walk:
+        specifier: ^8.3.5
+        version: 8.3.5
+      eslint-scope:
+        specifier: ^8.4.0
+        version: 8.4.0
       fast-xml-parser:
         specifier: ^5.11.1
         version: 5.11.1
@@ -1185,6 +1194,9 @@ importers:
       '@rstest/core':
         specifier: catalog:rstest
         version: 0.11.12(core-js@3.50.0)(jsdom@30.0.1)
+      '@types/eslint-scope':
+        specifier: ^3.7.7
+        version: 3.7.7
       '@types/node':
         specifier: ^24.13.3
         version: 24.13.3
@@ -1282,6 +1294,9 @@ importers:
       vaul:
         specifier: ^1.1.2
         version: 1.1.2(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      xml-formatter:
+        specifier: ^3.7.0
+        version: 3.7.0
     devDependencies:
       '@lynx-js/config-rsbuild-plugin':
         specifier: workspace:*
@@ -6585,6 +6600,9 @@ packages:
 
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/eslint-scope@3.7.7':
+    resolution: {integrity: sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==}
 
   '@types/eslint@8.56.12':
     resolution: {integrity: sha512-03ruubjWyOHlmljCVoxSuNDdmfZDzsrrz0P2LeJsOXr+ZwFQ+0yQIwNCwt/GYhV7Z31fgtXJTAEs+FYlEL851g==}
@@ -12680,6 +12698,10 @@ packages:
       utf-8-validate:
         optional: true
 
+  xml-formatter@3.7.0:
+    resolution: {integrity: sha512-+8qTc3zv2UcJ1v9IsSIce37Dl4MQG14Cp7tWrwmy202UaI1wqRukw5QMX1JHsV+DX64yw77EgGsj2s5wGvuMbQ==}
+    engines: {node: '>= 16'}
+
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
@@ -12687,6 +12709,10 @@ packages:
   xml-naming@0.3.0:
     resolution: {integrity: sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==}
     engines: {node: '>=16.0.0'}
+
+  xml-parser-xo@4.1.6:
+    resolution: {integrity: sha512-mXbSNSM+rIwndoxSwmFa83bOdeP8G/cOGr7XvxA67X7ebCzoAuVez9JYDCDub3zRDNBZxIbfjuXLSsamr7NfwQ==}
+    engines: {node: '>= 20'}
 
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
@@ -16548,6 +16574,11 @@ snapshots:
       '@types/ms': 2.1.0
 
   '@types/deep-eql@4.0.2': {}
+
+  '@types/eslint-scope@3.7.7':
+    dependencies:
+      '@types/eslint': 8.56.12
+      '@types/estree': 1.0.9
 
   '@types/eslint@8.56.12':
     dependencies:
@@ -23318,9 +23349,15 @@ snapshots:
 
   ws@8.21.2: {}
 
+  xml-formatter@3.7.0:
+    dependencies:
+      xml-parser-xo: 4.1.6
+
   xml-name-validator@5.0.0: {}
 
   xml-naming@0.3.0: {}
+
+  xml-parser-xo@4.1.6: {}
 
   xmlchars@2.2.0: {}
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added separate XML Fragment and Model Output artifact views in the Playground.
  * XML fragments support Raw and Formatted display modes, with copying based on the selected format.
  * Original XML fragments and model output are preserved across local and shared conversation history.
  * XML fragments and model output remain excluded from previews and future model requests.
  * Lynx XML generation now supports node references across rendering, event handling, updates, and cleanup.
  * Streaming and raw generation now expose original XML fragments and exact model output as metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
