### PR TITLE
fix(react): schedule Element Template effects as microtasks

### DIFF
--- a/packages/react/runtime/__test__/element-template/runtime/background/root-render.test.tsx
+++ b/packages/react/runtime/__test__/element-template/runtime/background/root-render.test.tsx
@@ -1,3 +1,4 @@
+import { options } from 'preact';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { resetElementTemplateCommitState } from '../../../../src/element-template/background/commit-hook.js';
@@ -12,7 +13,7 @@ import {
   isElementTemplateRendering,
 } from '../../../../src/element-template/background/render-scope.js';
 import { callDestroyLifetimeFun } from '../../../../src/element-template/native/callDestroyLifetimeFun.js';
-import { root, useState } from '../../../../src/element-template/index.js';
+import { root, useEffect, useState } from '../../../../src/element-template/index.js';
 import { clearRefState, flushPendingRefs } from '../../../../src/element-template/prop-adapters/ref.js';
 import { __root } from '../../../../src/element-template/runtime/page/root-instance.js';
 import { __ElementTemplatePage } from '../../../../src/element-template/runtime/page/authored-page.js';
@@ -59,6 +60,58 @@ describe('ElementTemplate root render timing', () => {
     const { performance } = lynx;
     expect(performance.profileStart).toHaveBeenCalledWith('ReactLynx::renderBackground');
     expect(performance.profileEnd).toHaveBeenCalled();
+  });
+
+  it('flushes passive effects and ordinary unmount cleanup without waiting for a frame', async () => {
+    const calls: string[] = [];
+    function App() {
+      useEffect(() => {
+        calls.push('effect');
+        return () => {
+          calls.push('cleanup');
+        };
+      }, []);
+      return null;
+    }
+
+    root.render(<App />);
+    expect(calls).toEqual([]);
+
+    // Only drain microtasks: act() replaces Preact's scheduler, and the existing
+    // waitSchedule() also waits for frames and timers, hiding this regression.
+    await Promise.resolve();
+    expect(calls).toEqual(['effect']);
+
+    root.render(null);
+    expect(calls).toEqual(['effect']);
+
+    await Promise.resolve();
+    expect(calls).toEqual(['effect', 'cleanup']);
+  });
+
+  it('flushes passive cleanup synchronously on background destroy', async () => {
+    const effect = vi.fn();
+    const cleanup = vi.fn();
+    function App() {
+      useEffect(() => {
+        effect();
+        return cleanup;
+      }, []);
+      return null;
+    }
+
+    root.render(<App />);
+    await Promise.resolve();
+    expect(effect).toHaveBeenCalledTimes(1);
+    expect(cleanup).not.toHaveBeenCalled();
+
+    const scheduler = options.requestAnimationFrame;
+    callDestroyLifetimeFun();
+    expect(cleanup).toHaveBeenCalledTimes(1);
+    expect(options.requestAnimationFrame).toBe(scheduler);
+
+    await Promise.resolve();
+    expect(cleanup).toHaveBeenCalledTimes(1);
   });
 
   it('keeps render scope hook installation idempotent', () => {

--- a/packages/react/runtime/src/element-template/native/index.ts
+++ b/packages/react/runtime/src/element-template/native/index.ts
@@ -3,7 +3,7 @@
 // LICENSE file in the root directory of this source tree.
 import '@lynx-js/react/hooks';
 import type { ComponentChild, ContainerNode, VNode } from 'preact';
-import { render } from 'preact';
+import { options, render } from 'preact';
 
 import { callDestroyLifetimeFun } from './callDestroyLifetimeFun.js';
 import { injectCalledByNative } from './main-thread-api.js';
@@ -14,6 +14,7 @@ import { runWithForceRootRender } from '../../core/forceRootRender.js';
 import { updateGlobalProps as updateGlobalPropsCore } from '../../core/globalProps.js';
 import { installMainThreadHooks } from '../../core/hooks/mainThreadImpl.js';
 import { updateCardData } from '../../core/lynx-update-data.js';
+import { lynxQueueMicrotask } from '../../utils.js';
 import { installElementTemplateCommitHook } from '../background/commit-hook.js';
 import { setupBackgroundElementTemplateDocument } from '../background/document.js';
 import { installElementTemplateHydrationListener } from '../background/hydration-listener.js';
@@ -63,6 +64,7 @@ function init(): void {
   }
 
   if (__BACKGROUND__) {
+    options.requestAnimationFrame = lynxQueueMicrotask;
     console.log('experimental_useElementTemplate:', __USE_ELEMENT_TEMPLATE__);
     setRoot(new BackgroundPageRootInstance());
     setupBackgroundElementTemplateDocument();


### PR DESCRIPTION
Element Template leaves Preact's passive-effect scheduler on its frame/timer fallback, delaying `useEffect` callbacks and ordinary unmount cleanups compared with Snapshot.

Configure the scheduler during Element Template background initialization to use the existing `lynxQueueMicrotask` helper. Passive effects and ordinary unmount cleanups remain asynchronous, while page destruction continues to flush cleanups synchronously and restores the scheduler afterward. Regression tests render through the public Element Template hooks and drain only microtasks, so the frame/timer fallback cannot hide missing initialization.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).

No changeset is required for this unpublished Element Template implementation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved background rendering so passive effects and unmount cleanup are processed promptly after microtasks complete.
  - Ensured cleanup runs synchronously when background content is destroyed, preventing delayed teardown behavior.
  - Preserved existing animation-frame scheduling behavior while improving effect handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->