### PR TITLE
feat: add lynxml in bench

### DIFF
--- a/.github/a2ui-bench.instructions.md
+++ b/.github/a2ui-bench.instructions.md
@@ -1,10 +1,14 @@
 ---
-applyTo: "packages/genui/server/service/{a2ui,openui}/*bench*.ts,packages/genui/server/service/common/bench/**,packages/genui/server/app/a2ui/bench/**,packages/genui/playground/src/pages/bench/**,packages/genui/server/rslib.config.ts"
+applyTo: "packages/genui/server/service/{a2ui,openui,lynx-xml}/*bench*.ts,packages/genui/server/service/common/bench/**,packages/genui/server/app/a2ui/bench/**,packages/genui/playground/src/pages/bench/**,packages/genui/server/rslib.config.ts"
 ---
 
 A2UI bench jobs run agent generation and validation in `genui-server`, but browser-backed render metrics and screenshots remain disabled. Keep browser metrics marked as disabled in reports.
 
+Lynx XML participates in Bench as `lynx-xml` with the `native` profile and no component catalog. Reuse its existing generation service and document normalization, retain its deterministic fragment conversion tool, and disable search and image generation. Capture the final source through UI Judge's existing `POST /screenshot/lynxml` multipart route with `entry=index.lynxml`, `source`, `width`, and `height`; do not wrap XML in an A2UI/OpenUI bundle or send globalProps, model settings, or JSON-only capture options. Reuse BMP conversion, GenUI scoring, cancellation, and report storage. Keep XML protocol identity in history and every report label, and preserve the user's baseline protocol when adding comparisons.
+
 Let every comparison group select its model independently, but expose and accept only public model names returned by the GenUI server. Do not add a free-form Bench model input or reinterpret an unknown group model as an upstream model ID.
+
+Preserve exact configured public model names in structured Bench `model` fields even when they equal a private upstream model ID; keep upstream IDs and provider credentials redacted in diagnostics and unrecognized model fields. Preserve generated comparison `id`/`groupId` values through history serialization so reports can join the saved plan. Older redacted group IDs may recover model names only through a unique match on name, protocol, profile, and role in the same history entry; never guess from another group, array order, or the current default model.
 
 Use the Rust HTTP sidecar for screenshots and deterministic comparison, and GenUI Server for model evaluation. Configure the capture service through `UI_JUDGE_SERVER_URL` or a normalized credential-free job-level `playground.uiJudgeServerUrl`; keep bundle URLs server-owned. Probe `GET /health`, then send sanitized page data to `POST /screenshot/template`. Convert the returned BMP to PNG before scoring with the Bench group's GenUI model. Reject nonempty `judgeSteps` before capture; do not extend remote interaction.
 
@@ -19,3 +23,9 @@ Never let model-generated Bench messages make the server-side headless renderer 
 Do not add `@sparticuz/chromium` or `playwright-core` back to `packages/genui/server`. Keep the entire browser-backed implementation in `a2ui-bench-preview.ts` and its runner import and call sites commented until preview rendering moves to its dedicated service. Do not add a fallback preview implementation, capability flag, or configuration switch while it is disabled.
 
 Bench job event streams can sit in a long-running phase without producing run events. Keep the `/a2ui/bench/jobs/[jobId]/events` SSE response alive with heartbeat comments, and let native EventSource disconnects reconnect unless the server sends an explicit `event: error` payload. Otherwise proxies or serverless hosts may close an idle stream and the playground will lose a still-running job.
+
+Preserve generation usage for every Bench protocol and sum all generation steps and repair attempts, excluding UI Judge calls. Keep missing input, output, cache-read, cache-write, and reasoning counts unknown rather than zero; a partial retry breakdown must not appear complete. Cache counts are subsets of input and reasoning is a subset of output, so never add them to total tokens again. Keep numeric and nested AI SDK usage formats plus snake-case provider formats readable in older browser history, and divide group breakdowns by the same planned-run denominator as avgTokens.
+
+Request a 390 × 844 portrait viewport where the existing screenshot API supports it: Lynx XML multipart capture accepts width and height, but the current A2UI/OpenUI JSON template route rejects them. Do not send unsupported dimensions to that route or change UI Judge to add them.
+
+Default new A2UI groups and switches from another protocol to A2UI to native with Full Catalog. Adding comparisons must not rewrite existing groups' profiles or catalogs; preserve manual A2UI choices when cloning model/prompt comparisons or retaining the same protocol.

--- a/packages/genui/playground/README.md
+++ b/packages/genui/playground/README.md
@@ -171,6 +171,20 @@ post-paid keys are supported. See the [Doubao Search Custom API documentation](h
 and [Doubao Search console](https://console.volcengine.com/search-infinity) for
 service activation and API-key management.
 
+Bench Tokens can be hovered for a preview or expanded for input, output, cache read/write,
+reasoning, and cache hit rate. Totals include generation steps and repair attempts and
+exclude UI Judge. Comparison-group details use the same planned-run average as Tokens.
+Missing provider fields and unavailable historical breakdowns display `Not recorded`;
+cache and reasoning tokens are already included in input and output respectively.
+
+Bench supports A2UI, OpenUI, and Lynx XML comparison groups. Lynx XML uses
+the native profile without a component catalog, reuses the XML generation
+service, and submits the resulting source to UI Judge's `/screenshot/lynxml`
+endpoint for capture. Search and image generation are disabled in all Bench
+groups. The same GenUI scoring and report pipeline evaluates each protocol;
+browser render timing metrics remain disabled. Protocol comparisons preserve
+the selected baseline and offer protocols not yet present in the job.
+
 Bench is a regular GenUI top-level tab. Its Create-style history rail keeps
 drafts, completed runs, and report screenshots in the shared local IndexedDB
 (`a2ui-playground`, `benchHistory` store). Database migration and reads/writes

--- a/packages/genui/playground/src/pages/bench/BenchComparisonGroupsSection.tsx
+++ b/packages/genui/playground/src/pages/bench/BenchComparisonGroupsSection.tsx
@@ -2,8 +2,10 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 import {
+  BENCH_PROTOCOL_OPTIONS,
   findComparableBaseline,
   getBenchGroupDifferences,
+  getBenchProtocolLabel,
   usesCatalog,
 } from './benchData.js';
 import type {
@@ -152,9 +154,9 @@ export function BenchComparisonGroupsSection(props: {
               <div className='benchGroupSummary'>
                 <span
                   data-protocol={group.protocol}
-                  title={group.protocol === 'a2ui' ? 'A2UI' : 'OpenUI'}
+                  title={getBenchProtocolLabel(group.protocol)}
                 >
-                  {group.protocol === 'a2ui' ? 'A2UI' : 'OpenUI'}
+                  {getBenchProtocolLabel(group.protocol)}
                 </span>
                 <span title={group.profile}>{group.profile}</span>
                 <span title={group.model || 'Model required'}>
@@ -188,28 +190,22 @@ export function BenchComparisonGroupsSection(props: {
                       ariaLabel={`${groupName} Protocol`}
                       value={group.protocol}
                       disabled={props.locked}
-                      options={[
-                        {
-                          value: 'a2ui',
-                          label: 'A2UI',
-                          description: 'Structured message stream',
-                        },
-                        {
-                          value: 'openui',
-                          label: 'OpenUI',
-                          description: 'OpenUI Lang',
-                        },
-                      ]}
+                      options={BENCH_PROTOCOL_OPTIONS}
                       onChange={(protocol) =>
                         props.onProtocolChange(group.id, protocol)}
                     />
                   </div>
-                  <div className='benchField'>
+                  <div
+                    className='benchField'
+                    title={group.profile === 'matched-core'
+                      ? 'matched-core uses only capabilities shared by A2UI and OpenUI, making it suitable for a like-for-like Protocol comparison.'
+                      : 'Use the full protocol capability set.'}
+                  >
                     <span className='benchFieldLabel'>Profile</span>
                     <BenchDropdown
                       ariaLabel={`${groupName} Profile`}
                       value={group.profile}
-                      disabled={props.locked || group.protocol === 'openui'}
+                      disabled={props.locked || group.protocol !== 'a2ui'}
                       options={[
                         {
                           value: 'native',
@@ -227,15 +223,6 @@ export function BenchComparisonGroupsSection(props: {
                     />
                   </div>
                 </div>
-                {group.profile === 'matched-core'
-                  ? (
-                    <p className='benchProfileHint'>
-                      <strong>matched-core</strong>{' '}
-                      uses only capabilities shared by A2UI and OpenUI, making
-                      it suitable for a like-for-like Protocol comparison.
-                    </p>
-                  )
-                  : null}
                 <div className='benchGroupFields'>
                   <div className='benchField'>
                     <span className='benchFieldLabel'>Model</span>
@@ -250,20 +237,29 @@ export function BenchComparisonGroupsSection(props: {
                       onChange={(model) => props.onModelChange(group.id, model)}
                     />
                   </div>
-                  <div className='benchField'>
+                  <div
+                    className='benchField'
+                    title={group.protocol === 'lynx-xml'
+                      ? 'Lynx XML generates a complete page without a component catalog.'
+                      : undefined}
+                  >
                     <span className='benchFieldLabel'>Catalog</span>
                     <BenchDropdown
                       ariaLabel={`${groupName} Catalog`}
-                      value={group.catalog}
+                      value={group.protocol === 'lynx-xml'
+                        ? 'none'
+                        : group.catalog}
                       disabled={props.locked || !usesCatalog(group)}
-                      options={props.catalogOptions.map((catalog) => ({
-                        value: catalog,
-                        label: catalog,
-                      }))}
+                      options={group.protocol === 'lynx-xml'
+                        ? [{ value: 'none', label: 'Not applicable' }]
+                        : props.catalogOptions.map((catalog) => ({
+                          value: catalog,
+                          label: catalog,
+                        }))}
                       onChange={(catalog) =>
                         props.onCatalogChange(group.id, catalog)}
                     />
-                    {usesCatalog(group)
+                    {usesCatalog(group) || group.protocol === 'lynx-xml'
                       ? null
                       : (
                         <p className='benchFieldHint'>

--- a/packages/genui/playground/src/pages/bench/BenchPage.css
+++ b/packages/genui/playground/src/pages/bench/BenchPage.css
@@ -1196,20 +1196,6 @@
   margin-top: 10px;
 }
 
-.benchProfileHint {
-  margin: 9px 0 0;
-  padding-left: 9px;
-  border-left: 2px solid var(--geist-foreground);
-  color: var(--geist-secondary);
-  font-size: 11px;
-  line-height: 1.55;
-}
-
-.benchProfileHint strong {
-  color: var(--geist-foreground);
-  font-weight: 650;
-}
-
 .benchPlanSection {
   border: 1px solid var(--geist-border);
   border-radius: var(--geist-radius-md);
@@ -2147,4 +2133,64 @@
   .benchDirectionPicker {
     grid-template-columns: 1fr;
   }
+}
+
+.benchGroupSummary span[data-protocol="lynx-xml"] {
+  color: #7c3aed;
+  background: #f3e8ff;
+}
+
+.benchTokenDetails {
+  width: fit-content;
+  font-variant-numeric: tabular-nums;
+}
+
+.benchTokenDetails > summary {
+  cursor: pointer;
+  text-decoration: underline dotted;
+  text-underline-offset: 4px;
+  white-space: nowrap;
+}
+
+.benchTokenDetails > summary:focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 3px;
+  border-radius: 2px;
+}
+
+.benchTokenBreakdown {
+  min-width: 220px;
+  max-width: 300px;
+  padding: 12px 0;
+  font-size: 12px;
+  line-height: 1.5;
+  font-weight: 400;
+  white-space: normal;
+}
+
+.benchTokenBreakdown dl {
+  margin: 8px 0;
+}
+
+.benchTokenBreakdown dl > div {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.benchTokenBreakdown dd {
+  margin: 0;
+}
+
+.benchTokenBreakdown p {
+  margin: 8px 0 0;
+  opacity: 0.7;
+}
+
+.benchRunTokenMetrics {
+  display: flex;
+  align-items: baseline;
+  gap: 4px;
+  margin: 12px 0;
+  font-size: 13px;
 }

--- a/packages/genui/playground/src/pages/bench/BenchPage.test.ts
+++ b/packages/genui/playground/src/pages/bench/BenchPage.test.ts
@@ -10,6 +10,7 @@ import {
   DEFAULT_BENCH_SCENARIOS,
   DEFAULT_BENCH_SETTINGS,
   createDefaultBenchGroups,
+  withBenchProtocol,
 } from './benchData.js';
 import {
   migrateBenchHistoryEntries,
@@ -39,6 +40,43 @@ import { BenchScenarioSection } from './BenchScenarioSection.js';
 (globalThis as typeof globalThis & { React: typeof React }).React = React;
 
 const noop = () => undefined;
+
+test('renders a Lynx XML comparison with native capability and no catalog', () => {
+  const group = withBenchProtocol(
+    createDefaultBenchGroups('test-model')[0]!,
+    'lynx-xml',
+  );
+  const markup = renderToStaticMarkup(
+    React.createElement(BenchComparisonGroupsSection, {
+      catalogOptions: ['Full Catalog', 'Core Catalog'],
+      groups: [group],
+      locked: false,
+      modelOptions: [{ id: 'test-model', label: 'Test model' }],
+      onAdd: noop,
+      onCatalogChange: noop,
+      onEnabledChange: noop,
+      onModelChange: noop,
+      onNameChange: noop,
+      onProfileChange: noop,
+      onPromptChange: noop,
+      onProtocolChange: noop,
+      onRemove: noop,
+      onRoleChange: noop,
+    }),
+  );
+  expect(markup).toContain('data-protocol="lynx-xml"');
+  expect(markup).toContain('Lynx XML');
+  expect(markup).toContain('Not applicable');
+  expect(markup).toContain(
+    'title="Lynx XML generates a complete page without a component catalog."',
+  );
+  expect(markup).not.toContain('<p class="benchFieldHint">');
+  expect(markup).toMatch(
+    /aria-label="Baseline Profile" disabled=""><span>native<\/span>/u,
+  );
+  expect(markup).toMatch(/aria-label="Baseline Catalog" disabled=""/u);
+  expect(markup).not.toContain('fixed shared catalog');
+});
 
 function createCompletedHistoryEntry(id: string, jobId: string) {
   return {

--- a/packages/genui/playground/src/pages/bench/BenchPage.tsx
+++ b/packages/genui/playground/src/pages/bench/BenchPage.tsx
@@ -18,8 +18,11 @@ import {
   createCustomBenchScenario,
   createDefaultBenchGroups,
   findComparableBaseline,
+  getBenchProtocolLabel,
   inferBenchVariable,
+  nextBenchComparisonProtocol,
   usesCatalog,
+  withBenchProtocol,
 } from './benchData.js';
 import type {
   BenchComparisonDirection,
@@ -539,7 +542,7 @@ function createBenchHistoryEntry(
   const protocols = [
     ...new Set(
       createBenchGroupsFromReport(report).map((group) =>
-        group.protocol === 'openui' ? 'OpenUI' : 'A2UI'
+        getBenchProtocolLabel(group.protocol)
       ),
     ),
   ];
@@ -1116,38 +1119,27 @@ export function BenchPage() {
       const nextModel = direction === 'model'
         ? (env.models.find((item) => item.id !== model)?.id ?? model)
         : model;
+      const nextProtocol = direction === 'protocol'
+        ? nextBenchComparisonProtocol(current, baseline)
+        : baseline.protocol;
+      const protocolGroup = withBenchProtocol(baseline, nextProtocol);
       const nextGroup: BenchGroup = {
         ...baseline,
         id: createId(`${direction}-comparison`),
         role: 'experiment',
-        protocol: direction === 'protocol' ? 'openui' : baseline.protocol,
-        profile: direction === 'protocol' ? 'matched-core' : baseline.profile,
+        protocol: protocolGroup.protocol,
+        profile: protocolGroup.profile,
         name: `${direction} comparison`,
         variable: direction,
         model: nextModel,
-        catalog: direction === 'protocol'
-          ? 'Core Catalog'
-          : baseline.catalog,
+        catalog: protocolGroup.catalog,
         extraInstruction: direction === 'prompt'
           ? 'Use concise copy and minimize unnecessary UI structure while preserving the requested content and interaction.'
           : baseline.extraInstruction,
         enabled: true,
       };
 
-      if (direction !== 'protocol') return [...current, nextGroup];
-      return [
-        ...current.map((group) =>
-          group.id === baseline.id
-            ? {
-              ...group,
-              protocol: 'a2ui' as const,
-              profile: 'matched-core' as const,
-              catalog: 'Core Catalog',
-            }
-            : group
-        ),
-        nextGroup,
-      ];
+      return [...current, nextGroup];
     });
     if (direction === 'protocol') {
       setSettings((current) => ({ ...current, parallelism: 1 }));
@@ -1159,20 +1151,11 @@ export function BenchPage() {
       setGroups((current) =>
         current.map((group) =>
           group.id === id
-            ? {
-              ...group,
-              protocol,
-              profile: protocol === 'openui'
-                ? 'matched-core'
-                : group.profile,
-              catalog: protocol === 'openui'
-                ? 'Core Catalog'
-                : group.catalog,
-            }
+            ? withBenchProtocol(group, protocol)
             : group
         )
       );
-      if (protocol === 'openui') {
+      if (protocol !== 'a2ui') {
         setSettings((current) => ({ ...current, parallelism: 1 }));
       }
     },

--- a/packages/genui/playground/src/pages/bench/BenchReportPanel.tsx
+++ b/packages/genui/playground/src/pages/bench/BenchReportPanel.tsx
@@ -3,9 +3,11 @@
 // LICENSE file in the root directory of this source tree.
 import { useMemo } from 'react';
 
-import { findComparableBaseline } from './benchData.js';
+import { findComparableBaseline, getBenchProtocolLabel } from './benchData.js';
 import type { BenchSettings } from './benchData.js';
 import type { BenchGroupSummary, BenchReport } from './benchReportTypes.js';
+import { BenchTokens } from './BenchTokens.js';
+import { groupBenchTokenUsage } from './benchTokenUsage.js';
 import { Button } from '../../components/Button.js';
 import { FileText, Maximize2, Sparkles } from '../../components/Icon.js';
 import { PageHeader } from '../../components/PageHeader.js';
@@ -162,9 +164,17 @@ export function BenchReportPanel(props: {
               <div className='benchInsight'>
                 <span>Lowest tokens</span>
                 <strong>{getGroupName(bestTokens)}</strong>
-                <small>
-                  {bestTokens ? formatNumber(bestTokens.avgTokens) : 'n/a'}
-                </small>
+                <div>
+                  {bestTokens
+                    ? (
+                      <BenchTokens
+                        tokens={bestTokens.avgTokens}
+                        usage={groupBenchTokenUsage(props.report, bestTokens)}
+                        average
+                      />
+                    )
+                    : 'n/a'}
+                </div>
               </div>
               <div className='benchInsight'>
                 <span>Fastest agent</span>
@@ -208,16 +218,18 @@ export function BenchReportPanel(props: {
                             <span>
                               {getGroupName(summary)}
                               <small>
-                                {summary.protocol === 'openui'
-                                  ? 'OpenUI'
-                                  : 'A2UI'}
+                                {getBenchProtocolLabel(summary.protocol)}
                                 {summary.profile ? ` · ${summary.profile}` : ''}
                               </small>
                             </span>
                           </div>
                         </td>
                         <td>
-                          <strong>{formatNumber(summary.avgTokens)}</strong>
+                          <BenchTokens
+                            tokens={summary.avgTokens}
+                            usage={groupBenchTokenUsage(props.report!, summary)}
+                            average
+                          />
                           <small>
                             {deltaText(summary.avgTokens, baseline.avgTokens)}
                           </small>

--- a/packages/genui/playground/src/pages/bench/BenchRunFooter.tsx
+++ b/packages/genui/playground/src/pages/bench/BenchRunFooter.tsx
@@ -1,6 +1,7 @@
 // Copyright 2026 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
+import { getBenchProtocolLabel } from './benchData.js';
 import type { BenchProtocol } from './benchData.js';
 import { Button } from '../../components/Button.js';
 import { Pause, Play } from '../../components/Icon.js';
@@ -76,7 +77,7 @@ export function BenchRunFooter(props: {
     props.runCount,
   );
   const protocolLabel = props.protocols.map((protocol) =>
-    protocol === 'a2ui' ? 'A2UI' : 'OpenUI'
+    getBenchProtocolLabel(protocol)
   ).join(' + ');
   const planComplete = isBenchRunPlanComplete(
     props.protocols,

--- a/packages/genui/playground/src/pages/bench/BenchScreenshotsDialog.tsx
+++ b/packages/genui/playground/src/pages/bench/BenchScreenshotsDialog.tsx
@@ -8,6 +8,7 @@ import type {
   PointerEvent as ReactPointerEvent,
 } from 'react';
 
+import { getBenchProtocolLabel } from './benchData.js';
 import type { BenchGroup, BenchScenario, BenchSettings } from './benchData.js';
 import type { BenchReport, BenchResult } from './benchReportTypes.js';
 import { Button } from '../../components/Button.js';
@@ -395,7 +396,7 @@ export function BenchScreenshotsDialog(props: {
                     <div>
                       <strong>{row.group.name}</strong>
                       <span>
-                        {row.group.protocol === 'openui' ? 'OpenUI' : 'A2UI'}
+                        {getBenchProtocolLabel(row.group.protocol)}
                         {' · '}
                         {row.group.profile}
                       </span>

--- a/packages/genui/playground/src/pages/bench/BenchTokens.tsx
+++ b/packages/genui/playground/src/pages/bench/BenchTokens.tsx
@@ -1,0 +1,62 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import type { BenchTokenUsage } from './benchTokenUsage.js';
+
+const numbers = new Intl.NumberFormat('en-US', { maximumFractionDigits: 1 });
+const format = (value: number | undefined) =>
+  value === undefined || !Number.isFinite(value)
+    ? 'Not recorded'
+    : numbers.format(value);
+
+export function BenchTokens(props: {
+  tokens: number;
+  usage: BenchTokenUsage;
+  average?: boolean;
+}) {
+  const usage = props.usage;
+  const rows: [string, string][] = [
+    ['Total', format(props.tokens)],
+    ['Input', format(usage.inputTokens)],
+    ['Output', format(usage.outputTokens)],
+    ['Cache read', format(usage.cachedTokens)],
+    ['Cache write', format(usage.cacheWriteTokens)],
+    ['Reasoning', format(usage.reasoningTokens)],
+    [
+      'Cache hit rate',
+      usage.cachedTokens !== undefined && (usage.inputTokens ?? 0) > 0
+        ? `${numbers.format(usage.cachedTokens / usage.inputTokens! * 100)}%`
+        : 'Not recorded',
+    ],
+  ];
+  return (
+    <details className='benchTokenDetails'>
+      <summary
+        aria-label={`${props.average ? 'Average token' : 'Token'} details: ${
+          format(props.tokens)
+        }`}
+        title={rows.map(([label, value]) => `${label}: ${value}`).join('\n')}
+      >
+        {format(props.tokens)}
+      </summary>
+      <div className='benchTokenBreakdown'>
+        <strong>
+          {props.average ? 'Average tokens per planned run' : 'Token details'}
+        </strong>
+        <dl>
+          {rows.map(([label, value]) => (
+            <div key={label}>
+              <dt>{label}</dt>
+              <dd>{value}</dd>
+            </div>
+          ))}
+        </dl>
+        <p>Includes generation steps and repair attempts. Excludes UI Judge.</p>
+        <p>
+          Cache counts are part of input; reasoning is part of output. Missing
+          usage is not recorded as zero.
+        </p>
+      </div>
+    </details>
+  );
+}

--- a/packages/genui/playground/src/pages/bench/PublishedReportPage.test.ts
+++ b/packages/genui/playground/src/pages/bench/PublishedReportPage.test.ts
@@ -18,6 +18,7 @@ import {
   createDefaultBenchGroups,
 } from './benchData.js';
 import { BenchHistoryRail } from './BenchHistoryRail.js';
+import { sanitizeBenchReportValue } from './benchReportSerialization.js';
 import type { BenchReport } from './benchReportTypes.js';
 import {
   getHistoryReport,
@@ -171,6 +172,86 @@ describe('local historical Bench reports', () => {
     expect(report.results[0]!.groupId).toBe(id);
   });
 
+  test('keeps generated XML group ids linked to the saved model through serialization', () => {
+    const entry = historyEntry();
+    const xml = {
+      ...entry.config.groups[0]!,
+      id: 'protocol-comparison-mfd4x9ab-abc123',
+      name: 'protocol comparison',
+      protocol: 'lynx-xml' as const,
+      role: 'experiment' as const,
+      model: 'doubao-evolving-medium',
+    };
+    entry.config.groups = [...entry.config.groups, xml];
+    entry.report.groups = [...entry.report.groups, {
+      ...xml,
+      model: '[REDACTED]',
+    }];
+    entry.report.results.push({
+      ...entry.report.results[0]!,
+      groupId: xml.id,
+      groupName: xml.name,
+      protocol: xml.protocol,
+      role: xml.role,
+      model: '[REDACTED]',
+    });
+    const report = getHistoryReport({
+      ...entry,
+      report: sanitizeBenchReportValue(entry.report),
+    });
+    expect(report.groups[1]).toMatchObject({ id: xml.id, model: xml.model });
+    expect(report.results[1]).toMatchObject({
+      groupId: xml.id,
+      model: xml.model,
+    });
+    expect(sanitizeBenchReportValue({ id: xml.id, error: 'x'.repeat(40) }))
+      .toEqual({
+        id: xml.id,
+        error: '[redacted credential]',
+      });
+    expect(JSON.stringify(sanitizeBenchReportValue({ id: xml.id }, [xml.id])))
+      .not.toContain(xml.id);
+  });
+
+  test('recovers old redacted XML group ids only when the saved plan has a unique match', () => {
+    const entry = historyEntry();
+    const xml = {
+      ...entry.config.groups[0]!,
+      id: 'protocol-comparison-mfd4x9ab-abc123',
+      name: 'protocol comparison',
+      protocol: 'lynx-xml' as const,
+      role: 'experiment' as const,
+      model: 'doubao-evolving-medium',
+    };
+    entry.config.groups = [...entry.config.groups, xml];
+    entry.report.groups = [...entry.report.groups, {
+      ...xml,
+      id: '[redacted credential]',
+      model: '[REDACTED]',
+    }];
+    entry.report.results.push({
+      ...entry.report.results[0]!,
+      groupId: '[redacted credential]',
+      groupName: xml.name,
+      protocol: xml.protocol,
+      role: xml.role,
+      model: '[REDACTED]',
+    });
+    const original = JSON.stringify(entry);
+    const report = getHistoryReport(entry);
+    expect(report.groups[1]?.model).toBe(xml.model);
+    expect(report.results[1]?.model).toBe(xml.model);
+    expect(JSON.stringify(entry)).toBe(original);
+    entry.config.groups.push({
+      ...xml,
+      id: 'another-xml-group',
+      model: 'different-model',
+    });
+    expect(getHistoryReport(entry).groups[1]?.model).toBe(
+      'Model name unavailable',
+    );
+  });
+
   test('recovers public model names only from the same cached comparison group', () => {
     const entry = historyEntry();
     entry.config.groups = [
@@ -233,7 +314,14 @@ describe('fixed read-only report template', () => {
     const markup = renderToStaticMarkup(
       React.createElement(PublishedReportPage, { report }),
     );
-    const disclosures = markup.match(/<details[^>]*>/gu) ?? [];
+    const disclosures = (markup.match(/<details[^>]*>/gu) ?? [])
+      .filter((tag) => tag.includes('publishedReportDisclosure'));
+    const tokenDetails = (markup.match(/<details[^>]*>/gu) ?? [])
+      .filter((tag) => tag.includes('benchTokenDetails'));
+    expect(tokenDetails).toHaveLength(
+      report.summaries.length + report.results.length,
+    );
+    expect(tokenDetails.every((tag) => !tag.includes('open=""'))).toBe(true);
     expect(disclosures).toHaveLength(
       report.scenarios.length + report.groups.length + report.results.length,
     );
@@ -339,4 +427,26 @@ describe('fixed read-only report template', () => {
       /disabled=""[^>]*aria-label="View report details/u,
     );
   });
+});
+
+test('preserves usage through history serialization and displays group and run details', () => {
+  const report = reportFixture();
+  report.results[0]!.usage = [{
+    inputTokens: 11000,
+    outputTokens: 408,
+    inputTokenDetails: { cacheReadTokens: 5500, cacheWriteTokens: 0 },
+    outputTokenDetails: { reasoningTokens: 100 },
+  }];
+  const saved = sanitizeBenchReportValue(report) as BenchReport;
+  const markup = renderToStaticMarkup(
+    React.createElement(PublishedReportPage, { report: saved }),
+  );
+  expect(markup).toContain('Input: 11,000');
+  expect(markup).toContain('Output: 408');
+  expect(markup).toContain('Cache read: 5,500');
+  expect(markup).toContain('Cache write: 0');
+  expect(markup).toContain('Reasoning: 100');
+  expect(markup).toContain('Cache hit rate: 50%');
+  expect(markup).toContain('Average token details: 11,408');
+  expect(markup).toContain('Token details: 11,408');
 });

--- a/packages/genui/playground/src/pages/bench/PublishedReportPage.tsx
+++ b/packages/genui/playground/src/pages/bench/PublishedReportPage.tsx
@@ -4,9 +4,15 @@
 import { useMemo, useState } from 'react';
 import type { ReactNode, Ref } from 'react';
 
+import { getBenchProtocolLabel } from './benchData.js';
 import type { BenchGroupSummary, BenchReport } from './benchReportTypes.js';
 import { createBenchScreenshotReader } from './benchScreenshot.js';
 import { BenchScreenshotsDialog } from './BenchScreenshotsDialog.js';
+import { BenchTokens } from './BenchTokens.js';
+import {
+  groupBenchTokenUsage,
+  readBenchTokenUsage,
+} from './benchTokenUsage.js';
 import { Button } from '../../components/Button.js';
 import { Maximize2 } from '../../components/Icon.js';
 import './BenchPage.css';
@@ -157,14 +163,19 @@ export function PublishedReportPage(
                       <th scope='row'>
                         <strong>{group?.name ?? summary.groupName}</strong>
                         <small>
-                          {(group?.protocol ?? summary.protocol) === 'openui'
-                            ? 'OpenUI'
-                            : 'A2UI'} ·{' '}
-                          {group?.profile ?? summary.profile ?? 'native'}
+                          {getBenchProtocolLabel(
+                            group?.protocol ?? summary.protocol,
+                          )} · {group?.profile ?? summary.profile ?? 'native'}
                         </small>
                         <small>{group?.model ?? report.env.model}</small>
                       </th>
-                      <td>{formatNumber(summary.avgTokens)}</td>
+                      <td>
+                        <BenchTokens
+                          tokens={summary.avgTokens}
+                          usage={groupBenchTokenUsage(report, summary)}
+                          average
+                        />
+                      </td>
                       <td>{formatMs(summary.avgAgentMs)}</td>
                       <td>{formatNumber(summary.avgAttempts)}</td>
                       <td>{judgeScore(report, summary)}</td>
@@ -237,7 +248,7 @@ export function PublishedReportPage(
                     <div>
                       <dt>Protocol</dt>
                       <dd>
-                        {group.protocol === 'openui' ? 'OpenUI' : 'A2UI'} ·{' '}
+                        {getBenchProtocolLabel(group.protocol)} ·{' '}
                         {group.profile}
                       </dd>
                     </div>
@@ -346,11 +357,16 @@ export function PublishedReportPage(
                       : 'Not recorded')}
                 </span>
               </summary>
-              <p>
-                {formatNumber(result.tokens)} tokens ·{' '}
-                {formatMs(result.agentMs)} Agent ·{' '}
-                {formatNumber(result.attempts)} attempts
-              </p>
+              <div className='benchRunTokenMetrics'>
+                <BenchTokens
+                  tokens={result.tokens}
+                  usage={readBenchTokenUsage(result.usage)}
+                />
+                <span>
+                  tokens · {formatMs(result.agentMs)} Agent ·{' '}
+                  {formatNumber(result.attempts)} attempts
+                </span>
+              </div>
               <p>
                 UI Judge: {result.judgeStatus === 'complete'
                     && Number.isFinite(result.judgeScore)

--- a/packages/genui/playground/src/pages/bench/benchData.ts
+++ b/packages/genui/playground/src/pages/bench/benchData.ts
@@ -3,7 +3,7 @@
 // LICENSE file in the root directory of this source tree.
 
 export type BenchRole = 'control' | 'experiment';
-export type BenchProtocol = 'a2ui' | 'openui';
+export type BenchProtocol = 'a2ui' | 'openui' | 'lynx-xml';
 export type BenchProfile = 'matched-core' | 'native';
 export type BenchVariable =
   | 'catalog'
@@ -35,6 +35,53 @@ export interface BenchScenario {
   name: string;
   prompt: string;
   type: string;
+}
+
+export const BENCH_PROTOCOL_OPTIONS = [
+  { value: 'a2ui', label: 'A2UI', description: 'Structured message stream' },
+  { value: 'openui', label: 'OpenUI', description: 'OpenUI Lang' },
+  {
+    value: 'lynx-xml',
+    label: 'Lynx XML',
+    description: 'Self-contained Lynx XML page',
+  },
+] as const;
+
+export function getBenchProtocolLabel(
+  protocol: BenchProtocol = 'a2ui',
+): string {
+  return BENCH_PROTOCOL_OPTIONS.find((option) => option.value === protocol)
+    ?.label ?? protocol;
+}
+
+export function withBenchProtocol(
+  group: BenchGroup,
+  protocol: BenchProtocol,
+): BenchGroup {
+  if (protocol === 'a2ui') {
+    return group.protocol === 'a2ui'
+      ? group
+      : { ...group, protocol, profile: 'native', catalog: 'Full Catalog' };
+  }
+  let profile = group.profile;
+  if (protocol === 'openui') profile = 'matched-core';
+  if (protocol === 'lynx-xml') profile = 'native';
+  let catalog = group.catalog === 'none' ? 'Full Catalog' : group.catalog;
+  if (profile === 'matched-core') catalog = 'Core Catalog';
+  if (protocol === 'lynx-xml') catalog = 'none';
+  return { ...group, protocol, profile, catalog };
+}
+
+export function nextBenchComparisonProtocol(
+  groups: readonly BenchGroup[],
+  baseline: BenchGroup,
+): BenchProtocol {
+  return BENCH_PROTOCOL_OPTIONS.find((option) =>
+    !groups.some((group) => group.protocol === option.value)
+  )?.value
+    ?? BENCH_PROTOCOL_OPTIONS.find((option) =>
+      option.value !== baseline.protocol
+    )!.value;
 }
 
 export interface BenchSettings {

--- a/packages/genui/playground/src/pages/bench/benchHistory.ts
+++ b/packages/genui/playground/src/pages/bench/benchHistory.ts
@@ -68,7 +68,7 @@ function isBenchVariable(value: unknown): value is BenchVariable {
 }
 
 function isBenchProtocol(value: unknown): value is BenchProtocol {
-  return value === 'a2ui' || value === 'openui';
+  return value === 'a2ui' || value === 'openui' || value === 'lynx-xml';
 }
 
 function isBenchProfile(value: unknown): value is BenchProfile {
@@ -126,7 +126,9 @@ export function createBenchGroupsFromReport(
       name: item.name ?? `Group ${index + 1}`,
       variable: isBenchVariable(item.variable) ? item.variable : 'custom',
       model: item.model ?? fallbackModel,
-      catalog: item.catalog ?? 'Full Catalog',
+      catalog: protocol === 'lynx-xml'
+        ? 'none'
+        : item.catalog ?? 'Full Catalog',
       extraInstruction: item.extraInstruction ?? '',
       enabled: readBoolean(item.enabled, true),
     };

--- a/packages/genui/playground/src/pages/bench/benchProtocols.test.ts
+++ b/packages/genui/playground/src/pages/bench/benchProtocols.test.ts
@@ -1,0 +1,67 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { describe, expect, test } from '@rstest/core';
+
+import {
+  createDefaultBenchGroups,
+  getBenchProtocolLabel,
+  nextBenchComparisonProtocol,
+  usesCatalog,
+  withBenchProtocol,
+} from './benchData.js';
+import { createBenchGroupsFromReport } from './benchHistory.js';
+
+describe('Bench protocol selection', () => {
+  test('switches to XML native without retaining a component catalog', () => {
+    const original = createDefaultBenchGroups('test-model')[0]!;
+    const xml = withBenchProtocol(
+      withBenchProtocol(original, 'openui'),
+      'lynx-xml',
+    );
+    expect(xml).toMatchObject({
+      protocol: 'lynx-xml',
+      profile: 'native',
+      catalog: 'none',
+      model: 'test-model',
+    });
+    expect(usesCatalog(xml)).toBe(false);
+    expect(getBenchProtocolLabel(xml.protocol)).toBe('Lynx XML');
+    expect(withBenchProtocol(xml, 'a2ui')).toMatchObject({
+      protocol: 'a2ui',
+      profile: 'native',
+      catalog: 'Full Catalog',
+    });
+    expect(withBenchProtocol(xml, 'openui')).toMatchObject({
+      protocol: 'openui',
+      profile: 'matched-core',
+      catalog: 'Core Catalog',
+    });
+  });
+
+  test('offers XML after A2UI/OpenUI and supports an XML baseline', () => {
+    const original = createDefaultBenchGroups('test-model')[0]!;
+    const openui = withBenchProtocol(original, 'openui');
+    const xml = withBenchProtocol(original, 'lynx-xml');
+    expect(nextBenchComparisonProtocol([original, openui], original)).toBe(
+      'lynx-xml',
+    );
+    expect(nextBenchComparisonProtocol([xml], xml)).toBe('a2ui');
+    expect(nextBenchComparisonProtocol([original, openui, xml], xml)).not.toBe(
+      'lynx-xml',
+    );
+  });
+
+  test('restores XML protocol and model from a report', () => {
+    const original = withBenchProtocol(
+      createDefaultBenchGroups('xml-model')[0]!,
+      'lynx-xml',
+    );
+    const restored = createBenchGroupsFromReport({
+      env: { model: 'fallback-model', apiKeyConfigured: false },
+      groups: [original],
+    });
+    expect(restored).toEqual([original]);
+  });
+});

--- a/packages/genui/playground/src/pages/bench/benchReportSerialization.ts
+++ b/packages/genui/playground/src/pages/bench/benchReportSerialization.ts
@@ -5,6 +5,9 @@ import type { BenchReport } from './benchReportTypes.js';
 import { createBenchScreenshotReader } from './benchScreenshot.js';
 import { BENCH_JOB_ID } from '../../utils/appRoute.js';
 
+const BENCH_COMPARISON_GROUP_ID =
+  /^(?:protocol|model|prompt)-comparison-[a-z0-9]{8,10}-[a-z0-9]{1,6}$/u;
+
 function isSensitiveKey(key: string): boolean {
   const normalized = key.replaceAll(/[-_]/gu, '').toLowerCase();
   return normalized === 'apikey'
@@ -68,6 +71,14 @@ export function sanitizeBenchReportValue(
         }
         if (isSensitiveKey(key)) return [];
         if (key === 'model' && typeof item === 'string') {
+          return [[key, redactString(item, secrets, true)]];
+        }
+        // Generated group identities join the report to its saved plan. Their
+        // length is not evidence of a credential; still redact known secrets.
+        if (
+          (key === 'id' || key === 'groupId') && typeof item === 'string'
+          && BENCH_COMPARISON_GROUP_ID.test(item)
+        ) {
           return [[key, redactString(item, secrets, true)]];
         }
         // UUID job handles are public report identities, not provider credentials.

--- a/packages/genui/playground/src/pages/bench/benchReportTypes.ts
+++ b/packages/genui/playground/src/pages/bench/benchReportTypes.ts
@@ -57,6 +57,7 @@ export interface BenchResult {
   status?: 'complete' | 'failed';
   ttiMs: number;
   tokens: number;
+  usage?: unknown;
 }
 
 export interface BenchGroupSummary {
@@ -76,6 +77,7 @@ export interface BenchGroupSummary {
   protocol?: BenchProtocol;
   role: BenchRole;
   runCount?: number;
+  plannedRuns?: number;
   successRate?: number;
 }
 

--- a/packages/genui/playground/src/pages/bench/benchTokenUsage.test.ts
+++ b/packages/genui/playground/src/pages/bench/benchTokenUsage.test.ts
@@ -1,0 +1,107 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { describe, expect, test } from '@rstest/core';
+import * as React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { BenchTokens } from './BenchTokens.js';
+import { readBenchTokenUsage, sumBenchTokenUsage } from './benchTokenUsage.js';
+
+(globalThis as typeof globalThis & { React: typeof React }).React = React;
+
+describe('Bench token usage', () => {
+  test('reads numeric SDK usage and provider cache/reasoning details without double counting', () => {
+    expect(
+      readBenchTokenUsage({
+        prompt_tokens: 100,
+        completion_tokens: 20,
+        total_tokens: 120,
+        prompt_tokens_details: { cached_tokens: 70 },
+        completion_tokens_details: { reasoning_tokens: 8 },
+        cache_creation_input_tokens: 10,
+      }),
+    ).toEqual({
+      inputTokens: 100,
+      outputTokens: 20,
+      totalTokens: 120,
+      cachedTokens: 70,
+      cacheWriteTokens: 10,
+      reasoningTokens: 8,
+    });
+    expect(
+      readBenchTokenUsage({
+        inputTokens: 100,
+        outputTokens: 20,
+        inputTokenDetails: { cacheReadTokens: 0, cacheWriteTokens: 10 },
+        outputTokenDetails: { reasoningTokens: 8 },
+      }),
+    ).toEqual({
+      inputTokens: 100,
+      outputTokens: 20,
+      totalTokens: 120,
+      cachedTokens: 0,
+      cacheWriteTokens: 10,
+      reasoningTokens: 8,
+    });
+  });
+  test('accumulates nested SDK usage across repair attempts', () => {
+    const usage = {
+      inputTokens: { total: 100, cacheRead: 60, cacheWrite: 10 },
+      outputTokens: { total: 20, reasoning: 8 },
+    };
+    expect(readBenchTokenUsage([usage, usage])).toEqual({
+      inputTokens: 200,
+      outputTokens: 40,
+      totalTokens: 240,
+      cachedTokens: 120,
+      cacheWriteTokens: 20,
+      reasoningTokens: 16,
+    });
+  });
+  test('does not turn missing or partial usage into zero cache misses', () => {
+    expect(readBenchTokenUsage({ totalTokens: 42 })).toEqual({
+      totalTokens: 42,
+    });
+    expect(
+      readBenchTokenUsage([{
+        inputTokens: 10,
+        outputTokens: 5,
+        cachedTokens: 0,
+      }, { inputTokens: 10, outputTokens: 5 }]),
+    ).toEqual({ inputTokens: 20, outputTokens: 10, totalTokens: 30 });
+    expect(
+      readBenchTokenUsage([undefined, { inputTokens: 10, outputTokens: 5 }]),
+    ).toEqual({});
+    expect(
+      readBenchTokenUsage({
+        inputTokens: -1,
+        outputTokens: Number.NaN,
+        cachedTokens: '10',
+      }),
+    ).toEqual({});
+    expect(readBenchTokenUsage([])).toEqual({});
+  });
+});
+
+test('keeps planned-run averaging and labels the generation-only breakdown', () => {
+  const usage = sumBenchTokenUsage([{
+    inputTokens: 100,
+    outputTokens: 20,
+    cachedTokens: 50,
+  }], 2);
+  expect(usage).toEqual({
+    inputTokens: 50,
+    outputTokens: 10,
+    cachedTokens: 25,
+  });
+  const markup = renderToStaticMarkup(
+    React.createElement(BenchTokens, { tokens: 60, usage, average: true }),
+  );
+  expect(markup).toContain('Average tokens per planned run');
+  expect(markup).toContain('Input: 50');
+  expect(markup).toContain('Cache hit rate: 50%');
+  expect(markup).toContain('Cache write: Not recorded');
+  expect(markup).toContain('Excludes UI Judge');
+  expect(markup).toContain('<summary');
+});

--- a/packages/genui/playground/src/pages/bench/benchTokenUsage.ts
+++ b/packages/genui/playground/src/pages/bench/benchTokenUsage.ts
@@ -1,0 +1,147 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import type { BenchGroupSummary, BenchReport } from './benchReportTypes.js';
+
+export interface BenchTokenUsage {
+  inputTokens?: number;
+  outputTokens?: number;
+  totalTokens?: number;
+  cachedTokens?: number;
+  cacheWriteTokens?: number;
+  reasoningTokens?: number;
+}
+
+const TOKEN_KEYS = [
+  'inputTokens',
+  'outputTokens',
+  'totalTokens',
+  'cachedTokens',
+  'cacheWriteTokens',
+  'reasoningTokens',
+] as const;
+
+function record(value: unknown): Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {};
+}
+
+function count(value: unknown): number | undefined {
+  const candidate = typeof value === 'object' ? record(value).total : value;
+  return typeof candidate === 'number' && Number.isFinite(candidate)
+      && candidate >= 0
+    ? candidate
+    : undefined;
+}
+
+function pick(value: unknown, keys: readonly string[]): number | undefined {
+  const source = record(value);
+  for (const key of keys) {
+    const result = count(source[key]);
+    if (result !== undefined) return result;
+  }
+  return undefined;
+}
+
+export function sumBenchTokenUsage(
+  usages: BenchTokenUsage[],
+  divisor = 1,
+): BenchTokenUsage {
+  const result: BenchTokenUsage = {};
+  if (usages.length === 0 || divisor <= 0) return result;
+  for (const key of TOKEN_KEYS) {
+    // A missing field in any call means the complete breakdown is unknown.
+    if (usages.every((usage) => usage[key] !== undefined)) {
+      result[key] = usages.reduce((sum, usage) => sum + usage[key]!, 0)
+        / divisor;
+    }
+  }
+  return result;
+}
+
+export function readBenchTokenUsage(value: unknown): BenchTokenUsage {
+  if (Array.isArray(value)) {
+    return sumBenchTokenUsage(value.map((item) => readBenchTokenUsage(item)));
+  }
+  const source = record(value);
+  const inputTokens = pick(source, [
+    'inputTokens',
+    'promptTokens',
+    'input_tokens',
+    'prompt_tokens',
+  ]);
+  const outputTokens = pick(source, [
+    'outputTokens',
+    'completionTokens',
+    'output_tokens',
+    'completion_tokens',
+  ]);
+  const totalTokens = pick(source, ['totalTokens', 'total_tokens'])
+    ?? (inputTokens !== undefined && outputTokens !== undefined
+      ? inputTokens + outputTokens
+      : undefined);
+  const inputDetails = [
+    source,
+    source.inputTokens,
+    source.inputTokenDetails,
+    source.inputTokensDetails,
+    source.input_tokens_details,
+    source.prompt_tokens_details,
+  ];
+  const outputDetails = [
+    source,
+    source.outputTokens,
+    source.outputTokenDetails,
+    source.outputTokensDetails,
+    source.output_tokens_details,
+    source.completion_tokens_details,
+  ];
+  const find = (values: unknown[], keys: string[]) =>
+    values.map((item) => pick(item, keys))
+      .find((item) => item !== undefined);
+  const cachedTokens = find(inputDetails, [
+    'cachedTokens',
+    'cached_tokens',
+    'cachedInputTokens',
+    'cached_input_tokens',
+    'cacheReadTokens',
+    'cacheRead',
+    'cache_read_input_tokens',
+  ]);
+  const cacheWriteTokens = find(inputDetails, [
+    'cacheWriteTokens',
+    'cacheWrite',
+    'cache_write_tokens',
+    'cache_creation_input_tokens',
+  ]);
+  const reasoningTokens = find(outputDetails, [
+    'reasoningTokens',
+    'reasoning_tokens',
+    'reasoning',
+  ]);
+  return {
+    ...(inputTokens === undefined ? {} : { inputTokens }),
+    ...(outputTokens === undefined ? {} : { outputTokens }),
+    ...(totalTokens === undefined ? {} : { totalTokens }),
+    ...(cachedTokens === undefined ? {} : { cachedTokens }),
+    ...(cacheWriteTokens === undefined ? {} : { cacheWriteTokens }),
+    ...(reasoningTokens === undefined ? {} : { reasoningTokens }),
+  };
+}
+
+export function groupBenchTokenUsage(
+  report: BenchReport,
+  summary: BenchGroupSummary,
+): BenchTokenUsage {
+  const results = report.results.filter((result) =>
+    result.groupId === summary.groupId
+  );
+  const plannedRuns = summary.plannedRuns
+    ?? report.scenarios.length * report.settings.repeats;
+  return sumBenchTokenUsage(
+    results.map((result) => readBenchTokenUsage(result.usage)),
+    plannedRuns,
+  );
+}

--- a/packages/genui/playground/src/pages/bench/publishedReportLoader.ts
+++ b/packages/genui/playground/src/pages/bench/publishedReportLoader.ts
@@ -15,12 +15,46 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function isVisibleModelName(name: unknown): name is string {
   return typeof name === 'string'
-    && name.trim().length > 0 && !/\[redacted(?: credential)?\]/iu.test(name);
+    && name.trim().length > 0 && name !== 'Model name unavailable'
+    && !/\[redacted(?: credential)?\]/iu.test(name);
 }
 
 function modelName(value: unknown, fallback: unknown): string {
   if (isVisibleModelName(value)) return value;
   return isVisibleModelName(fallback) ? fallback : 'Model name unavailable';
+}
+
+function findSavedGroup(
+  group: BenchReport['groups'][number],
+  configGroups: Record<string, unknown>[],
+): Record<string, unknown> | undefined {
+  if (isVisibleModelName(group.id)) {
+    return configGroups.find((item) => item.id === group.id);
+  }
+  // Older serialization replaced long generated ids with a redaction marker.
+  // Recover only a unique match in this report's own saved plan, never by order.
+  const matches = configGroups.filter((item) =>
+    ['name', 'protocol', 'profile', 'role'].every((key) => {
+      const value = group[key as keyof typeof group];
+      return typeof value === 'string' && value.length > 0
+        && item[key] === value;
+    })
+  );
+  return matches.length === 1 ? matches[0] : undefined;
+}
+
+function findResultGroup(
+  result: BenchReport['results'][number],
+  groups: BenchReport['groups'],
+): BenchReport['groups'][number] | undefined {
+  if (isVisibleModelName(result.groupId)) {
+    return groups.find((group) => group.id === result.groupId);
+  }
+  const matches = groups.filter((group) =>
+    group.name === result.groupName
+    && group.protocol === result.protocol && group.role === result.role
+  );
+  return matches.length === 1 ? matches[0] : undefined;
 }
 
 /** Fill missing display configuration from the same saved entry, never another run. */
@@ -51,7 +85,7 @@ export function getHistoryReport(entry: unknown): BenchReport {
     ...group,
     model: modelName(
       group.model,
-      configGroups.find((item) => item.id === group.id)?.model,
+      findSavedGroup(group, configGroups)?.model,
     ),
   }));
   return {
@@ -75,7 +109,7 @@ export function getHistoryReport(entry: unknown): BenchReport {
         ...result,
         model: modelName(
           result.model,
-          displayGroups.find((group) => group.id === result.groupId)?.model,
+          findResultGroup(result, displayGroups)?.model,
         ),
       }
     ),

--- a/packages/genui/server/service/a2ui/a2ui-bench-adapter.ts
+++ b/packages/genui/server/service/a2ui/a2ui-bench-adapter.ts
@@ -18,18 +18,8 @@ import type {
   ProtocolBenchRunArtifact,
 } from '../common/bench/protocol-adapter.js';
 import type { ProtocolBenchAttemptResult } from '../common/bench/protocol-types.js';
+import { benchAttemptTokenCounts } from '../common/bench/usage.js';
 import type { ChatMessage } from '../common/types.js';
-
-interface UsageRecord {
-  promptTokens?: unknown;
-  completionTokens?: unknown;
-  totalTokens?: unknown;
-  inputTokens?: unknown;
-  outputTokens?: unknown;
-  prompt_tokens?: unknown;
-  completion_tokens?: unknown;
-  total_tokens?: unknown;
-}
 
 export type A2UIBenchGenerateRaw = (
   messages: ChatMessage[],
@@ -79,46 +69,6 @@ function createMatchedCoreCatalog(): A2UICatalog {
         components.map((component) => component.name).join(', ')
       }. Image and protocol-native extension components are excluded.`,
     ],
-  };
-}
-
-function pickToken(
-  usage: UsageRecord,
-  keys: (keyof UsageRecord)[],
-): number {
-  for (const key of keys) {
-    const value = usage[key];
-    if (typeof value === 'number' && Number.isFinite(value)) {
-      return Math.max(0, Math.round(value));
-    }
-  }
-  return 0;
-}
-
-function readUsage(usage: unknown): {
-  inputTokens: number;
-  outputTokens: number;
-  totalTokens: number;
-} {
-  if (!usage || typeof usage !== 'object') {
-    return { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
-  }
-  const record = usage as UsageRecord;
-  const inputTokens = pickToken(record, [
-    'promptTokens',
-    'inputTokens',
-    'prompt_tokens',
-  ]);
-  const outputTokens = pickToken(record, [
-    'completionTokens',
-    'outputTokens',
-    'completion_tokens',
-  ]);
-  const reportedTotal = pickToken(record, ['totalTokens', 'total_tokens']);
-  return {
-    inputTokens,
-    outputTokens,
-    totalTokens: reportedTotal || inputTokens + outputTokens,
   };
 }
 
@@ -295,11 +245,12 @@ export function createA2UIBenchAdapter(
           const validation = validateA2UIOutput(generated.text, catalog);
           finalErrors = validation.errors;
           warnings.push(...validation.warnings);
-          const usage = readUsage(generated.usage);
+          const usage = benchAttemptTokenCounts(generated.usage);
           attempts.push({
             index,
             durationMs,
             ...usage,
+            usage: generated.usage,
             valid: validation.ok,
             validationErrors: [...validation.errors],
             outputChars: generated.text.length,

--- a/packages/genui/server/service/a2ui/a2ui-bench-judge.ts
+++ b/packages/genui/server/service/a2ui/a2ui-bench-judge.ts
@@ -27,7 +27,7 @@ type FetchLike = (
 ) => Promise<Response>;
 
 export interface BenchUiJudgeSession {
-  bundleUrl: string;
+  bundleUrl?: string;
   screenshotUrl: string;
 }
 
@@ -96,6 +96,7 @@ interface RunBenchUiJudgeOptions {
 export interface RunBenchUiJudgeRequestOptions {
   model?: string;
   globalProps: Record<string, unknown>;
+  lynxXmlSource?: string;
   scenario: BenchUiJudgeScenario;
   includeScreenshot?: boolean;
   screenshotSettleMs?: number;
@@ -258,6 +259,7 @@ function containsOpenUrlCall(
 export async function probeBenchUiJudge(
   options: {
     bundleUrl?: string;
+    sourceKind?: 'lynx-xml';
     env?: NodeJS.ProcessEnv;
     fetch?: FetchLike;
     serverUrl?: string;
@@ -288,8 +290,10 @@ export async function probeBenchUiJudge(
       && configuredBundleUrl.length > 0
     ? configuredBundleUrl
     : DEFAULT_A2UI_BUNDLE_URL;
-  const bundleUrl = normalizeBundleUrl(rawBundleUrl);
-  if (!bundleUrl) {
+  const bundleUrl = options.sourceKind === 'lynx-xml'
+    ? undefined
+    : normalizeBundleUrl(rawBundleUrl);
+  if (options.sourceKind !== 'lynx-xml' && !bundleUrl) {
     return {
       enabled: false,
       reason: 'UI_JUDGE_BUNDLE_URL must be an HTTP(S) URL without credentials.',
@@ -326,8 +330,13 @@ export async function probeBenchUiJudge(
   return {
     enabled: true,
     session: {
-      bundleUrl,
-      screenshotUrl: new URL('screenshot/template', serverUrl).toString(),
+      ...(bundleUrl ? { bundleUrl } : {}),
+      screenshotUrl: new URL(
+        options.sourceKind === 'lynx-xml'
+          ? 'screenshot/lynxml'
+          : 'screenshot/template',
+        serverUrl,
+      ).toString(),
     },
   };
 }
@@ -406,6 +415,7 @@ export async function runBenchUiJudgeRequest(
       warnings,
     };
   }
+  const viewport = { width: 390, height: 844 };
   const body = {
     globalProps: options.globalProps,
     ...(options.screenshotSettleMs === undefined
@@ -415,13 +425,21 @@ export async function runBenchUiJudgeRequest(
     url: options.session.bundleUrl,
   };
 
+  const form = options.lynxXmlSource === undefined ? undefined : new FormData();
+  if (form) {
+    form.set('entry', 'index.lynxml');
+    form.set('source', options.lynxXmlSource!);
+    form.set('width', String(viewport.width));
+    form.set('height', String(viewport.height));
+  }
+
   let response: Response;
   try {
     response = await fetchImpl(options.session.screenshotUrl, {
-      body: JSON.stringify(body),
+      body: form ?? JSON.stringify(body),
       headers: {
         Accept: 'image/bmp',
-        'Content-Type': 'application/json',
+        ...(form ? {} : { 'Content-Type': 'application/json' }),
       },
       method: 'POST',
       signal: requestSignal,

--- a/packages/genui/server/service/common/bench/judge.ts
+++ b/packages/genui/server/service/common/bench/judge.ts
@@ -2,6 +2,7 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
+import type { BenchProtocol } from './protocol-types.js';
 import type { BenchScenarioRequest } from './types.js';
 import type { A2UIMessage } from '../../../agent/a2ui/a2ui-validator.js';
 import {
@@ -22,7 +23,7 @@ const UNSAFE_OPENUI_RESOURCE_URL =
   /(?:^|[\s("'=])(?:data|file|https?):(?:\/\/)?/iu;
 const UNSAFE_OPENUI_HOST_CALL = /\bopenUrl\s*\(/u;
 
-export type GenuiBenchProtocol = 'a2ui' | 'openui';
+export type GenuiBenchProtocol = BenchProtocol;
 type FetchLike = (
   input: string | URL,
   init?: RequestInit,
@@ -30,7 +31,7 @@ type FetchLike = (
 
 export type GenuiBenchJudgeArtifact =
   | { messages: A2UIMessage[]; protocol: 'a2ui' }
-  | { protocol: 'openui'; rawText: string };
+  | { protocol: 'openui' | 'lynx-xml'; rawText: string };
 
 export interface RunGenuiBenchUiJudgeOptions {
   model?: string;
@@ -155,6 +156,7 @@ export async function probeGenuiBenchUiJudge(
     : env.UI_JUDGE_OPENUI_BUNDLE_URL?.trim()
       ?? DEFAULT_OPENUI_BUNDLE_URL;
   return await probeBenchUiJudge({
+    ...(protocol === 'lynx-xml' ? { sourceKind: 'lynx-xml' as const } : {}),
     ...(bundleUrl ? { bundleUrl } : {}),
     env,
     ...(options.fetch ? { fetch: options.fetch } : {}),
@@ -194,7 +196,9 @@ export async function runGenuiBenchUiJudge(
   ) {
     return {
       errors: [
-        'ui-judge rejected OpenUI output containing an external resource URL or openUrl call.',
+        `ui-judge rejected ${
+          options.artifact.protocol === 'lynx-xml' ? 'Lynx XML' : 'OpenUI'
+        } output containing an external resource URL or openUrl call.`,
       ],
       score: 0,
       status: 'failed',
@@ -208,6 +212,9 @@ export async function runGenuiBenchUiJudge(
       runBenchUiJudgeRequest(
         {
           model: options.model,
+          ...(options.artifact.protocol === 'lynx-xml'
+            ? { lynxXmlSource: rawText }
+            : {}),
           globalProps: {
             benchMode: true,
             instant: true,

--- a/packages/genui/server/service/common/bench/protocol-adapter.ts
+++ b/packages/genui/server/service/common/bench/protocol-adapter.ts
@@ -21,6 +21,10 @@ export type ProtocolBenchJudgePayload =
   | {
     kind: 'openui-text';
     rawText: string;
+  }
+  | {
+    kind: 'lynx-xml-source';
+    rawText: string;
   };
 
 export interface ProtocolBenchAdapterInput {

--- a/packages/genui/server/service/common/bench/protocol-types.ts
+++ b/packages/genui/server/service/common/bench/protocol-types.ts
@@ -2,7 +2,7 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
-export const BENCH_PROTOCOLS = ['a2ui', 'openui'] as const;
+export const BENCH_PROTOCOLS = ['a2ui', 'openui', 'lynx-xml'] as const;
 
 export type BenchProtocol = (typeof BENCH_PROTOCOLS)[number];
 
@@ -34,6 +34,7 @@ export interface ProtocolBenchAttemptResult {
   validationErrors: string[];
   outputChars: number;
   finishReason?: unknown;
+  usage?: unknown;
 }
 
 export type ProtocolBenchEvaluationStatus = 'passed' | 'failed' | 'not-run';

--- a/packages/genui/server/service/common/bench/redaction.ts
+++ b/packages/genui/server/service/common/bench/redaction.ts
@@ -3,7 +3,10 @@
 // LICENSE file in the root directory of this source tree.
 
 import type { BenchProviderConfig } from './types.js';
-import { redactModelConfigSecrets } from '../model-config.js';
+import {
+  configuredModelName,
+  redactModelConfigSecrets,
+} from '../model-config.js';
 
 const PRIVATE_FIELD_NAMES = new Set([
   'apikey',
@@ -86,6 +89,13 @@ export function sanitizeBenchPublicValue(
   return Object.fromEntries(
     Object.entries(value).flatMap(([key, item]) => {
       const normalizedKey = key.replace(/[^a-z]/giu, '').toLowerCase();
+      // Public model names are already exposed by /models. A name can equal
+      // an upstream id, which remains private everywhere outside this field.
+      if (
+        key === 'model' && typeof item === 'string' && configuredModelName(item)
+      ) {
+        return [[key, item]];
+      }
       return PRIVATE_FIELD_NAMES.has(normalizedKey)
         ? []
         : [[

--- a/packages/genui/server/service/common/bench/request.ts
+++ b/packages/genui/server/service/common/bench/request.ts
@@ -14,6 +14,7 @@ import type {
   BenchVariable,
 } from './types.js';
 import { configuredModelName } from '../model-config.js';
+import { BENCH_PROTOCOLS } from './protocol-types.js';
 
 const MAX_GROUPS = 8;
 const MAX_SCENARIOS = 20;
@@ -30,7 +31,7 @@ const CATALOG_LABELS = new Set<BenchCatalogLabel>([
 ]);
 
 const ROLES = new Set<BenchRole>(['control', 'experiment']);
-const PROTOCOLS = new Set<BenchProtocol>(['a2ui', 'openui']);
+const PROTOCOLS = new Set<BenchProtocol>(BENCH_PROTOCOLS);
 const PROFILES = new Set<BenchProfile>(['native', 'matched-core']);
 const VARIABLES = new Set<BenchVariable>([
   'model',
@@ -297,6 +298,18 @@ export function normalizeBenchJobRequest(
     };
   }
 
+  if (
+    enabledGroups.some((group) =>
+      group.protocol === 'lynx-xml' && group.profile !== 'native'
+    )
+  ) {
+    return {
+      ok: false,
+      status: 400,
+      error: 'lynx-xml groups require the "native" profile',
+    };
+  }
+
   const scenarios = normalizeScenarios(value.scenarios);
   if (scenarios.length === 0) {
     return {
@@ -314,7 +327,10 @@ export function normalizeBenchJobRequest(
     * (settings.maxRepairAttempts + 1);
   if (
     (settings.judgeEnabled
-      || enabledGroups.some((group) => group.profile === 'matched-core'))
+      || enabledGroups.some((group) =>
+        group.profile === 'matched-core'
+        || group.protocol === 'lynx-xml'
+      ))
     && plannedGenerationAttempts > MAX_PLANNED_GENERATION_ATTEMPTS
   ) {
     return {

--- a/packages/genui/server/service/common/bench/runner.ts
+++ b/packages/genui/server/service/common/bench/runner.ts
@@ -23,6 +23,7 @@ import type {
   BenchRunResult,
   BenchScenarioRequest,
 } from './types.js';
+import { benchAttemptTokenCounts, readBenchTokenUsage } from './usage.js';
 import { createA2UIImageSourcePolicy } from '../../../agent/a2ui/a2ui-image-source-policy.js';
 import {
   formatErrorsForModel,
@@ -41,6 +42,7 @@ import type {
   BenchUiJudgeResult,
 } from '../../a2ui/a2ui-bench-judge.js';
 // import { runBenchPreview } from '../../a2ui/a2ui-bench-preview.js';
+import { createLynxXmlBenchAdapter } from '../../lynx-xml/lynx-xml-bench-adapter.js';
 import { createOpenUIBenchAdapter } from '../../openui/openui-bench-adapter.js';
 import { defaultModelName } from '../model-config.js';
 import type { ChatMessage } from '../types.js';
@@ -61,45 +63,9 @@ export interface BenchRunnerDependencies {
 
 type BenchJudgeCapabilities = Map<string, BenchUiJudgeCapability>;
 
-interface UsageRecord {
-  promptTokens?: unknown;
-  completionTokens?: unknown;
-  totalTokens?: unknown;
-  inputTokens?: unknown;
-  outputTokens?: unknown;
-  prompt_tokens?: unknown;
-  completion_tokens?: unknown;
-  total_tokens?: unknown;
-}
-
 function averagePlanned(values: number[], plannedRuns: number): number {
   if (plannedRuns === 0) return 0;
   return values.reduce((sum, value) => sum + value, 0) / plannedRuns;
-}
-
-function pickNumber(record: UsageRecord, keys: (keyof UsageRecord)[]): number {
-  for (const key of keys) {
-    const value = record[key];
-    if (typeof value === 'number' && Number.isFinite(value)) return value;
-  }
-  return 0;
-}
-
-function parseTotalTokens(usage: unknown): number {
-  if (!usage || typeof usage !== 'object') return 0;
-  const record = usage as UsageRecord;
-  const promptTokens = pickNumber(record, [
-    'promptTokens',
-    'inputTokens',
-    'prompt_tokens',
-  ]);
-  const completionTokens = pickNumber(record, [
-    'completionTokens',
-    'outputTokens',
-    'completion_tokens',
-  ]);
-  const totalTokens = pickNumber(record, ['totalTokens', 'total_tokens']);
-  return Math.round(totalTokens || promptTokens + completionTokens);
 }
 
 function protocolForGroup(group: BenchGroupRequest): BenchProtocol {
@@ -391,7 +357,7 @@ async function runA2UINativeOne(
       model: model ?? defaultModelName() ?? 'server default',
       catalog: catalogLabel,
       tokens: result.usage.reduce<number>(
-        (total, usage) => total + parseTotalTokens(usage),
+        (total, usage) => total + benchAttemptTokenCounts(usage).totalTokens,
         0,
       ),
       agentMs: Math.round(agentMs),
@@ -508,9 +474,11 @@ async function runProtocolAdapterOne(
   const protocol = protocolForGroup(item.group);
   const profile = profileForGroup(item.group);
   const model = pickRunModel(request, item.group);
-  const catalogLabel = profile === 'matched-core'
-    ? 'matched-core' as const
-    : pickRunCatalog(item.group);
+  const catalogLabel = protocol === 'lynx-xml'
+    ? 'none' as const
+    : (profile === 'matched-core'
+      ? 'matched-core' as const
+      : pickRunCatalog(item.group));
 
   store.emit(jobId, 'run-start', {
     runId,
@@ -569,7 +537,12 @@ async function runProtocolAdapterOne(
                 BenchRunResult['messages']
               >,
             }
-            : { protocol: 'openui', rawText: judgePayload.rawText },
+            : {
+              protocol: judgePayload.kind === 'lynx-xml-source'
+                ? 'lynx-xml'
+                : 'openui',
+              rawText: judgePayload.rawText,
+            },
           scenario: item.scenario,
           session: judgeCapability.session!,
           signal,
@@ -647,7 +620,10 @@ async function runProtocolAdapterOne(
         : {
           finishReason: attempts[attempts.length - 1]?.finishReason,
         }),
-      usage: { totalTokens: tokens },
+      usage: {
+        ...readBenchTokenUsage(attempts.map((attempt) => attempt.usage)),
+        totalTokens: tokens,
+      },
       ...(messages ? { messages } : {}),
       ...('screenshotDataUrl' in judge && judge.screenshotDataUrl
         ? { screenshotDataUrl: judge.screenshotDataUrl }
@@ -962,7 +938,9 @@ function resolveProtocolAdapters(
     adapters[protocol] = overrides?.[protocol]
       ?? (protocol === 'a2ui'
         ? createA2UIBenchAdapter()
-        : createOpenUIBenchAdapter());
+        : (protocol === 'openui'
+          ? createOpenUIBenchAdapter()
+          : createLynxXmlBenchAdapter()));
   }
   return adapters;
 }

--- a/packages/genui/server/service/common/bench/types.ts
+++ b/packages/genui/server/service/common/bench/types.ts
@@ -2,10 +2,11 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
+import type { BenchProtocol } from './protocol-types.js';
 import type { A2UIMessage } from '../../../agent/a2ui/a2ui-validator.js';
 
 export type BenchRole = 'control' | 'experiment';
-export type BenchProtocol = 'a2ui' | 'openui';
+export type { BenchProtocol } from './protocol-types.js';
 export type BenchProfile = 'native' | 'matched-core';
 export type BenchVariable =
   | 'model'
@@ -110,7 +111,7 @@ export interface BenchRunResult {
   status: 'complete' | 'failed';
   ok: boolean;
   model: string;
-  catalog: BenchCatalogLabel | 'matched-core';
+  catalog: BenchCatalogLabel | 'matched-core' | 'none';
   tokens: number;
   agentMs: number;
   fmpMs: number;

--- a/packages/genui/server/service/common/bench/usage.ts
+++ b/packages/genui/server/service/common/bench/usage.ts
@@ -1,0 +1,140 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+export interface BenchTokenUsage {
+  inputTokens?: number;
+  outputTokens?: number;
+  totalTokens?: number;
+  cachedTokens?: number;
+  cacheWriteTokens?: number;
+  reasoningTokens?: number;
+}
+
+const TOKEN_KEYS = [
+  'inputTokens',
+  'outputTokens',
+  'totalTokens',
+  'cachedTokens',
+  'cacheWriteTokens',
+  'reasoningTokens',
+] as const;
+
+function record(value: unknown): Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {};
+}
+
+function count(value: unknown): number | undefined {
+  const candidate = typeof value === 'object' ? record(value).total : value;
+  return typeof candidate === 'number' && Number.isFinite(candidate)
+      && candidate >= 0
+    ? candidate
+    : undefined;
+}
+
+function pick(value: unknown, keys: readonly string[]): number | undefined {
+  const source = record(value);
+  for (const key of keys) {
+    const result = count(source[key]);
+    if (result !== undefined) return result;
+  }
+  return undefined;
+}
+
+export function sumBenchTokenUsage(
+  usages: BenchTokenUsage[],
+  divisor = 1,
+): BenchTokenUsage {
+  const result: BenchTokenUsage = {};
+  if (usages.length === 0 || divisor <= 0) return result;
+  for (const key of TOKEN_KEYS) {
+    // A missing field in any call means the complete breakdown is unknown.
+    if (usages.every((usage) => usage[key] !== undefined)) {
+      result[key] = usages.reduce((sum, usage) => sum + usage[key]!, 0)
+        / divisor;
+    }
+  }
+  return result;
+}
+
+export function readBenchTokenUsage(value: unknown): BenchTokenUsage {
+  if (Array.isArray(value)) {
+    return sumBenchTokenUsage(value.map((item) => readBenchTokenUsage(item)));
+  }
+  const source = record(value);
+  const inputTokens = pick(source, [
+    'inputTokens',
+    'promptTokens',
+    'input_tokens',
+    'prompt_tokens',
+  ]);
+  const outputTokens = pick(source, [
+    'outputTokens',
+    'completionTokens',
+    'output_tokens',
+    'completion_tokens',
+  ]);
+  const totalTokens = pick(source, ['totalTokens', 'total_tokens'])
+    ?? (inputTokens !== undefined && outputTokens !== undefined
+      ? inputTokens + outputTokens
+      : undefined);
+  const inputDetails = [
+    source,
+    source.inputTokens,
+    source.inputTokenDetails,
+    source.inputTokensDetails,
+    source.input_tokens_details,
+    source.prompt_tokens_details,
+  ];
+  const outputDetails = [
+    source,
+    source.outputTokens,
+    source.outputTokenDetails,
+    source.outputTokensDetails,
+    source.output_tokens_details,
+    source.completion_tokens_details,
+  ];
+  const find = (values: unknown[], keys: string[]) =>
+    values.map((item) => pick(item, keys))
+      .find((item) => item !== undefined);
+  const cachedTokens = find(inputDetails, [
+    'cachedTokens',
+    'cached_tokens',
+    'cachedInputTokens',
+    'cached_input_tokens',
+    'cacheReadTokens',
+    'cacheRead',
+    'cache_read_input_tokens',
+  ]);
+  const cacheWriteTokens = find(inputDetails, [
+    'cacheWriteTokens',
+    'cacheWrite',
+    'cache_write_tokens',
+    'cache_creation_input_tokens',
+  ]);
+  const reasoningTokens = find(outputDetails, [
+    'reasoningTokens',
+    'reasoning_tokens',
+    'reasoning',
+  ]);
+  return {
+    ...(inputTokens === undefined ? {} : { inputTokens }),
+    ...(outputTokens === undefined ? {} : { outputTokens }),
+    ...(totalTokens === undefined ? {} : { totalTokens }),
+    ...(cachedTokens === undefined ? {} : { cachedTokens }),
+    ...(cacheWriteTokens === undefined ? {} : { cacheWriteTokens }),
+    ...(reasoningTokens === undefined ? {} : { reasoningTokens }),
+  };
+}
+
+export function benchAttemptTokenCounts(value: unknown) {
+  const usage = readBenchTokenUsage(value);
+  return {
+    inputTokens: usage.inputTokens ?? 0,
+    outputTokens: usage.outputTokens ?? 0,
+    totalTokens: usage.totalTokens
+      ?? (usage.inputTokens ?? 0) + (usage.outputTokens ?? 0),
+  };
+}

--- a/packages/genui/server/service/lynx-xml/lynx-xml-bench-adapter.ts
+++ b/packages/genui/server/service/lynx-xml/lynx-xml-bench-adapter.ts
@@ -1,0 +1,152 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { setTimeout as sleep } from 'node:timers/promises';
+
+import { getLynxXmlAgentService } from './lynx-xml-agent.js';
+import type { LynxXmlChatOptions } from './lynx-xml-agent.js';
+import { normalizeLynxXmlArtifact } from '../../agent/lynx-xml/lynx-xml-output.js';
+import type {
+  ProtocolBenchAdapter,
+  ProtocolBenchAdapterInput,
+} from '../common/bench/protocol-adapter.js';
+import type { ProtocolBenchAttemptResult } from '../common/bench/protocol-types.js';
+import { benchAttemptTokenCounts } from '../common/bench/usage.js';
+import type { ChatMessage } from '../common/types.js';
+
+export interface LynxXmlBenchAdapterOptions {
+  generateRaw?: (
+    messages: ChatMessage[],
+    options: LynxXmlChatOptions,
+    signal?: AbortSignal,
+  ) => Promise<{ text: string; usage: unknown; finishReason: unknown }>;
+  retryDelayMs?: number;
+}
+
+function buildPrompt(input: ProtocolBenchAdapterInput): string {
+  return [
+    'Generate one self-contained Lynx XML UI for the benchmark scenario below.',
+    `Scenario name: ${input.scenario.name}`,
+    `Scenario type: ${input.scenario.type}`,
+    `Scenario complexity: ${input.scenario.complexity}`,
+    input.scenario.action ? `Required action: ${input.scenario.action}` : '',
+    '',
+    input.scenario.prompt,
+    '',
+    'Return only the complete Lynx XML artifact, without benchmark metadata.',
+    'Use local content and interactions. Do not load external resources, open URLs, or use network requests. Use a non-image presentation for image requests.',
+  ].join('\n');
+}
+
+export function createLynxXmlBenchAdapter(
+  options: LynxXmlBenchAdapterOptions = {},
+): ProtocolBenchAdapter {
+  const generateRaw = options.generateRaw
+    ?? ((messages, chatOptions, signal) =>
+      getLynxXmlAgentService().generateRaw(
+        messages,
+        chatOptions,
+        undefined,
+        signal,
+      ));
+  const retryDelayMs = Number.isFinite(options.retryDelayMs)
+    ? Math.max(0, options.retryDelayMs!)
+    : 10_000;
+  return {
+    protocol: 'lynx-xml',
+    async generate(input, signal) {
+      signal?.throwIfAborted();
+      const messages: ChatMessage[] = [{
+        role: 'user',
+        content: buildPrompt(input),
+      }];
+      const attempts: ProtocolBenchAttemptResult[] = [];
+      const maxAttempts = Number.isFinite(input.maxAttempts)
+        ? Math.min(4, Math.max(1, Math.floor(input.maxAttempts)))
+        : 1;
+      let finalText = '';
+      let finalErrors: string[] = [];
+      let finalValid = false;
+      for (let index = 1; index <= maxAttempts; index++) {
+        signal?.throwIfAborted();
+        const startedAt = performance.now();
+        let generated;
+        try {
+          generated = await generateRaw(messages, {
+            ...input.provider,
+            resourceId: `genui-bench:${input.runId}:attempt-${index}`,
+            disableAgentCache: true,
+            enableWebSearch: false,
+            enableImageGeneration: false,
+            inheritReasoningEffort: false,
+          }, signal);
+          signal?.throwIfAborted();
+        } catch (error) {
+          signal?.throwIfAborted();
+          finalErrors = [
+            error instanceof Error ? error.message : String(error),
+          ];
+          attempts.push({
+            index,
+            durationMs: Math.round(performance.now() - startedAt),
+            ...benchAttemptTokenCounts(undefined),
+            valid: false,
+            validationErrors: [...finalErrors],
+            outputChars: 0,
+          });
+          if (index < maxAttempts) {
+            await sleep(retryDelayMs, undefined, { signal });
+          }
+          continue;
+        }
+
+        finalText = generated.text;
+        try {
+          finalText = normalizeLynxXmlArtifact(generated.text);
+          finalErrors = [];
+          finalValid = true;
+        } catch (error) {
+          finalErrors = [
+            error instanceof Error ? error.message : String(error),
+          ];
+        }
+        attempts.push({
+          index,
+          durationMs: Math.round(performance.now() - startedAt),
+          ...benchAttemptTokenCounts(generated.usage),
+          usage: generated.usage,
+          valid: finalValid,
+          validationErrors: [...finalErrors],
+          outputChars: generated.text.length,
+          finishReason: generated.finishReason,
+        });
+        if (finalValid) break;
+        if (index < maxAttempts) {
+          messages.push({ role: 'assistant', content: generated.text });
+          messages.push({
+            role: 'user',
+            content:
+              `Fix the following validation errors and return the complete Lynx XML artifact:\n${
+                finalErrors.join('\n')
+              }`,
+          });
+        }
+      }
+      return {
+        attempts,
+        finalValid,
+        finalText,
+        finalErrors,
+        ...(finalValid
+          ? {
+            judgePayload: {
+              kind: 'lynx-xml-source' as const,
+              rawText: finalText,
+            },
+          }
+          : {}),
+      };
+    },
+  };
+}

--- a/packages/genui/server/service/openui/openui-bench-adapter.ts
+++ b/packages/genui/server/service/openui/openui-bench-adapter.ts
@@ -25,6 +25,7 @@ import type {
   ProtocolBenchAttemptResult,
   ProtocolBenchScenario,
 } from '../common/bench/protocol-types.js';
+import { benchAttemptTokenCounts } from '../common/bench/usage.js';
 import type { ChatMessage } from '../common/types.js';
 
 export { OPENUI_BENCH_MATCHED_COMPONENTS, OPENUI_BENCH_ROOT_COMPONENT };
@@ -135,58 +136,8 @@ export const OPENUI_BENCH_PROMPT_OPTIONS: NonNullable<
   examples: [],
 };
 
-interface UsageRecord {
-  promptTokens?: unknown;
-  completionTokens?: unknown;
-  totalTokens?: unknown;
-  inputTokens?: unknown;
-  outputTokens?: unknown;
-  prompt_tokens?: unknown;
-  completion_tokens?: unknown;
-  total_tokens?: unknown;
-  input_tokens?: unknown;
-  output_tokens?: unknown;
-}
-
-function pickTokenCount(
-  usage: UsageRecord,
-  keys: (keyof UsageRecord)[],
-): number {
-  for (const key of keys) {
-    const value = usage[key];
-    if (typeof value === 'number' && Number.isFinite(value)) {
-      return Math.max(0, Math.round(value));
-    }
-  }
-  return 0;
-}
-
 export function normalizeOpenUIBenchUsage(usage: unknown): OpenUIBenchUsage {
-  if (usage === null || typeof usage !== 'object' || Array.isArray(usage)) {
-    return { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
-  }
-  const record = usage as UsageRecord;
-  const inputTokens = pickTokenCount(record, [
-    'inputTokens',
-    'promptTokens',
-    'input_tokens',
-    'prompt_tokens',
-  ]);
-  const outputTokens = pickTokenCount(record, [
-    'outputTokens',
-    'completionTokens',
-    'output_tokens',
-    'completion_tokens',
-  ]);
-  const reportedTotal = pickTokenCount(record, [
-    'totalTokens',
-    'total_tokens',
-  ]);
-  return {
-    inputTokens,
-    outputTokens,
-    totalTokens: reportedTotal || inputTokens + outputTokens,
-  };
+  return benchAttemptTokenCounts(usage);
 }
 
 function sumUsage(attempts: OpenUIBenchAttemptResult[]): OpenUIBenchUsage {

--- a/packages/genui/server/test/a2ui-bench-request.test.ts
+++ b/packages/genui/server/test/a2ui-bench-request.test.ts
@@ -26,6 +26,40 @@ function body(groups: unknown[]) {
 }
 
 describe('A2UI Bench request protocol groups', () => {
+  test('accepts Lynx XML native alongside both component protocols', () => {
+    const normalized = normalizeBenchJobRequest(body(
+      ['a2ui', 'openui', 'lynx-xml'].map((protocol) => ({
+        id: protocol,
+        protocol,
+        catalog: 'Core Catalog',
+        enabled: true,
+      })),
+    ));
+    expect(normalized.ok).toBe(true);
+    if (!normalized.ok) return;
+    expect(
+      normalized.request.groups.map((group) => [group.protocol, group.profile]),
+    ).toEqual([
+      ['a2ui', 'native'],
+      ['openui', 'matched-core'],
+      ['lynx-xml', 'native'],
+    ]);
+    expect(normalized.request.groups[2]).not.toHaveProperty('catalog');
+    expect(normalized.request.settings.parallelism).toBe(1);
+  });
+
+  test('rejects a matched-core profile for Lynx XML', () => {
+    expect(normalizeBenchJobRequest(body([{
+      id: 'xml',
+      protocol: 'lynx-xml',
+      profile: 'matched-core',
+    }]))).toMatchObject({
+      ok: false,
+      status: 400,
+      error: 'lynx-xml groups require the "native" profile',
+    });
+  });
+
   test('keeps legacy groups on the A2UI native profile', () => {
     const normalized = normalizeBenchJobRequest(
       body([{

--- a/packages/genui/server/test/a2ui-bench-runner.test.ts
+++ b/packages/genui/server/test/a2ui-bench-runner.test.ts
@@ -143,6 +143,87 @@ function screenshotDataUrlForBytes(bytes: number): string {
 }
 
 describe('A2UI Bench UI Judge integration', () => {
+  test('routes XML source to Judge and preserves XML results and summaries', async () => {
+    const rawText =
+      '<!doctype lynx><lynx engine-version="4.2"><script thread="main"></script></lynx>';
+    rstest.mocked(probeGenuiBenchUiJudge).mockResolvedValueOnce({
+      enabled: true,
+      session: { screenshotUrl: 'https://judge.example/screenshot/lynxml' },
+    });
+    rstest.mocked(runGenuiBenchUiJudge).mockResolvedValueOnce({
+      errors: [],
+      score: 4,
+      status: 'complete',
+      warnings: [],
+    });
+    const benchRequest = request();
+    benchRequest.groups = [{
+      ...group,
+      protocol: 'lynx-xml',
+      profile: 'native',
+      model: 'xml-model',
+    }];
+    const store = getBenchJobStore();
+    const job = store.createJob(benchRequest, 1);
+    await runBenchJob(job.id, {
+      adapters: {
+        'lynx-xml': {
+          protocol: 'lynx-xml',
+          generate: () =>
+            Promise.resolve({
+              attempts: [{
+                index: 1,
+                durationMs: 10,
+                inputTokens: 2,
+                outputTokens: 3,
+                totalTokens: 5,
+                usage: {
+                  inputTokens: 2,
+                  outputTokens: 3,
+                  inputTokenDetails: { cacheReadTokens: 1 },
+                },
+                valid: true,
+                validationErrors: [],
+                outputChars: rawText.length,
+              }],
+              finalValid: true,
+              finalText: rawText,
+              finalErrors: [],
+              judgePayload: { kind: 'lynx-xml-source', rawText },
+            }),
+        },
+      },
+    });
+    expect(runGenuiBenchUiJudge).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        model: 'xml-model',
+        artifact: { protocol: 'lynx-xml', rawText },
+      }),
+    );
+    const report = store.getJob(job.id)?.report;
+    expect(report?.results[0]).toMatchObject({
+      protocol: 'lynx-xml',
+      profile: 'native',
+      catalog: 'none',
+      text: rawText,
+      tokens: 5,
+      usage: {
+        inputTokens: 2,
+        outputTokens: 3,
+        totalTokens: 5,
+        cachedTokens: 1,
+      },
+      judgeScore: 4,
+      status: 'complete',
+      ok: true,
+    });
+    expect(report?.summaries[0]).toMatchObject({
+      protocol: 'lynx-xml',
+      profile: 'native',
+      judgeRunCount: 1,
+    });
+  });
+
   test('does not restore a cancelled job to running after the health probe', async () => {
     let resolveProbe:
       | ((capability: Awaited<ReturnType<typeof probeBenchUiJudge>>) => void)
@@ -479,6 +560,7 @@ describe('A2UI Bench UI Judge integration', () => {
               inputTokens: 7,
               outputTokens: 3,
               totalTokens: 10,
+              usage: { inputTokens: 7, outputTokens: 3, cachedTokens: 2 },
               valid: false,
               validationErrors: ['repair'],
               outputChars: 5,
@@ -489,6 +571,7 @@ describe('A2UI Bench UI Judge integration', () => {
               inputTokens: 11,
               outputTokens: 4,
               totalTokens: 15,
+              usage: { inputTokens: 11, outputTokens: 4, cachedTokens: 5 },
               valid: true,
               validationErrors: [],
               outputChars: 12,
@@ -536,6 +619,12 @@ describe('A2UI Bench UI Judge integration', () => {
       profile: 'matched-core',
       catalog: 'matched-core',
       tokens: 25,
+      usage: {
+        inputTokens: 18,
+        outputTokens: 7,
+        totalTokens: 25,
+        cachedTokens: 7,
+      },
       attempts: 2,
       judgeScore: 4.5,
       judgeStatus: 'complete',

--- a/packages/genui/server/test/bench-usage.test.ts
+++ b/packages/genui/server/test/bench-usage.test.ts
@@ -1,0 +1,80 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { describe, expect, test } from '@rstest/core';
+
+import { readBenchTokenUsage } from '../service/common/bench/usage.js';
+
+describe('Bench token usage', () => {
+  test('reads numeric SDK usage and provider cache/reasoning details without double counting', () => {
+    expect(
+      readBenchTokenUsage({
+        prompt_tokens: 100,
+        completion_tokens: 20,
+        total_tokens: 120,
+        prompt_tokens_details: { cached_tokens: 70 },
+        completion_tokens_details: { reasoning_tokens: 8 },
+        cache_creation_input_tokens: 10,
+      }),
+    ).toEqual({
+      inputTokens: 100,
+      outputTokens: 20,
+      totalTokens: 120,
+      cachedTokens: 70,
+      cacheWriteTokens: 10,
+      reasoningTokens: 8,
+    });
+    expect(
+      readBenchTokenUsage({
+        inputTokens: 100,
+        outputTokens: 20,
+        inputTokenDetails: { cacheReadTokens: 0, cacheWriteTokens: 10 },
+        outputTokenDetails: { reasoningTokens: 8 },
+      }),
+    ).toEqual({
+      inputTokens: 100,
+      outputTokens: 20,
+      totalTokens: 120,
+      cachedTokens: 0,
+      cacheWriteTokens: 10,
+      reasoningTokens: 8,
+    });
+  });
+  test('accumulates nested SDK usage across repair attempts', () => {
+    const usage = {
+      inputTokens: { total: 100, cacheRead: 60, cacheWrite: 10 },
+      outputTokens: { total: 20, reasoning: 8 },
+    };
+    expect(readBenchTokenUsage([usage, usage])).toEqual({
+      inputTokens: 200,
+      outputTokens: 40,
+      totalTokens: 240,
+      cachedTokens: 120,
+      cacheWriteTokens: 20,
+      reasoningTokens: 16,
+    });
+  });
+  test('does not turn missing or partial usage into zero cache misses', () => {
+    expect(readBenchTokenUsage({ totalTokens: 42 })).toEqual({
+      totalTokens: 42,
+    });
+    expect(
+      readBenchTokenUsage([{
+        inputTokens: 10,
+        outputTokens: 5,
+        cachedTokens: 0,
+      }, { inputTokens: 10, outputTokens: 5 }]),
+    ).toEqual({ inputTokens: 20, outputTokens: 10, totalTokens: 30 });
+    expect(
+      readBenchTokenUsage([undefined, { inputTokens: 10, outputTokens: 5 }]),
+    ).toEqual({});
+    expect(
+      readBenchTokenUsage({
+        inputTokens: -1,
+        outputTokens: Number.NaN,
+        cachedTokens: '10',
+      }),
+    ).toEqual({});
+    expect(readBenchTokenUsage([])).toEqual({});
+  });
+});

--- a/packages/genui/server/test/genui-bench-judge.test.ts
+++ b/packages/genui/server/test/genui-bench-judge.test.ts
@@ -64,6 +64,20 @@ function geqiResponse(score: number): {
 }
 
 describe('probeGenuiBenchUiJudge', () => {
+  test('uses source capture for Lynx XML without any bundle configuration', async () => {
+    const capability = await probeGenuiBenchUiJudge('lynx-xml', {
+      env: {
+        UI_JUDGE_BUNDLE_URL: 'invalid-bundle',
+        UI_JUDGE_SERVER_URL: 'http://judge.test',
+      },
+      fetch: () => Promise.resolve(Response.json({ status: 'ok' })),
+    });
+    expect(capability).toEqual({
+      enabled: true,
+      session: { screenshotUrl: 'http://judge.test/screenshot/lynxml' },
+    });
+  });
+
   test('selects the OpenUI bundle independently', async () => {
     const capability = await probeGenuiBenchUiJudge('openui', {
       env: {
@@ -103,6 +117,58 @@ describe('probeGenuiBenchUiJudge', () => {
 });
 
 describe('runGenuiBenchUiJudge', () => {
+  test('captures Lynx XML as multipart source and scores the converted PNG', async () => {
+    const rawText =
+      '<!doctype lynx><lynx engine-version="4.2"><script thread="main">const page = __CreatePage("0", 0);</script></lynx>';
+    const result = await runGenuiBenchUiJudge({
+      artifact: { protocol: 'lynx-xml', rawText },
+      model: 'xml-model',
+      scenario: { prompt: 'Build a greeting' },
+      session: { screenshotUrl: 'http://judge.test/screenshot/lynxml' },
+      timeoutMs: 10_000,
+    }, (input, init) => {
+      expect(String(input)).toBe('http://judge.test/screenshot/lynxml');
+      expect(init?.body).toBeInstanceOf(FormData);
+      expect([...(init?.body as FormData).entries()]).toEqual([
+        ['entry', 'index.lynxml'],
+        ['source', rawText],
+        ['width', '390'],
+        ['height', '844'],
+      ]);
+      expect(new Headers(init?.headers).get('Content-Type')).toBeNull();
+      return Promise.resolve(evaluationResponse(geqiResponse(4)));
+    });
+    expect(result).toMatchObject({
+      status: 'complete',
+      score: 4,
+      geqiScore: 80,
+    });
+    expect(evaluateScreenshot).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        model: 'xml-model',
+        task: 'Build a greeting',
+        screenshotDataUrl: expect.stringMatching(
+          /^data:image\/png;base64,/u,
+        ) as unknown,
+      }),
+    );
+  });
+
+  test('rejects external XML resources before calling the screenshot service', async () => {
+    const capture = rstest.fn();
+    const result = await runGenuiBenchUiJudge({
+      artifact: {
+        protocol: 'lynx-xml',
+        rawText:
+          '<style>.hero { background-image: url("https://assets.test/image.png"); }</style>',
+      },
+      scenario: { prompt: 'Build a card' },
+      session: { screenshotUrl: 'http://judge.test/screenshot/lynxml' },
+    }, capture);
+    expect(capture).not.toHaveBeenCalled();
+    expect(result.status).toBe('failed');
+  });
+
   test('injects OpenUI source into the OpenUI bundle', async () => {
     let body: unknown;
     const result = await runGenuiBenchUiJudge(

--- a/packages/genui/server/test/lynx-xml-bench-adapter.test.ts
+++ b/packages/genui/server/test/lynx-xml-bench-adapter.test.ts
@@ -1,0 +1,106 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { describe, expect, test } from '@rstest/core';
+
+import type { ProtocolBenchAdapterInput } from '../service/common/bench/protocol-adapter.js';
+import type { ChatMessage } from '../service/common/types.js';
+import { createLynxXmlBenchAdapter } from '../service/lynx-xml/lynx-xml-bench-adapter.js';
+
+const SOURCE =
+  '<!doctype lynx>\n<lynx engine-version="4.2"><script thread="main">const page = __CreatePage("0", 0);</script></lynx>';
+const INPUT: ProtocolBenchAdapterInput = {
+  runId: 'xml-run',
+  pairId: 'pair-1',
+  scenario: {
+    id: 'greeting',
+    name: 'Greeting',
+    type: 'Information',
+    complexity: 1,
+    prompt: 'Show Hello',
+    action: 'Refresh',
+  },
+  repeatIndex: 1,
+  maxAttempts: 2,
+  provider: { model: 'test-model' },
+};
+
+describe('Lynx XML Bench adapter', () => {
+  test('repairs the document contract and preserves token usage and source', async () => {
+    const conversations: ChatMessage[][] = [];
+    const controller = new AbortController();
+    const adapter = createLynxXmlBenchAdapter({
+      generateRaw(messages, options, signal) {
+        conversations.push([...messages]);
+        expect(signal).toBe(controller.signal);
+        expect(options).toMatchObject({
+          model: 'test-model',
+          disableAgentCache: true,
+          enableWebSearch: false,
+          enableImageGeneration: false,
+          inheritReasoningEffort: false,
+        });
+        return Promise.resolve({
+          text: conversations.length === 1
+            ? '<!doctype lynx>'
+            : `\`\`\`xml\n${SOURCE}\n\`\`\``,
+          usage: {
+            inputTokens: { total: 12, cacheRead: 5, cacheWrite: 0 },
+            outputTokens: { total: 8, reasoning: 2 },
+          },
+          finishReason: 'stop',
+        });
+      },
+    });
+    const artifact = await adapter.generate(INPUT, controller.signal);
+    expect(artifact.attempts[0]?.usage).toMatchObject({
+      inputTokens: { total: 12, cacheRead: 5, cacheWrite: 0 },
+    });
+    expect(conversations.map((messages) => messages.length)).toEqual([1, 3]);
+    expect(conversations[0]?.[0]?.content).toContain(
+      'Required action: Refresh',
+    );
+    expect(conversations[1]?.[2]?.content).toContain('closing </lynx>');
+    expect(
+      artifact.attempts.map((attempt) => [attempt.valid, attempt.totalTokens]),
+    ).toEqual([[false, 20], [true, 20]]);
+    expect(artifact).toMatchObject({
+      finalValid: true,
+      finalText: SOURCE,
+      finalErrors: [],
+      judgePayload: { kind: 'lynx-xml-source', rawText: SOURCE },
+    });
+  });
+
+  test('bounds transport retries and never supplies invalid output to Judge', async () => {
+    let calls = 0;
+    const adapter = createLynxXmlBenchAdapter({
+      retryDelayMs: 0,
+      generateRaw() {
+        calls++;
+        return Promise.reject(new Error('provider unavailable'));
+      },
+    });
+    const artifact = await adapter.generate({ ...INPUT, maxAttempts: 99 });
+    expect(calls).toBe(4);
+    expect(artifact.finalValid).toBe(false);
+    expect(artifact.finalErrors).toEqual(['provider unavailable']);
+    expect(artifact.judgePayload).toBeUndefined();
+  });
+
+  test('cancels transport backoff before another request', async () => {
+    const controller = new AbortController();
+    let calls = 0;
+    const adapter = createLynxXmlBenchAdapter({
+      generateRaw() {
+        calls++;
+        setTimeout(() => controller.abort(), 0);
+        return Promise.reject(new Error('provider unavailable'));
+      },
+    });
+    await expect(adapter.generate(INPUT, controller.signal)).rejects
+      .toMatchObject({ name: 'AbortError' });
+    expect(calls).toBe(1);
+  });
+});

--- a/packages/genui/server/test/model-config.test.ts
+++ b/packages/genui/server/test/model-config.test.ts
@@ -7,7 +7,10 @@ import { describe, expect, test } from '@rstest/core';
 import { createLLMProvider } from '../agent/common/openai-provider.js';
 import { errorMessage } from '../app/common/errors.js';
 import { pickProviderOptions } from '../app/common/provider-options.js';
-import { redactBenchText } from '../service/common/bench/redaction.js';
+import {
+  redactBenchText,
+  sanitizeBenchPublicValue,
+} from '../service/common/bench/redaction.js';
 import {
   GENUI_MODEL_CONFIG_ENV,
   configuredModelName,
@@ -35,6 +38,31 @@ const CONFIG = {
 };
 
 describe('GenUI model configuration', () => {
+  test('preserves configured public Bench model names even when they equal upstream ids', () => {
+    const previous = process.env[GENUI_MODEL_CONFIG_ENV];
+    const name = 'doubao-seed-upstream';
+    process.env[GENUI_MODEL_CONFIG_ENV] = JSON.stringify({
+      ...CONFIG,
+      [name]: { ...CONFIG['Doubao Seed'], default: false },
+    });
+    try {
+      expect(sanitizeBenchPublicValue({
+        groups: [{ model: name }],
+        results: [{ model: name, error: `${name} seed-secret` }],
+        unknown: { model: 'doubao-pro-upstream' },
+        apiKey: 'seed-secret',
+        baseURL: 'https://seed.example.com/api/v3',
+      }, {})).toEqual({
+        groups: [{ model: name }],
+        results: [{ model: name, error: '[REDACTED] [REDACTED]' }],
+        unknown: { model: '[REDACTED]' },
+      });
+    } finally {
+      if (previous === undefined) delete process.env[GENUI_MODEL_CONFIG_ENV];
+      else process.env[GENUI_MODEL_CONFIG_ENV] = previous;
+    }
+  });
+
   test('parses a provider config map keyed by public model name', () => {
     expect(parseModelConfig(JSON.stringify(CONFIG))).toEqual({
       defaultModel: 'Doubao Seed',


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Lynx XML as a Bench comparison protocol, with native rendering, XML capture, validation, retries, and UI Judge scoring.
  - Added detailed token usage views covering input, output, cache, reasoning, totals, and cache hit rates.
  - Added support for preserving comparison settings, model names, usage data, and Lynx XML results in reports.
- **Documentation**
  - Updated Bench guidance and README content for Lynx XML comparisons, token metrics, scoring, and report behavior.
- **Bug Fixes**
  - Improved recovery of model and comparison details when report identifiers are redacted or unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
