### PR TITLE
fix(rspeedy): support Rsbuild 2.2.4 chain types

### DIFF
--- a/.changeset/tidy-rsbuild-chain.md
+++ b/.changeset/tidy-rsbuild-chain.md
@@ -1,0 +1,6 @@
+---
+'@lynx-js/rspeedy': patch
+'@lynx-js/react-rsbuild-plugin': patch
+---
+
+Upgrade Rsbuild to 2.2.4 and fix CSS rule cloning with its stricter bundler chain types.

--- a/packages/rspeedy/plugin-lynx/src/plugins/optimization.plugin.ts
+++ b/packages/rspeedy/plugin-lynx/src/plugins/optimization.plugin.ts
@@ -21,8 +21,8 @@ export function pluginOptimization(): RsbuildPlugin {
         chain
           .module
           .rule('js-override-strict')
-          .type(jsMainRule.get('type') as string)
-          .test(jsRule.get('test') as RegExp)
+          .type(jsMainRule.get('type'))
+          .test(jsRule.get('test'))
           // We do not directly apply this to `CHAIN_ID.RULE.JS` since it will not
           // includes the `node_modules` by default.
           .parser({

--- a/packages/rspeedy/plugin-react/src/css.ts
+++ b/packages/rspeedy/plugin-react/src/css.ts
@@ -76,7 +76,7 @@ export function applyCSS(
         //   - resolve-url-loader(for sass/less)
         //   - sass-loader/less-loader(for sass/less)
         const uses = mainRule.uses.entries() ?? {}
-        const ruleEntries = mainRule.entries() as Rspack.RuleSetRule
+        const ruleEntries = mainRule.entries() as Record<string, unknown>
 
         const cssLoader = uses[CHAIN_ID.USE.CSS]
         if (!cssLoader) {

--- a/packages/rspeedy/plugin-react/test/lazy.test.ts
+++ b/packages/rspeedy/plugin-react/test/lazy.test.ts
@@ -270,7 +270,7 @@ describe('Lazy', () => {
                   // add .ts suffix to ignore-css-loader
                   // this workaround is needed because vitest
                   // runs on our ts files.
-                  rule.get('loader') as string + '.ts',
+                  rule.get('loader')! + '.ts',
                 )
               })
             },
@@ -409,7 +409,7 @@ describe('Lazy', () => {
                   // add .ts suffix to ignore-css-loader
                   // this workaround is needed because vitest
                   // runs on our ts files.
-                  rule.get('loader') as string + '.ts',
+                  rule.get('loader')! + '.ts',
                 )
               })
             },
@@ -537,7 +537,7 @@ describe('Lazy', () => {
                   // add .ts suffix to ignore-css-loader
                   // this workaround is needed because vitest
                   // runs on our ts files.
-                  rule.get('loader') as string + '.ts',
+                  rule.get('loader')! + '.ts',
                 )
               })
             },

--- a/packages/rspeedy/plugin-react/test/sourcemap.test.ts
+++ b/packages/rspeedy/plugin-react/test/sourcemap.test.ts
@@ -82,7 +82,7 @@ async function buildSourcemapFixture(
                 // add .ts suffix to ignore-css-loader
                 // this workaround is needed because vitest
                 // runs on our ts files.
-                rule.get('loader') as string + '.ts',
+                rule.get('loader')! + '.ts',
               )
             })
           },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,8 +129,8 @@ catalogs:
       version: 11.0.0-rc.1-20260903085447-f95471a
   rsbuild:
     '@rsbuild/core':
-      specifier: 2.2.3
-      version: 2.2.3
+      specifier: 2.2.4
+      version: 2.2.4
   rslib:
     '@rslib/core':
       specifier: 1.0.0
@@ -184,7 +184,7 @@ importers:
         version: 7.58.12(@types/node@24.13.3)
       '@rsbuild/core':
         specifier: catalog:rsbuild
-        version: 2.2.3(core-js@3.50.0)
+        version: 2.2.4(core-js@3.50.0)
       '@rslib/core':
         specifier: catalog:rslib
         version: 1.0.0(@microsoft/api-extractor@7.58.12(@types/node@24.13.3))(core-js@3.50.0)(typescript@6.0.3)
@@ -366,7 +366,7 @@ importers:
         version: 4.1.0
       '@rsbuild/core':
         specifier: catalog:rsbuild
-        version: 2.2.3(core-js@3.50.0)
+        version: 2.2.4(core-js@3.50.0)
       '@types/react':
         specifier: ^19.2.18
         version: 19.2.18
@@ -397,7 +397,7 @@ importers:
         version: 4.1.0
       '@rsbuild/core':
         specifier: catalog:rsbuild
-        version: 2.2.3(core-js@3.50.0)
+        version: 2.2.4(core-js@3.50.0)
       '@types/react':
         specifier: ^19.2.18
         version: 19.2.18
@@ -425,7 +425,7 @@ importers:
         version: 4.1.0
       '@rsbuild/core':
         specifier: catalog:rsbuild
-        version: 2.2.3(core-js@3.50.0)
+        version: 2.2.4(core-js@3.50.0)
       '@types/react':
         specifier: ^19.2.18
         version: 19.2.18
@@ -453,10 +453,10 @@ importers:
         version: 4.1.0
       '@rsbuild/core':
         specifier: catalog:rsbuild
-        version: 2.2.3(core-js@3.50.0)
+        version: 2.2.4(core-js@3.50.0)
       '@rsbuild/plugin-babel':
         specifier: 2.0.1
-        version: 2.0.1(@rsbuild/core@2.2.3(core-js@3.50.0))(@rspack/core@2.2.2(@swc/helpers@0.5.23))(supports-color@10.2.2)(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(cssnano@7.1.2(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
+        version: 2.0.1(@rsbuild/core@2.2.4(core-js@3.50.0))(@rspack/core@2.2.2(@swc/helpers@0.5.23))(supports-color@10.2.2)(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(cssnano@7.1.2(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
       '@types/react':
         specifier: ^19.2.18
         version: 19.2.18
@@ -487,7 +487,7 @@ importers:
         version: 4.1.0
       '@rsbuild/core':
         specifier: catalog:rsbuild
-        version: 2.2.3(core-js@3.50.0)
+        version: 2.2.4(core-js@3.50.0)
       '@rstest/core':
         specifier: catalog:rstest
         version: 0.11.12(core-js@3.50.0)(jsdom@30.0.1)
@@ -524,7 +524,7 @@ importers:
         version: 4.1.0
       '@rsbuild/core':
         specifier: catalog:rsbuild
-        version: 2.2.3(core-js@3.50.0)
+        version: 2.2.4(core-js@3.50.0)
       '@types/react':
         specifier: ^19.2.18
         version: 19.2.18
@@ -552,7 +552,7 @@ importers:
         version: 4.1.0
       '@rsbuild/core':
         specifier: catalog:rsbuild
-        version: 2.2.3(core-js@3.50.0)
+        version: 2.2.4(core-js@3.50.0)
       '@types/react':
         specifier: ^19.2.18
         version: 19.2.18
@@ -577,7 +577,7 @@ importers:
         version: 4.1.0
       '@rsbuild/core':
         specifier: catalog:rsbuild
-        version: 2.2.3(core-js@3.50.0)
+        version: 2.2.4(core-js@3.50.0)
       '@types/react':
         specifier: ^19.2.18
         version: 19.2.18
@@ -605,7 +605,7 @@ importers:
         version: 4.1.0
       '@rsbuild/core':
         specifier: catalog:rsbuild
-        version: 2.2.3(core-js@3.50.0)
+        version: 2.2.4(core-js@3.50.0)
       '@types/react':
         specifier: ^19.2.18
         version: 19.2.18
@@ -630,7 +630,7 @@ importers:
         version: 4.1.0
       '@rsbuild/core':
         specifier: catalog:rsbuild
-        version: 2.2.3(core-js@3.50.0)
+        version: 2.2.4(core-js@3.50.0)
       '@types/react':
         specifier: ^19.2.18
         version: 19.2.18
@@ -655,7 +655,7 @@ importers:
         version: 4.1.0
       '@rsbuild/core':
         specifier: catalog:rsbuild
-        version: 2.2.3(core-js@3.50.0)
+        version: 2.2.4(core-js@3.50.0)
       '@types/react':
         specifier: ^19.2.18
         version: 19.2.18
@@ -689,7 +689,7 @@ importers:
         version: 4.1.0
       '@rsbuild/core':
         specifier: catalog:rsbuild
-        version: 2.2.3(core-js@3.50.0)
+        version: 2.2.4(core-js@3.50.0)
       '@types/react':
         specifier: ^19.2.18
         version: 19.2.18
@@ -732,7 +732,7 @@ importers:
         version: link:../../packages/web-platform/web-elements
       '@rsbuild/core':
         specifier: catalog:rsbuild
-        version: 2.2.3(core-js@3.50.0)
+        version: 2.2.4(core-js@3.50.0)
       '@types/react':
         specifier: ^19.2.18
         version: 19.2.18
@@ -763,7 +763,7 @@ importers:
         version: 4.1.0
       '@rsbuild/core':
         specifier: catalog:rsbuild
-        version: 2.2.3(core-js@3.50.0)
+        version: 2.2.4(core-js@3.50.0)
       '@types/react':
         specifier: ^19.2.18
         version: 19.2.18
@@ -791,7 +791,7 @@ importers:
         version: 4.1.0
       '@rsbuild/core':
         specifier: catalog:rsbuild
-        version: 2.2.3(core-js@3.50.0)
+        version: 2.2.4(core-js@3.50.0)
       '@types/react':
         specifier: ^19.2.18
         version: 19.2.18
@@ -822,7 +822,7 @@ importers:
         version: 4.1.0
       '@rsbuild/core':
         specifier: catalog:rsbuild
-        version: 2.2.3(core-js@3.50.0)
+        version: 2.2.4(core-js@3.50.0)
       '@types/react':
         specifier: ^19.2.18
         version: 19.2.18
@@ -853,7 +853,7 @@ importers:
         version: 4.1.0
       '@rsbuild/core':
         specifier: catalog:rsbuild
-        version: 2.2.3(core-js@3.50.0)
+        version: 2.2.4(core-js@3.50.0)
       '@types/react':
         specifier: ^19.2.18
         version: 19.2.18
@@ -875,7 +875,7 @@ importers:
         version: 4.1.0
       '@rsbuild/core':
         specifier: catalog:rsbuild
-        version: 2.2.3(core-js@3.50.0)
+        version: 2.2.4(core-js@3.50.0)
       '@types/react':
         specifier: ^19.2.18
         version: 19.2.18
@@ -900,7 +900,7 @@ importers:
         version: 4.1.0
       '@rsbuild/core':
         specifier: catalog:rsbuild
-        version: 2.2.3(core-js@3.50.0)
+        version: 2.2.4(core-js@3.50.0)
       '@types/react':
         specifier: ^19.2.18
         version: 19.2.18
@@ -928,7 +928,7 @@ importers:
         version: 4.1.0
       '@rsbuild/core':
         specifier: catalog:rsbuild
-        version: 2.2.3(core-js@3.50.0)
+        version: 2.2.4(core-js@3.50.0)
       '@types/react':
         specifier: ^19.2.18
         version: 19.2.18
@@ -1012,13 +1012,13 @@ importers:
         version: 4.1.0
       '@rsbuild/core':
         specifier: catalog:rsbuild
-        version: 2.2.3(core-js@3.50.0)
+        version: 2.2.4(core-js@3.50.0)
       '@types/react':
         specifier: ^19.2.18
         version: 19.2.18
       rsbuild-plugin-tailwindcss:
         specifier: 0.2.4
-        version: 0.2.4(@rsbuild/core@2.2.3(core-js@3.50.0))(tailwindcss@3.4.19)
+        version: 0.2.4(@rsbuild/core@2.2.4(core-js@3.50.0))(tailwindcss@3.4.19)
       tailwindcss:
         specifier: ^3.4.19
         version: 3.4.19
@@ -1039,7 +1039,7 @@ importers:
         version: link:../../packages/rspeedy/plugin-vanilla
       '@rsbuild/core':
         specifier: catalog:rsbuild
-        version: 2.2.3(core-js@3.50.0)
+        version: 2.2.4(core-js@3.50.0)
 
   packages/background-only: {}
 
@@ -1315,10 +1315,10 @@ importers:
         version: 4.1.0
       '@rsbuild/core':
         specifier: catalog:rsbuild
-        version: 2.2.3(core-js@3.50.0)
+        version: 2.2.4(core-js@3.50.0)
       '@rsbuild/plugin-react':
         specifier: 2.1.0
-        version: 2.1.0(@rsbuild/core@2.2.3(core-js@3.50.0))(@rspack/core@2.2.2(@swc/helpers@0.5.23))
+        version: 2.1.0(@rsbuild/core@2.2.4(core-js@3.50.0))(@rspack/core@2.2.2(@swc/helpers@0.5.23))
       '@rstest/core':
         specifier: catalog:rstest
         version: 0.11.12(core-js@3.50.0)(jsdom@30.0.1)
@@ -1420,7 +1420,7 @@ importers:
         version: 1.67.7(@swc/helpers@0.5.23)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(typescript@6.0.3)
       rsbuild-plugin-i18next-extractor:
         specifier: 0.2.1
-        version: 0.2.1(@rsbuild/core@2.2.3(core-js@3.50.0))(i18next-cli@1.67.7(@swc/helpers@0.5.23)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(typescript@6.0.3))(rollup@4.62.2)
+        version: 0.2.1(@rsbuild/core@2.2.4(core-js@3.50.0))(i18next-cli@1.67.7(@swc/helpers@0.5.23)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(typescript@6.0.3))(rollup@4.62.2)
 
   packages/lynx/autolink-codegen:
     devDependencies:
@@ -1469,7 +1469,7 @@ importers:
         version: 7.0.0(@testing-library/dom@10.4.1)
       rsbuild-plugin-publint:
         specifier: 1.0.0
-        version: 1.0.0(@rsbuild/core@2.2.3(core-js@3.50.0))
+        version: 1.0.0(@rsbuild/core@2.2.4(core-js@3.50.0))
 
   packages/mcp-servers/docs-mcp-server:
     dependencies:
@@ -1525,7 +1525,7 @@ importers:
         version: 4.1.0
       rsbuild-plugin-publint:
         specifier: 1.0.0
-        version: 1.0.0(@rsbuild/core@2.2.3(core-js@3.50.0))
+        version: 1.0.0(@rsbuild/core@2.2.4(core-js@3.50.0))
 
   packages/react:
     dependencies:
@@ -1638,10 +1638,10 @@ importers:
         version: link:../../testing-library/testing-environment
       '@rsbuild/core':
         specifier: catalog:rsbuild
-        version: 2.2.3(core-js@3.50.0)
+        version: 2.2.4(core-js@3.50.0)
       '@rstest/adapter-rsbuild':
         specifier: catalog:rstest
-        version: 0.11.12(@rsbuild/core@2.2.3(core-js@3.50.0))(@rstest/core@0.11.12(core-js@3.50.0)(jsdom@30.0.1))
+        version: 0.11.12(@rsbuild/core@2.2.4(core-js@3.50.0))(@rstest/core@0.11.12(core-js@3.50.0)(jsdom@30.0.1))
       '@rstest/core':
         specifier: catalog:rstest
         version: 0.11.12(core-js@3.50.0)(jsdom@30.0.1)
@@ -1737,10 +1737,10 @@ importers:
         version: link:../web-platform/web-rsbuild-plugin
       '@rsbuild/core':
         specifier: catalog:rsbuild
-        version: 2.2.3(core-js@3.50.0)
+        version: 2.2.4(core-js@3.50.0)
       '@rsbuild/plugin-react':
         specifier: 2.1.0
-        version: 2.1.0(@rsbuild/core@2.2.3(core-js@3.50.0))(@rspack/core@2.2.2(@swc/helpers@0.5.23))
+        version: 2.1.0(@rsbuild/core@2.2.4(core-js@3.50.0))(@rspack/core@2.2.2(@swc/helpers@0.5.23))
       '@tailwindcss/postcss':
         specifier: ^4.3.3
         version: 4.3.3
@@ -1782,10 +1782,10 @@ importers:
         version: link:../plugin-lynx
       '@rsbuild/core':
         specifier: catalog:rsbuild
-        version: 2.2.3(core-js@3.50.0)
+        version: 2.2.4(core-js@3.50.0)
       '@rsdoctor/rspack-plugin':
         specifier: ~1.6.1
-        version: 1.6.1(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@rsbuild/core@2.2.3(core-js@3.50.0))(@rspack/core@2.2.2(@swc/helpers@0.5.23))(supports-color@10.2.2)(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(cssnano@7.1.2(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
+        version: 1.6.1(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@rsbuild/core@2.2.4(core-js@3.50.0))(@rspack/core@2.2.2(@swc/helpers@0.5.23))(supports-color@10.2.2)(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(cssnano@7.1.2(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
       typescript:
         specifier: 5.1.6 - 6.0.x
         version: 6.0.3
@@ -1798,10 +1798,10 @@ importers:
         version: 7.58.12(@types/node@24.13.3)
       '@rsbuild/plugin-css-minimizer':
         specifier: 2.0.1
-        version: 2.0.1(@rsbuild/core@2.2.3(core-js@3.50.0))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(cssnano@7.1.2(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
+        version: 2.0.1(@rsbuild/core@2.2.4(core-js@3.50.0))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(cssnano@7.1.2(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
       '@rsdoctor/core':
         specifier: ~1.6.1
-        version: 1.6.1(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@rsbuild/core@2.2.3(core-js@3.50.0))(@rspack/core@2.2.2(@swc/helpers@0.5.23))(supports-color@10.2.2)(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(cssnano@7.1.2(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
+        version: 1.6.1(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@rsbuild/core@2.2.4(core-js@3.50.0))(@rspack/core@2.2.2(@swc/helpers@0.5.23))(supports-color@10.2.2)(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(cssnano@7.1.2(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
       '@rstest/core':
         specifier: catalog:rstest
         version: 0.11.12(core-js@3.50.0)(jsdom@30.0.1)
@@ -1831,10 +1831,10 @@ importers:
         version: 1.1.1
       rsbuild-plugin-arethetypeswrong:
         specifier: 0.3.1
-        version: 0.3.1(@rsbuild/core@2.2.3(core-js@3.50.0))(typescript@6.0.3)
+        version: 0.3.1(@rsbuild/core@2.2.4(core-js@3.50.0))(typescript@6.0.3)
       rsbuild-plugin-publint:
         specifier: 1.0.0
-        version: 1.0.0(@rsbuild/core@2.2.3(core-js@3.50.0))
+        version: 1.0.0(@rsbuild/core@2.2.4(core-js@3.50.0))
       ts-blank-space:
         specifier: ^0.9.0
         version: 0.9.0
@@ -1871,7 +1871,7 @@ importers:
         version: link:../core
       '@rsbuild/plugin-type-check':
         specifier: 1.6.0
-        version: 1.6.0(@rsbuild/core@2.2.3(core-js@3.50.0))(@rspack/core@2.2.2(@swc/helpers@0.5.23))(@typescript/native-preview@7.0.0-dev.20260707.2)(typescript@6.0.3)
+        version: 1.6.0(@rsbuild/core@2.2.4(core-js@3.50.0))(@rspack/core@2.2.2(@swc/helpers@0.5.23))(@typescript/native-preview@7.0.0-dev.20260707.2)(typescript@6.0.3)
       '@rstest/core':
         specifier: catalog:rstest
         version: 0.11.12(core-js@3.50.0)(jsdom@30.0.1)
@@ -1926,7 +1926,7 @@ importers:
         version: 7.58.12(@types/node@24.13.3)
       '@rsbuild/core':
         specifier: catalog:rsbuild
-        version: 2.2.3(core-js@3.50.0)
+        version: 2.2.4(core-js@3.50.0)
       '@rspack/core':
         specifier: 2.2.2
         version: 2.2.2(@swc/helpers@0.5.23)
@@ -1972,7 +1972,7 @@ importers:
         version: 12.3.0(patch_hash=926ba262ec682d27369f1a8648a0dfb657fb5f1b28539ca3628d292276c91c3d)(rollup@4.62.2)(tslib@2.8.1)(typescript@6.0.3)
       '@rsbuild/core':
         specifier: catalog:rsbuild
-        version: 2.2.3(core-js@3.50.0)
+        version: 2.2.4(core-js@3.50.0)
 
   packages/rspeedy/plugin-external-bundle:
     dependencies:
@@ -1991,7 +1991,7 @@ importers:
         version: 7.58.12(@types/node@24.13.3)
       '@rsbuild/core':
         specifier: catalog:rsbuild
-        version: 2.2.3(core-js@3.50.0)
+        version: 2.2.4(core-js@3.50.0)
 
   packages/rspeedy/plugin-lynx:
     dependencies:
@@ -2021,7 +2021,7 @@ importers:
         version: link:../websocket
       '@rsbuild/plugin-css-minimizer':
         specifier: 2.0.1
-        version: 2.0.1(@rsbuild/core@2.2.3(core-js@3.50.0))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(cssnano@7.1.2(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
+        version: 2.0.1(@rsbuild/core@2.2.4(core-js@3.50.0))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(cssnano@7.1.2(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
     devDependencies:
       '@lynx-js/test-tools':
         specifier: workspace:*
@@ -2031,7 +2031,7 @@ importers:
         version: 7.58.12(@types/node@24.13.3)
       '@rsbuild/core':
         specifier: catalog:rsbuild
-        version: 2.2.3(core-js@3.50.0)
+        version: 2.2.4(core-js@3.50.0)
       '@rstest/core':
         specifier: catalog:rstest
         version: 0.11.12(core-js@3.50.0)(jsdom@30.0.1)
@@ -2067,7 +2067,7 @@ importers:
         version: 7.58.12(@types/node@24.13.3)
       '@rsbuild/core':
         specifier: catalog:rsbuild
-        version: 2.2.3(core-js@3.50.0)
+        version: 2.2.4(core-js@3.50.0)
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
@@ -2134,22 +2134,22 @@ importers:
         version: 7.58.12(@types/node@24.13.3)
       '@rsbuild/core':
         specifier: catalog:rsbuild
-        version: 2.2.3(core-js@3.50.0)
+        version: 2.2.4(core-js@3.50.0)
       '@rsbuild/plugin-sass':
         specifier: 2.0.1
-        version: 2.0.1(@rsbuild/core@2.2.3(core-js@3.50.0))
+        version: 2.0.1(@rsbuild/core@2.2.4(core-js@3.50.0))
       '@rsbuild/plugin-typed-css-modules':
         specifier: 1.2.4
-        version: 1.2.4(@rsbuild/core@2.2.3(core-js@3.50.0))
+        version: 1.2.4(@rsbuild/core@2.2.4(core-js@3.50.0))
       '@rstest/core':
         specifier: catalog:rstest
         version: 0.11.12(core-js@3.50.0)(jsdom@30.0.1)
       rsbuild-plugin-arethetypeswrong:
         specifier: 0.3.1
-        version: 0.3.1(@rsbuild/core@2.2.3(core-js@3.50.0))(typescript@6.0.3)
+        version: 0.3.1(@rsbuild/core@2.2.4(core-js@3.50.0))(typescript@6.0.3)
       rsbuild-plugin-publint:
         specifier: 1.0.0
-        version: 1.0.0(@rsbuild/core@2.2.3(core-js@3.50.0))
+        version: 1.0.0(@rsbuild/core@2.2.4(core-js@3.50.0))
       source-map:
         specifier: ^0.8.0
         version: 0.8.0
@@ -2185,7 +2185,7 @@ importers:
         version: 7.58.12(@types/node@24.13.3)
       '@rsbuild/core':
         specifier: catalog:rsbuild
-        version: 2.2.3(core-js@3.50.0)
+        version: 2.2.4(core-js@3.50.0)
       '@rspack/core':
         specifier: 2.2.2
         version: 2.2.2(@swc/helpers@0.5.23)
@@ -2219,7 +2219,7 @@ importers:
         version: link:../../webpack/test-tools
       '@rsbuild/core':
         specifier: catalog:rsbuild
-        version: 2.2.3(core-js@3.50.0)
+        version: 2.2.4(core-js@3.50.0)
       '@rstest/core':
         specifier: catalog:rstest
         version: 0.11.12(core-js@3.50.0)(jsdom@30.0.1)
@@ -2249,10 +2249,10 @@ importers:
         version: link:../../web-platform/web-elements
       '@rsbuild/plugin-less':
         specifier: 2.0.1
-        version: 2.0.1(@rsbuild/core@2.2.3(core-js@3.50.0))(@rspack/core@2.2.2(@swc/helpers@0.5.23))(supports-color@10.2.2)(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(cssnano@7.1.2(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
+        version: 2.0.1(@rsbuild/core@2.2.4(core-js@3.50.0))(@rspack/core@2.2.2(@swc/helpers@0.5.23))(supports-color@10.2.2)(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(cssnano@7.1.2(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
       '@rsbuild/plugin-sass':
         specifier: 2.0.1
-        version: 2.0.1(@rsbuild/core@2.2.3(core-js@3.50.0))
+        version: 2.0.1(@rsbuild/core@2.2.4(core-js@3.50.0))
       commander:
         specifier: ^15.0.0
         version: 15.0.0
@@ -2267,7 +2267,7 @@ importers:
         version: 1.1.1
       rsbuild-plugin-tailwindcss:
         specifier: 0.2.4
-        version: 0.2.4(@rsbuild/core@2.2.3(core-js@3.50.0))(tailwindcss@4.3.3)
+        version: 0.2.4(@rsbuild/core@2.2.4(core-js@3.50.0))(tailwindcss@4.3.3)
       rslog:
         specifier: ^2.3.0
         version: 2.3.0
@@ -2364,7 +2364,7 @@ importers:
         version: 4.1.0
       '@rsbuild/plugin-babel':
         specifier: 2.0.1
-        version: 2.0.1(@rsbuild/core@2.2.3(core-js@3.50.0))(@rspack/core@2.2.2(@swc/helpers@0.5.23))(supports-color@10.2.2)(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(cssnano@7.1.2(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
+        version: 2.0.1(@rsbuild/core@2.2.4(core-js@3.50.0))(@rspack/core@2.2.2(@swc/helpers@0.5.23))(supports-color@10.2.2)(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(cssnano@7.1.2(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
       '@testing-library/jest-dom':
         specifier: ^7.0.0
         version: 7.0.0(@testing-library/dom@10.4.1)
@@ -2419,7 +2419,7 @@ importers:
         version: 0.4.4
       rsbuild-plugin-publint:
         specifier: 1.0.0
-        version: 1.0.0(@rsbuild/core@2.2.3(core-js@3.50.0))
+        version: 1.0.0(@rsbuild/core@2.2.4(core-js@3.50.0))
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -2437,7 +2437,7 @@ importers:
         version: 28.0.3
       rsbuild-plugin-publint:
         specifier: 1.0.0
-        version: 1.0.0(@rsbuild/core@2.2.3(core-js@3.50.0))
+        version: 1.0.0(@rsbuild/core@2.2.4(core-js@3.50.0))
 
   packages/tools/canary-release:
     dependencies:
@@ -2518,13 +2518,13 @@ importers:
         version: 0.1.4
       '@rsbuild/core':
         specifier: catalog:rsbuild
-        version: 2.2.3(core-js@3.50.0)
+        version: 2.2.4(core-js@3.50.0)
       '@rsbuild/plugin-eslint':
         specifier: 1.3.0
-        version: 1.3.0(@rsbuild/core@2.2.3(core-js@3.50.0))(eslint@9.39.5(jiti@2.7.0)(supports-color@10.2.2))
+        version: 1.3.0(@rsbuild/core@2.2.4(core-js@3.50.0))(eslint@9.39.5(jiti@2.7.0)(supports-color@10.2.2))
       '@rsbuild/plugin-source-build':
         specifier: 1.0.6
-        version: 1.0.6(@rsbuild/core@2.2.3(core-js@3.50.0))
+        version: 1.0.6(@rsbuild/core@2.2.4(core-js@3.50.0))
       '@rslib/core':
         specifier: catalog:rslib
         version: 1.0.0(@microsoft/api-extractor@7.58.12(@types/node@24.13.3))(core-js@3.50.0)(typescript@6.0.3)
@@ -2581,7 +2581,7 @@ importers:
         version: 1.61.1
       '@rsbuild/core':
         specifier: catalog:rsbuild
-        version: 2.2.3(core-js@3.50.0)
+        version: 2.2.4(core-js@3.50.0)
       '@rslib/core':
         specifier: catalog:rslib
         version: 1.0.0(@microsoft/api-extractor@7.58.12(@types/node@24.13.3))(core-js@3.50.0)(typescript@6.0.3)
@@ -2615,10 +2615,10 @@ importers:
         version: 1.61.1
       '@rsbuild/core':
         specifier: catalog:rsbuild
-        version: 2.2.3(core-js@3.50.0)
+        version: 2.2.4(core-js@3.50.0)
       '@rsbuild/plugin-source-build':
         specifier: 1.0.6
-        version: 1.0.6(@rsbuild/core@2.2.3(core-js@3.50.0))
+        version: 1.0.6(@rsbuild/core@2.2.4(core-js@3.50.0))
       '@types/markdown-it':
         specifier: ^14.1.2
         version: 14.1.2
@@ -2651,10 +2651,10 @@ importers:
         version: link:../web-rsbuild-plugin
       '@rsbuild/core':
         specifier: catalog:rsbuild
-        version: 2.2.3(core-js@3.50.0)
+        version: 2.2.4(core-js@3.50.0)
       '@rsdoctor/rspack-plugin':
         specifier: ~1.6.1
-        version: 1.6.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@rsbuild/core@2.2.3(core-js@3.50.0))(@rspack/core@2.2.2(@swc/helpers@0.5.23))(supports-color@10.2.2)(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(cssnano@7.1.2(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
+        version: 1.6.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@rsbuild/core@2.2.4(core-js@3.50.0))(@rspack/core@2.2.2(@swc/helpers@0.5.23))(supports-color@10.2.2)(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(cssnano@7.1.2(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
       tslib:
         specifier: ^2.8.1
         version: 2.8.1
@@ -2673,7 +2673,7 @@ importers:
         version: link:../web-elements
       '@rsbuild/core':
         specifier: catalog:rsbuild
-        version: 2.2.3(core-js@3.50.0)
+        version: 2.2.4(core-js@3.50.0)
       '@rspack/core':
         specifier: 2.2.2
         version: 2.2.2(@swc/helpers@0.5.23)
@@ -2697,16 +2697,16 @@ importers:
         version: link:../web-elements
       '@rsbuild/core':
         specifier: catalog:rsbuild
-        version: 2.2.3(core-js@3.50.0)
+        version: 2.2.4(core-js@3.50.0)
       '@rstest/core':
         specifier: catalog:rstest
         version: 0.11.12(core-js@3.50.0)(jsdom@30.0.1)
       rsbuild-plugin-arethetypeswrong:
         specifier: 0.3.1
-        version: 0.3.1(@rsbuild/core@2.2.3(core-js@3.50.0))(typescript@6.0.3)
+        version: 0.3.1(@rsbuild/core@2.2.4(core-js@3.50.0))(typescript@6.0.3)
       rsbuild-plugin-publint:
         specifier: 1.0.0
-        version: 1.0.0(@rsbuild/core@2.2.3(core-js@3.50.0))
+        version: 1.0.0(@rsbuild/core@2.2.4(core-js@3.50.0))
 
   packages/web-platform/web-worker-rpc:
     devDependencies:
@@ -5823,6 +5823,16 @@ packages:
 
   '@rsbuild/core@2.2.3':
     resolution: {integrity: sha512-oJrYtYDhb7AMwY8HIda2hgMuuxHkYPYar4svdS5uTq0fXY0M1wLfllkTQz0d729pNJ4S//6GUM1WX5LsW2mFLw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      core-js: '>= 3.0.0'
+    peerDependenciesMeta:
+      core-js:
+        optional: true
+
+  '@rsbuild/core@2.2.4':
+    resolution: {integrity: sha512-36Znklavtu2iSp7tGsn4VLRmMik60N50SFrimSORypBaGHHreDq/IpdSFJiu9xXdy4SmzK9LkTlmvSJ9L4gvfQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -15601,7 +15611,16 @@ snapshots:
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
 
-  '@rsbuild/plugin-babel@2.0.1(@rsbuild/core@2.2.3(core-js@3.50.0))(@rspack/core@2.2.2(@swc/helpers@0.5.23))(supports-color@10.2.2)(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(cssnano@7.1.2(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))':
+  '@rsbuild/core@2.2.4(core-js@3.50.0)':
+    dependencies:
+      '@rspack/core': 2.2.2(@swc/helpers@0.5.23)
+      '@swc/helpers': 0.5.23
+    optionalDependencies:
+      core-js: 3.50.0
+    transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
+
+  '@rsbuild/plugin-babel@2.0.1(@rsbuild/core@2.2.4(core-js@3.50.0))(@rspack/core@2.2.2(@swc/helpers@0.5.23))(supports-color@10.2.2)(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(cssnano@7.1.2(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))':
     dependencies:
       '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/plugin-proposal-decorators': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
@@ -15611,13 +15630,13 @@ snapshots:
       babel-loader: 10.1.1(@babel/core@7.29.7(supports-color@10.2.2))(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(cssnano@7.1.2(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
       reduce-configs: 1.1.2
     optionalDependencies:
-      '@rsbuild/core': 2.2.3(core-js@3.50.0)
+      '@rsbuild/core': 2.2.4(core-js@3.50.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - supports-color
       - webpack
 
-  '@rsbuild/plugin-check-syntax@1.6.1(@rsbuild/core@2.2.3(core-js@3.50.0))':
+  '@rsbuild/plugin-check-syntax@1.6.1(@rsbuild/core@2.2.4(core-js@3.50.0))':
     dependencies:
       acorn: 8.17.0
       browserslist-to-es-version: 1.4.1
@@ -15625,14 +15644,14 @@ snapshots:
       picocolors: 1.1.1
       source-map: 0.7.6
     optionalDependencies:
-      '@rsbuild/core': 2.2.3(core-js@3.50.0)
+      '@rsbuild/core': 2.2.4(core-js@3.50.0)
 
-  '@rsbuild/plugin-css-minimizer@2.0.1(@rsbuild/core@2.2.3(core-js@3.50.0))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(cssnano@7.1.2(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))':
+  '@rsbuild/plugin-css-minimizer@2.0.1(@rsbuild/core@2.2.4(core-js@3.50.0))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(cssnano@7.1.2(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))':
     dependencies:
       css-minimizer-webpack-plugin: 8.0.0(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(cssnano@7.1.2(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
       reduce-configs: 1.1.2
     optionalDependencies:
-      '@rsbuild/core': 2.2.3(core-js@3.50.0)
+      '@rsbuild/core': 2.2.4(core-js@3.50.0)
     transitivePeerDependencies:
       - '@parcel/css'
       - '@swc/css'
@@ -15642,21 +15661,21 @@ snapshots:
       - lightningcss
       - webpack
 
-  '@rsbuild/plugin-eslint@1.3.0(@rsbuild/core@2.2.3(core-js@3.50.0))(eslint@9.39.5(jiti@2.7.0)(supports-color@10.2.2))':
+  '@rsbuild/plugin-eslint@1.3.0(@rsbuild/core@2.2.4(core-js@3.50.0))(eslint@9.39.5(jiti@2.7.0)(supports-color@10.2.2))':
     dependencies:
       eslint: 9.39.5(jiti@2.7.0)(supports-color@10.2.2)
       eslint-rspack-plugin: 4.4.1(eslint@9.39.5(jiti@2.7.0)(supports-color@10.2.2))
     optionalDependencies:
-      '@rsbuild/core': 2.2.3(core-js@3.50.0)
+      '@rsbuild/core': 2.2.4(core-js@3.50.0)
 
-  '@rsbuild/plugin-less@2.0.1(@rsbuild/core@2.2.3(core-js@3.50.0))(@rspack/core@2.2.2(@swc/helpers@0.5.23))(supports-color@10.2.2)(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(cssnano@7.1.2(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))':
+  '@rsbuild/plugin-less@2.0.1(@rsbuild/core@2.2.4(core-js@3.50.0))(@rspack/core@2.2.2(@swc/helpers@0.5.23))(supports-color@10.2.2)(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(cssnano@7.1.2(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))':
     dependencies:
       deepmerge: 4.3.1
       less: 4.8.0(supports-color@10.2.2)
       less-loader: 12.3.3(@rspack/core@2.2.2(@swc/helpers@0.5.23))(less@4.8.0(supports-color@10.2.2))(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(cssnano@7.1.2(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
       reduce-configs: 2.0.1
     optionalDependencies:
-      '@rsbuild/core': 2.2.3(core-js@3.50.0)
+      '@rsbuild/core': 2.2.4(core-js@3.50.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - supports-color
@@ -15671,6 +15690,15 @@ snapshots:
     transitivePeerDependencies:
       - '@rspack/core'
 
+  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.2.4(core-js@3.50.0))(@rspack/core@2.2.2(@swc/helpers@0.5.23))':
+    dependencies:
+      '@rspack/plugin-react-refresh': 2.0.2(@rspack/core@2.2.2(@swc/helpers@0.5.23))(react-refresh@0.18.0)
+      react-refresh: 0.18.0
+    optionalDependencies:
+      '@rsbuild/core': 2.2.4(core-js@3.50.0)
+    transitivePeerDependencies:
+      - '@rspack/core'
+
   '@rsbuild/plugin-sass@2.0.1(@rsbuild/core@2.2.3(core-js@3.50.0))':
     dependencies:
       deepmerge: 4.3.1
@@ -15681,13 +15709,23 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 2.2.3(core-js@3.50.0)
 
-  '@rsbuild/plugin-source-build@1.0.6(@rsbuild/core@2.2.3(core-js@3.50.0))':
+  '@rsbuild/plugin-sass@2.0.1(@rsbuild/core@2.2.4(core-js@3.50.0))':
+    dependencies:
+      deepmerge: 4.3.1
+      loader-utils: 2.0.4
+      postcss: 8.5.25
+      reduce-configs: 2.0.1
+      sass-embedded: 1.100.0
+    optionalDependencies:
+      '@rsbuild/core': 2.2.4(core-js@3.50.0)
+
+  '@rsbuild/plugin-source-build@1.0.6(@rsbuild/core@2.2.4(core-js@3.50.0))':
     dependencies:
       fast-glob: 3.3.3
       json5: 2.2.3
       yaml: 2.9.0
     optionalDependencies:
-      '@rsbuild/core': 2.2.3(core-js@3.50.0)
+      '@rsbuild/core': 2.2.4(core-js@3.50.0)
 
   '@rsbuild/plugin-type-check@1.6.0(@rsbuild/core@2.2.3(core-js@3.50.0))(@rspack/core@2.2.2(@swc/helpers@0.5.23))(@typescript/native-preview@7.0.0-dev.20260707.2)(typescript@6.0.3)':
     dependencies:
@@ -15702,15 +15740,32 @@ snapshots:
       - '@rspack/core'
       - typescript
 
+  '@rsbuild/plugin-type-check@1.6.0(@rsbuild/core@2.2.4(core-js@3.50.0))(@rspack/core@2.2.2(@swc/helpers@0.5.23))(@typescript/native-preview@7.0.0-dev.20260707.2)(typescript@6.0.3)':
+    dependencies:
+      deepmerge: 4.3.1
+      json5: 2.2.3
+      reduce-configs: 1.1.2
+      ts-checker-rspack-plugin: 1.6.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(@typescript/native-preview@7.0.0-dev.20260707.2)(typescript@6.0.3)
+    optionalDependencies:
+      '@rsbuild/core': 2.2.4(core-js@3.50.0)
+      '@typescript/native-preview': 7.0.0-dev.20260707.2
+    transitivePeerDependencies:
+      - '@rspack/core'
+      - typescript
+
   '@rsbuild/plugin-typed-css-modules@1.2.4(@rsbuild/core@2.2.3(core-js@3.50.0))':
     optionalDependencies:
       '@rsbuild/core': 2.2.3(core-js@3.50.0)
 
+  '@rsbuild/plugin-typed-css-modules@1.2.4(@rsbuild/core@2.2.4(core-js@3.50.0))':
+    optionalDependencies:
+      '@rsbuild/core': 2.2.4(core-js@3.50.0)
+
   '@rsdoctor/client@1.6.1': {}
 
-  '@rsdoctor/core@1.6.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@rsbuild/core@2.2.3(core-js@3.50.0))(@rspack/core@2.2.2(@swc/helpers@0.5.23))(supports-color@10.2.2)(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(cssnano@7.1.2(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))':
+  '@rsdoctor/core@1.6.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@rsbuild/core@2.2.4(core-js@3.50.0))(@rspack/core@2.2.2(@swc/helpers@0.5.23))(supports-color@10.2.2)(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(cssnano@7.1.2(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))':
     dependencies:
-      '@rsbuild/plugin-check-syntax': 1.6.1(@rsbuild/core@2.2.3(core-js@3.50.0))
+      '@rsbuild/plugin-check-syntax': 1.6.1(@rsbuild/core@2.2.4(core-js@3.50.0))
       '@rsdoctor/graph': 1.6.1(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(cssnano@7.1.2(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
       '@rsdoctor/sdk': 1.6.1(@rspack/core@2.2.2(@swc/helpers@0.5.23))(supports-color@10.2.2)(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(cssnano@7.1.2(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
       '@rsdoctor/types': 1.6.1(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(cssnano@7.1.2(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
@@ -15732,9 +15787,9 @@ snapshots:
       - utf-8-validate
       - webpack
 
-  '@rsdoctor/core@1.6.1(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@rsbuild/core@2.2.3(core-js@3.50.0))(@rspack/core@2.2.2(@swc/helpers@0.5.23))(supports-color@10.2.2)(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(cssnano@7.1.2(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))':
+  '@rsdoctor/core@1.6.1(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@rsbuild/core@2.2.4(core-js@3.50.0))(@rspack/core@2.2.2(@swc/helpers@0.5.23))(supports-color@10.2.2)(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(cssnano@7.1.2(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))':
     dependencies:
-      '@rsbuild/plugin-check-syntax': 1.6.1(@rsbuild/core@2.2.3(core-js@3.50.0))
+      '@rsbuild/plugin-check-syntax': 1.6.1(@rsbuild/core@2.2.4(core-js@3.50.0))
       '@rsdoctor/graph': 1.6.1(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(cssnano@7.1.2(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
       '@rsdoctor/sdk': 1.6.1(@rspack/core@2.2.2(@swc/helpers@0.5.23))(supports-color@10.2.2)(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(cssnano@7.1.2(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
       '@rsdoctor/types': 1.6.1(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(cssnano@7.1.2(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
@@ -15767,9 +15822,9 @@ snapshots:
       - '@rspack/core'
       - webpack
 
-  '@rsdoctor/rspack-plugin@1.6.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@rsbuild/core@2.2.3(core-js@3.50.0))(@rspack/core@2.2.2(@swc/helpers@0.5.23))(supports-color@10.2.2)(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(cssnano@7.1.2(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))':
+  '@rsdoctor/rspack-plugin@1.6.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@rsbuild/core@2.2.4(core-js@3.50.0))(@rspack/core@2.2.2(@swc/helpers@0.5.23))(supports-color@10.2.2)(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(cssnano@7.1.2(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))':
     dependencies:
-      '@rsdoctor/core': 1.6.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@rsbuild/core@2.2.3(core-js@3.50.0))(@rspack/core@2.2.2(@swc/helpers@0.5.23))(supports-color@10.2.2)(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(cssnano@7.1.2(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
+      '@rsdoctor/core': 1.6.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@rsbuild/core@2.2.4(core-js@3.50.0))(@rspack/core@2.2.2(@swc/helpers@0.5.23))(supports-color@10.2.2)(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(cssnano@7.1.2(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
       '@rsdoctor/graph': 1.6.1(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(cssnano@7.1.2(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
       '@rsdoctor/sdk': 1.6.1(@rspack/core@2.2.2(@swc/helpers@0.5.23))(supports-color@10.2.2)(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(cssnano@7.1.2(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
       '@rsdoctor/types': 1.6.1(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(cssnano@7.1.2(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
@@ -15785,9 +15840,9 @@ snapshots:
       - utf-8-validate
       - webpack
 
-  '@rsdoctor/rspack-plugin@1.6.1(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@rsbuild/core@2.2.3(core-js@3.50.0))(@rspack/core@2.2.2(@swc/helpers@0.5.23))(supports-color@10.2.2)(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(cssnano@7.1.2(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))':
+  '@rsdoctor/rspack-plugin@1.6.1(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@rsbuild/core@2.2.4(core-js@3.50.0))(@rspack/core@2.2.2(@swc/helpers@0.5.23))(supports-color@10.2.2)(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(cssnano@7.1.2(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))':
     dependencies:
-      '@rsdoctor/core': 1.6.1(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@rsbuild/core@2.2.3(core-js@3.50.0))(@rspack/core@2.2.2(@swc/helpers@0.5.23))(supports-color@10.2.2)(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(cssnano@7.1.2(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
+      '@rsdoctor/core': 1.6.1(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@rsbuild/core@2.2.4(core-js@3.50.0))(@rspack/core@2.2.2(@swc/helpers@0.5.23))(supports-color@10.2.2)(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(cssnano@7.1.2(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
       '@rsdoctor/graph': 1.6.1(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(cssnano@7.1.2(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
       '@rsdoctor/sdk': 1.6.1(@rspack/core@2.2.2(@swc/helpers@0.5.23))(supports-color@10.2.2)(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(cssnano@7.1.2(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
       '@rsdoctor/types': 1.6.1(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(cssnano@7.1.2(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
@@ -15853,8 +15908,8 @@ snapshots:
 
   '@rslib/core@1.0.0(@microsoft/api-extractor@7.58.12(@types/node@24.13.3))(core-js@3.50.0)(typescript@6.0.3)':
     dependencies:
-      '@rsbuild/core': 2.2.3(core-js@3.50.0)
-      rsbuild-plugin-dts: 1.0.0(@microsoft/api-extractor@7.58.12(@types/node@24.13.3))(@rsbuild/core@2.2.3(core-js@3.50.0))(typescript@6.0.3)
+      '@rsbuild/core': 2.2.4(core-js@3.50.0)
+      rsbuild-plugin-dts: 1.0.0(@microsoft/api-extractor@7.58.12(@types/node@24.13.3))(@rsbuild/core@2.2.4(core-js@3.50.0))(typescript@6.0.3)
     optionalDependencies:
       '@microsoft/api-extractor': 7.58.12(@types/node@24.13.3)
       typescript: 6.0.3
@@ -16119,14 +16174,14 @@ snapshots:
 
   '@rstackjs/create-toolkit@2.1.4': {}
 
-  '@rstest/adapter-rsbuild@0.11.12(@rsbuild/core@2.2.3(core-js@3.50.0))(@rstest/core@0.11.12(core-js@3.50.0)(jsdom@30.0.1))':
+  '@rstest/adapter-rsbuild@0.11.12(@rsbuild/core@2.2.4(core-js@3.50.0))(@rstest/core@0.11.12(core-js@3.50.0)(jsdom@30.0.1))':
     dependencies:
-      '@rsbuild/core': 2.2.3(core-js@3.50.0)
+      '@rsbuild/core': 2.2.4(core-js@3.50.0)
       '@rstest/core': 0.11.12(core-js@3.50.0)(jsdom@30.0.1)
 
   '@rstest/core@0.11.12(core-js@3.50.0)(jsdom@27.4.0(supports-color@10.2.2))':
     dependencies:
-      '@rsbuild/core': 2.2.3(core-js@3.50.0)
+      '@rsbuild/core': 2.2.4(core-js@3.50.0)
       '@types/chai': 5.2.3
     optionalDependencies:
       jsdom: 27.4.0(supports-color@10.2.2)
@@ -16136,7 +16191,7 @@ snapshots:
 
   '@rstest/core@0.11.12(core-js@3.50.0)(jsdom@30.0.1)':
     dependencies:
-      '@rsbuild/core': 2.2.3(core-js@3.50.0)
+      '@rsbuild/core': 2.2.4(core-js@3.50.0)
       '@types/chai': 5.2.3
     optionalDependencies:
       jsdom: 30.0.1
@@ -21890,46 +21945,46 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  rsbuild-plugin-arethetypeswrong@0.3.1(@rsbuild/core@2.2.3(core-js@3.50.0))(typescript@6.0.3):
+  rsbuild-plugin-arethetypeswrong@0.3.1(@rsbuild/core@2.2.4(core-js@3.50.0))(typescript@6.0.3):
     dependencies:
       typescript: 6.0.3
     optionalDependencies:
-      '@rsbuild/core': 2.2.3(core-js@3.50.0)
+      '@rsbuild/core': 2.2.4(core-js@3.50.0)
 
-  rsbuild-plugin-dts@1.0.0(@microsoft/api-extractor@7.58.12(@types/node@24.13.3))(@rsbuild/core@2.2.3(core-js@3.50.0))(typescript@6.0.3):
+  rsbuild-plugin-dts@1.0.0(@microsoft/api-extractor@7.58.12(@types/node@24.13.3))(@rsbuild/core@2.2.4(core-js@3.50.0))(typescript@6.0.3):
     dependencies:
       '@ast-grep/napi': 0.45.2
-      '@rsbuild/core': 2.2.3(core-js@3.50.0)
+      '@rsbuild/core': 2.2.4(core-js@3.50.0)
     optionalDependencies:
       '@microsoft/api-extractor': 7.58.12(@types/node@24.13.3)
       typescript: 6.0.3
 
-  rsbuild-plugin-i18next-extractor@0.2.1(@rsbuild/core@2.2.3(core-js@3.50.0))(i18next-cli@1.67.7(@swc/helpers@0.5.23)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(typescript@6.0.3))(rollup@4.62.2):
+  rsbuild-plugin-i18next-extractor@0.2.1(@rsbuild/core@2.2.4(core-js@3.50.0))(i18next-cli@1.67.7(@swc/helpers@0.5.23)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(typescript@6.0.3))(rollup@4.62.2):
     dependencies:
       '@rollup/pluginutils': 5.3.0(rollup@4.62.2)
-      '@rsbuild/core': 2.2.3(core-js@3.50.0)
+      '@rsbuild/core': 2.2.4(core-js@3.50.0)
       '@rspack/lite-tapable': 1.1.5
       i18next-cli: 1.67.7(@swc/helpers@0.5.23)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(typescript@6.0.3)
     transitivePeerDependencies:
       - rollup
 
-  rsbuild-plugin-publint@1.0.0(@rsbuild/core@2.2.3(core-js@3.50.0)):
+  rsbuild-plugin-publint@1.0.0(@rsbuild/core@2.2.4(core-js@3.50.0)):
     dependencies:
       publint: 0.3.21
     optionalDependencies:
-      '@rsbuild/core': 2.2.3(core-js@3.50.0)
+      '@rsbuild/core': 2.2.4(core-js@3.50.0)
 
-  rsbuild-plugin-tailwindcss@0.2.4(@rsbuild/core@2.2.3(core-js@3.50.0))(tailwindcss@3.4.19):
+  rsbuild-plugin-tailwindcss@0.2.4(@rsbuild/core@2.2.4(core-js@3.50.0))(tailwindcss@3.4.19):
     dependencies:
       tailwindcss: 3.4.19
     optionalDependencies:
-      '@rsbuild/core': 2.2.3(core-js@3.50.0)
+      '@rsbuild/core': 2.2.4(core-js@3.50.0)
 
-  rsbuild-plugin-tailwindcss@0.2.4(@rsbuild/core@2.2.3(core-js@3.50.0))(tailwindcss@4.3.3):
+  rsbuild-plugin-tailwindcss@0.2.4(@rsbuild/core@2.2.4(core-js@3.50.0))(tailwindcss@4.3.3):
     dependencies:
       tailwindcss: 4.3.3
     optionalDependencies:
-      '@rsbuild/core': 2.2.3(core-js@3.50.0)
+      '@rsbuild/core': 2.2.4(core-js@3.50.0)
 
   rslog@2.3.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3106,13 +3106,13 @@ importers:
         version: 7.33.10(@types/node@24.13.3)
       '@rsbuild/plugin-sass':
         specifier: 2.0.1
-        version: 2.0.1(@rsbuild/core@2.2.3(core-js@3.50.0))
+        version: 2.0.1(@rsbuild/core@2.2.4(core-js@3.50.0))
       '@rsbuild/plugin-type-check':
         specifier: 1.6.0
-        version: 1.6.0(@rsbuild/core@2.2.3(core-js@3.50.0))(@rspack/core@2.2.2(@swc/helpers@0.5.23))(@typescript/native-preview@7.0.0-dev.20260707.2)(typescript@6.0.3)
+        version: 1.6.0(@rsbuild/core@2.2.4(core-js@3.50.0))(@rspack/core@2.2.2(@swc/helpers@0.5.23))(@typescript/native-preview@7.0.0-dev.20260707.2)(typescript@6.0.3)
       '@rsbuild/plugin-typed-css-modules':
         specifier: 1.2.4
-        version: 1.2.4(@rsbuild/core@2.2.3(core-js@3.50.0))
+        version: 1.2.4(@rsbuild/core@2.2.4(core-js@3.50.0))
       '@rspress/core':
         specifier: 2.0.21
         version: 2.0.21(@rspack/core@2.2.2(@swc/helpers@0.5.23))(core-js@3.50.0)(micromark-util-types@2.0.2)(micromark@4.0.2(supports-color@10.2.2))(supports-color@10.2.2)
@@ -5820,16 +5820,6 @@ packages:
     resolution: {integrity: sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==}
     cpu: [x64]
     os: [win32]
-
-  '@rsbuild/core@2.2.3':
-    resolution: {integrity: sha512-oJrYtYDhb7AMwY8HIda2hgMuuxHkYPYar4svdS5uTq0fXY0M1wLfllkTQz0d729pNJ4S//6GUM1WX5LsW2mFLw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-    peerDependencies:
-      core-js: '>= 3.0.0'
-    peerDependenciesMeta:
-      core-js:
-        optional: true
 
   '@rsbuild/core@2.2.4':
     resolution: {integrity: sha512-36Znklavtu2iSp7tGsn4VLRmMik60N50SFrimSORypBaGHHreDq/IpdSFJiu9xXdy4SmzK9LkTlmvSJ9L4gvfQ==}
@@ -15602,15 +15592,6 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.62.2':
     optional: true
 
-  '@rsbuild/core@2.2.3(core-js@3.50.0)':
-    dependencies:
-      '@rspack/core': 2.2.2(@swc/helpers@0.5.23)
-      '@swc/helpers': 0.5.23
-    optionalDependencies:
-      core-js: 3.50.0
-    transitivePeerDependencies:
-      - '@module-federation/runtime-tools'
-
   '@rsbuild/core@2.2.4(core-js@3.50.0)':
     dependencies:
       '@rspack/core': 2.2.2(@swc/helpers@0.5.23)
@@ -15681,15 +15662,6 @@ snapshots:
       - supports-color
       - webpack
 
-  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.2.3(core-js@3.50.0))(@rspack/core@2.2.2(@swc/helpers@0.5.23))':
-    dependencies:
-      '@rspack/plugin-react-refresh': 2.0.2(@rspack/core@2.2.2(@swc/helpers@0.5.23))(react-refresh@0.18.0)
-      react-refresh: 0.18.0
-    optionalDependencies:
-      '@rsbuild/core': 2.2.3(core-js@3.50.0)
-    transitivePeerDependencies:
-      - '@rspack/core'
-
   '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.2.4(core-js@3.50.0))(@rspack/core@2.2.2(@swc/helpers@0.5.23))':
     dependencies:
       '@rspack/plugin-react-refresh': 2.0.2(@rspack/core@2.2.2(@swc/helpers@0.5.23))(react-refresh@0.18.0)
@@ -15698,16 +15670,6 @@ snapshots:
       '@rsbuild/core': 2.2.4(core-js@3.50.0)
     transitivePeerDependencies:
       - '@rspack/core'
-
-  '@rsbuild/plugin-sass@2.0.1(@rsbuild/core@2.2.3(core-js@3.50.0))':
-    dependencies:
-      deepmerge: 4.3.1
-      loader-utils: 2.0.4
-      postcss: 8.5.25
-      reduce-configs: 2.0.1
-      sass-embedded: 1.100.0
-    optionalDependencies:
-      '@rsbuild/core': 2.2.3(core-js@3.50.0)
 
   '@rsbuild/plugin-sass@2.0.1(@rsbuild/core@2.2.4(core-js@3.50.0))':
     dependencies:
@@ -15727,19 +15689,6 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 2.2.4(core-js@3.50.0)
 
-  '@rsbuild/plugin-type-check@1.6.0(@rsbuild/core@2.2.3(core-js@3.50.0))(@rspack/core@2.2.2(@swc/helpers@0.5.23))(@typescript/native-preview@7.0.0-dev.20260707.2)(typescript@6.0.3)':
-    dependencies:
-      deepmerge: 4.3.1
-      json5: 2.2.3
-      reduce-configs: 1.1.2
-      ts-checker-rspack-plugin: 1.6.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(@typescript/native-preview@7.0.0-dev.20260707.2)(typescript@6.0.3)
-    optionalDependencies:
-      '@rsbuild/core': 2.2.3(core-js@3.50.0)
-      '@typescript/native-preview': 7.0.0-dev.20260707.2
-    transitivePeerDependencies:
-      - '@rspack/core'
-      - typescript
-
   '@rsbuild/plugin-type-check@1.6.0(@rsbuild/core@2.2.4(core-js@3.50.0))(@rspack/core@2.2.2(@swc/helpers@0.5.23))(@typescript/native-preview@7.0.0-dev.20260707.2)(typescript@6.0.3)':
     dependencies:
       deepmerge: 4.3.1
@@ -15752,10 +15701,6 @@ snapshots:
     transitivePeerDependencies:
       - '@rspack/core'
       - typescript
-
-  '@rsbuild/plugin-typed-css-modules@1.2.4(@rsbuild/core@2.2.3(core-js@3.50.0))':
-    optionalDependencies:
-      '@rsbuild/core': 2.2.3(core-js@3.50.0)
 
   '@rsbuild/plugin-typed-css-modules@1.2.4(@rsbuild/core@2.2.4(core-js@3.50.0))':
     optionalDependencies:
@@ -16108,8 +16053,8 @@ snapshots:
     dependencies:
       '@mdx-js/mdx': 3.1.1(supports-color@10.2.2)
       '@mdx-js/react': 3.1.1(@types/react@19.2.18)(react@19.2.8)
-      '@rsbuild/core': 2.2.3(core-js@3.50.0)
-      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.2.3(core-js@3.50.0))(@rspack/core@2.2.2(@swc/helpers@0.5.23))
+      '@rsbuild/core': 2.2.4(core-js@3.50.0)
+      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.2.4(core-js@3.50.0))(@rspack/core@2.2.2(@swc/helpers@0.5.23))
       '@rspress/shared': 2.0.21(core-js@3.50.0)(supports-color@10.2.2)
       '@shikijs/rehype': 4.3.1
       '@types/mdast': 4.0.4
@@ -16158,7 +16103,7 @@ snapshots:
 
   '@rspress/shared@2.0.21(core-js@3.50.0)(supports-color@10.2.2)':
     dependencies:
-      '@rsbuild/core': 2.2.3(core-js@3.50.0)
+      '@rsbuild/core': 2.2.4(core-js@3.50.0)
       '@shikijs/rehype': 4.3.1
       '@types/react': 19.2.18
       mdast-util-mdx-jsx: 3.2.0(supports-color@10.2.2)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -125,7 +125,7 @@ catalogs:
 
   # Rsbuild monorepo packages
   rsbuild:
-    "@rsbuild/core": "2.2.3"
+    "@rsbuild/core": "2.2.4"
 
   # Rslib monorepo packages
   rslib:


### PR DESCRIPTION
## Summary

Rsbuild ecosystem CI fails because CSS rule entries are asserted as a complete Rspack rule, whose array-based collections conflict with the stricter chain merge types. Upgrade Rsbuild to 2.2.4 and use a property-map type for the copied entries, preserving the existing CSS rule behavior.

## Related Links

- [Failing ecosystem CI](https://github.com/rstackjs/rstack-ecosystem-ci/actions/runs/34330719257/job/102398414870)
- [Rsbuild v2.2.4](https://github.com/web-infra-dev/rsbuild/releases/tag/v2.2.4)

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CSS rule processing to maintain reliable style configuration during builds.
  * Updated build compatibility for Rsbuild 2.2.4 and its stricter bundler type handling.

* **Chores**
  * Prepared patch releases for the Rspeedy and React Rspeedy integrations.
  * Updated build validation to improve consistency when processing JavaScript and CSS rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->