### PR TITLE
fix(react): reuse the host runtime in standalone Element Template bundles

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -39,18 +39,22 @@
     },
     "./element-template": {
       "types": "./runtime/lib/element-template/index.d.ts",
+      "lazy": "./runtime/lazy/element-template.js",
       "default": "./runtime/lib/element-template/index.js"
     },
     "./element-template/internal": {
       "types": "./runtime/lib/element-template/internal.d.ts",
+      "lazy": "./runtime/lazy/element-template-internal.js",
       "default": "./runtime/lib/element-template/internal.js"
     },
     "./element-template/jsx-runtime": {
       "types": "./runtime/lib/element-template/jsx-runtime/index.d.ts",
+      "lazy": "./runtime/lazy/element-template-jsx-runtime.js",
       "default": "./runtime/lib/element-template/jsx-runtime/index.js"
     },
     "./element-template/jsx-dev-runtime": {
       "types": "./runtime/lib/element-template/jsx-dev-runtime/index.d.ts",
+      "lazy": "./runtime/lazy/element-template-jsx-dev-runtime.js",
       "default": "./runtime/lib/element-template/jsx-dev-runtime/index.js"
     },
     "./jsx-runtime": {

--- a/packages/react/runtime/__test__/element-template/imports/suspense-lazy.test.ts
+++ b/packages/react/runtime/__test__/element-template/imports/suspense-lazy.test.ts
@@ -249,4 +249,47 @@ describe('element-template Suspense and lazy imports', () => {
     expect(lazyLegacyReactRuntime.default).toBe(legacyReactRuntime.default);
     expect(lazyLegacyReactRuntime.Component).toBe(legacyReactRuntime.Component);
   });
+
+  it('reuses host exports without reinitializing the runtime in standalone producers', async () => {
+    clearLazyTargetSymbols();
+    vi.resetModules();
+    await import('../../../lazy/element-template-import.js');
+
+    const appDescriptors = Object.getOwnPropertyDescriptors(lynx.getApp());
+    const target = lynx as typeof lynx & Record<symbol, unknown>;
+    const entries = [
+      [await import('../../../lazy/element-template.js'), target[sExportsReact]],
+      [await import('../../../lazy/element-template-internal.js'), target[sExportsReactInternal]],
+      [await import('../../../lazy/element-template-jsx-runtime.js'), target[sExportsJSXRuntime]],
+      [await import('../../../lazy/element-template-jsx-dev-runtime.js'), target[sExportsJSXDevRuntime]],
+    ] as const;
+
+    for (const [producer, host] of entries) {
+      expect(Object.keys(producer).sort()).toEqual(Object.keys(host as object).sort());
+      for (const [name, value] of Object.entries(producer)) {
+        expect(value).toBe((host as Record<string, unknown>)[name]);
+      }
+    }
+    expect(Object.getOwnPropertyDescriptors(lynx.getApp())).toEqual(appDescriptors);
+  });
+
+  it.each([
+    '../../../lazy/element-template.js',
+    '../../../lazy/element-template-internal.js',
+    '../../../lazy/element-template-jsx-runtime.js',
+    '../../../lazy/element-template-jsx-dev-runtime.js',
+  ])('rejects a Snapshot host before reading exports from %s', async (entry) => {
+    clearLazyTargetSymbols();
+    vi.resetModules();
+    Object.defineProperty(lynx, sRuntimeBackend, {
+      value: 'Snapshot',
+      configurable: true,
+    });
+    const appDescriptors = Object.getOwnPropertyDescriptors(lynx.getApp());
+
+    await expect(import(entry)).rejects.toThrow(
+      'Snapshot and Element Template templates cannot share lazy bundles.',
+    );
+    expect(Object.getOwnPropertyDescriptors(lynx.getApp())).toEqual(appDescriptors);
+  });
 });

--- a/packages/react/runtime/__test__/element-template/vitest.config.ts
+++ b/packages/react/runtime/__test__/element-template/vitest.config.ts
@@ -107,7 +107,7 @@ const config: UserConfigExport = defineConfig({
     name: 'react/runtime-et',
     include: ['**/__test__/element-template/**/*.{test,spec}.{js,ts,jsx,tsx}'],
     coverage: {
-      include: ['src/element-template/**'],
+      include: ['src/element-template/**', 'lazy/element-template*.js'],
       exclude: [
         'src/element-template/**/*.d.ts',
         'src/element-template/protocol/types.ts',

--- a/packages/react/runtime/lazy/element-template-internal.js
+++ b/packages/react/runtime/lazy/element-template-internal.js
@@ -1,0 +1,35 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import {
+  RUNTIME_BACKEND_ELEMENT_TEMPLATE,
+  registerLazyRuntimeBackend,
+  sExportsReactInternal,
+  target,
+} from './target.js';
+
+registerLazyRuntimeBackend(RUNTIME_BACKEND_ELEMENT_TEMPLATE);
+
+export const {
+  Component,
+  SnapshotInstance,
+  __ElementTemplatePage,
+  __dynamicImport,
+  __etAttrPlanMap,
+  __root,
+  adaptEventAttrSlot,
+  adaptMTEventAttrSlot,
+  adaptMTRefAttrSlot,
+  adaptRefAttrSlot,
+  adaptSpreadAttrSlot,
+  loadDynamicJS,
+  loadLazyBundle,
+  loadWorkletRuntime,
+  options,
+  process,
+  registerWorkletOnBackground,
+  transformToWorklet,
+  withInitDataInState,
+  wrapWithLynxComponent,
+} = target[sExportsReactInternal];

--- a/packages/react/runtime/lazy/element-template-jsx-dev-runtime.js
+++ b/packages/react/runtime/lazy/element-template-jsx-dev-runtime.js
@@ -1,0 +1,19 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import {
+  RUNTIME_BACKEND_ELEMENT_TEMPLATE,
+  registerLazyRuntimeBackend,
+  sExportsJSXDevRuntime,
+  target,
+} from './target.js';
+
+registerLazyRuntimeBackend(RUNTIME_BACKEND_ELEMENT_TEMPLATE);
+
+export const {
+  Fragment,
+  jsx,
+  jsxDEV,
+  jsxs,
+} = target[sExportsJSXDevRuntime];

--- a/packages/react/runtime/lazy/element-template-jsx-runtime.js
+++ b/packages/react/runtime/lazy/element-template-jsx-runtime.js
@@ -1,0 +1,14 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { RUNTIME_BACKEND_ELEMENT_TEMPLATE, registerLazyRuntimeBackend, sExportsJSXRuntime, target } from './target.js';
+
+registerLazyRuntimeBackend(RUNTIME_BACKEND_ELEMENT_TEMPLATE);
+
+export const {
+  Fragment,
+  jsx,
+  jsxDEV,
+  jsxs,
+} = target[sExportsJSXRuntime];

--- a/packages/react/runtime/lazy/element-template.js
+++ b/packages/react/runtime/lazy/element-template.js
@@ -1,0 +1,53 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { RUNTIME_BACKEND_ELEMENT_TEMPLATE, registerLazyRuntimeBackend, sExportsReact, target } from './target.js';
+
+registerLazyRuntimeBackend(RUNTIME_BACKEND_ELEMENT_TEMPLATE);
+
+export const {
+  Children,
+  Component,
+  Fragment,
+  InitDataConsumer,
+  InitDataProvider,
+  GlobalPropsConsumer,
+  GlobalPropsProvider,
+  MainThreadRef,
+  PureComponent,
+  Suspense,
+  cloneElement,
+  createContext,
+  createElement,
+  createRef,
+  forwardRef,
+  isValidElement,
+  lazy,
+  memo,
+  root,
+  runOnBackground,
+  runOnMainThread,
+  useCallback,
+  useContext,
+  useDebugValue,
+  useEffect,
+  useErrorBoundary,
+  useId,
+  useImperativeHandle,
+  useInitData,
+  useInitDataChanged,
+  useLynxGlobalEventListener,
+  useGlobalProps,
+  useGlobalPropsChanged,
+  useLayoutEffect,
+  useMainThreadRef,
+  useMemo,
+  useReducer,
+  useRef,
+  useState,
+  useSyncExternalStore,
+  withInitDataInState,
+} = target[sExportsReact];
+
+export default target[sExportsReact]['default'];

--- a/packages/react/runtime/vitest.config.ts
+++ b/packages/react/runtime/vitest.config.ts
@@ -126,7 +126,7 @@ export default defineConfig({
         'debug',
         'jsx-runtime',
         'jsx-dev-runtime',
-        'lazy/element-template-import.js',
+        'lazy/element-template*.js',
         'lepus/jsx-dev-runtime',
         'lepus/index.d.ts',
         'vitest.config.ts',

--- a/packages/rspeedy/plugin-react/test/fixtures/standalone-lazy-bundle/element-template.tsx
+++ b/packages/rspeedy/plugin-react/test/fixtures/standalone-lazy-bundle/element-template.tsx
@@ -1,9 +1,10 @@
-import { root, useEffect, useState } from '@lynx-js/react'
+import React, { root, useEffect, useState } from '@lynx-js/react'
 import { __root, options } from '@lynx-js/react/internal'
 import { jsx } from '@lynx-js/react/jsx-runtime'
 import { jsxDEV } from '@lynx-js/react/jsx-dev-runtime'
 
 export const runtime = {
+  default: React,
   root,
   useEffect,
   useState,

--- a/packages/rspeedy/plugin-react/test/fixtures/standalone-lazy-bundle/element-template.tsx
+++ b/packages/rspeedy/plugin-react/test/fixtures/standalone-lazy-bundle/element-template.tsx
@@ -1,0 +1,22 @@
+import { root, useEffect, useState } from '@lynx-js/react'
+import { __root, options } from '@lynx-js/react/internal'
+import { jsx } from '@lynx-js/react/jsx-runtime'
+import { jsxDEV } from '@lynx-js/react/jsx-dev-runtime'
+
+export const runtime = {
+  root,
+  useEffect,
+  useState,
+  __root,
+  options,
+  jsx,
+  jsxDEV,
+}
+
+function Empty() {
+  return null
+}
+
+export default function LazyBundleComp() {
+  return <Empty />
+}

--- a/packages/rspeedy/plugin-react/test/lazy.test.ts
+++ b/packages/rspeedy/plugin-react/test/lazy.test.ts
@@ -5,6 +5,7 @@ import fs from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { runInNewContext } from 'node:vm'
 
 import type { RsbuildPlugin, Rspack } from '@rsbuild/core'
 import { describe, expect, rstest, test } from '@rstest/core'
@@ -26,6 +27,7 @@ import { pluginStubRspeedyAPI } from './stub-rspeedy-api.plugin.js'
 function withLeakedCoverageCountersStubbed<T>(
   code: string,
   run: () => T,
+  counterTarget: Record<string, unknown> = globalThis,
 ): T {
   type CoverageCounterSink = () => CoverageCounterSink
   const sink: CoverageCounterSink = new Proxy(
@@ -38,8 +40,8 @@ function withLeakedCoverageCountersStubbed<T>(
   ) as unknown as CoverageCounterSink
   const added: string[] = []
   for (const name of new Set(code.match(/\bcov_\d+\b/g) ?? [])) {
-    if (!(name in globalThis)) {
-      ;(globalThis as Record<string, unknown>)[name] = () => sink
+    if (!(name in counterTarget)) {
+      counterTarget[name] = () => sink
       added.push(name)
     }
   }
@@ -47,7 +49,7 @@ function withLeakedCoverageCountersStubbed<T>(
     return run()
   } finally {
     for (const name of added) {
-      delete (globalThis as Record<string, unknown>)[name]
+      delete counterTarget[name]
     }
   }
 }
@@ -220,6 +222,190 @@ describe('Lazy', () => {
       expect(exports['default'].name).toBe('LazyBundleComp')
 
       rstest.unstubAllEnvs()
+    })
+  })
+  ;(['development', 'production'] as const).forEach(mode => {
+    test(`Element Template standalone lazy bundle reuses the host runtime in ${mode}`, async () => {
+      rstest.stubEnv('NODE_ENV', mode)
+      const { pluginReactLynx } = await import('../src/pluginReactLynx.js')
+      const tmpRoot = fileURLToPath(
+        new URL('../../../../.tmp/', import.meta.url),
+      )
+      await fs.mkdir(tmpRoot, { recursive: true })
+      const tmp = await fs.mkdtemp(
+        path.join(tmpRoot, 'rspeedy-react-test-et-standalone-'),
+      )
+      let backgroundCode = ''
+      let mainThreadCode = ''
+
+      try {
+        const rsbuild = await createRspeedy({
+          rspeedyConfig: {
+            mode,
+            source: {
+              entry: {
+                main: fileURLToPath(
+                  new URL(
+                    './fixtures/standalone-lazy-bundle/element-template.tsx',
+                    import.meta.url,
+                  ),
+                ),
+              },
+            },
+            dev: { hmr: false, liveReload: false },
+            output: { distPath: { root: tmp } },
+            plugins: [
+              pluginReactLynx({
+                experimental_isLazyBundle: true,
+                experimental_useElementTemplate: true,
+              }),
+            ],
+            tools: {
+              rspack: {
+                plugins: [{
+                  name: 'capture-standalone-et-runtime',
+                  apply(compiler) {
+                    compiler.hooks.compilation.tap(
+                      'capture-standalone-et-runtime',
+                      compilation => {
+                        const hooks = LynxTemplatePlugin
+                          .getLynxTemplatePluginHooks(
+                            compilation as unknown as Parameters<
+                              typeof LynxTemplatePlugin.getLynxTemplatePluginHooks
+                            >[0],
+                          )
+                        hooks.beforeEmit.tap(
+                          'capture-standalone-et-runtime',
+                          args => {
+                            mainThreadCode = args.finalEncodeOptions.lepusCode
+                              ?.root ?? ''
+                            const manifest = args.finalEncodeOptions.manifest
+                            const background = Object.keys(manifest).find(
+                              name => /background.*?\.js$/.test(name),
+                            )
+                            backgroundCode = background
+                              ? manifest[background]!
+                              : ''
+                            return args
+                          },
+                        )
+                      },
+                    )
+                  },
+                } as Rspack.RspackPluginInstance],
+              },
+            },
+          },
+        })
+        await rsbuild.build()
+        expect(backgroundCode).not.toBe('')
+        expect(mainThreadCode).not.toBe('')
+
+        for (const thread of ['background', 'main-thread']) {
+          const app = {
+            callDestroyLifetimeFun: rstest.fn(),
+            publishEvent: rstest.fn(),
+            publicComponentEvent: rstest.fn(),
+            updateGlobalProps: rstest.fn(),
+            updateCardData: rstest.fn(),
+            onAppReload: rstest.fn(),
+          }
+          const originalCallbacks = { ...app }
+          const vnode = {}
+          const host = {
+            root: { render: rstest.fn() },
+            useEffect: rstest.fn(),
+            useState: rstest.fn(),
+            __root: {},
+            options: {},
+            jsx: rstest.fn(() => vnode),
+            jsxDEV: rstest.fn(() => vnode),
+          }
+          // The emitted module reads the real lazy ABI. A finite host makes any
+          // accidental native initialization fail instead of absorbing it.
+          const target: Record<string | symbol, unknown> = {
+            bundleSupportLoadScript: true,
+            Promise,
+            getApp: () => app,
+          }
+          const backend = Symbol.for('__REACT_LYNX_RUNTIME_BACKEND__')
+          target[backend] = 'Element Template'
+          for (
+            const [entry, value] of Object.entries({
+              '@lynx-js/react': host,
+              '@lynx-js/react/lepus': host,
+              '@lynx-js/react/internal': host,
+              '@lynx-js/react/jsx-runtime': host,
+              '@lynx-js/react/jsx-dev-runtime': host,
+            })
+          ) {
+            target[Symbol.for(`__REACT_LYNX_EXPORTS__(${entry})`)] = value
+          }
+
+          const execute = () => {
+            const lynx = target
+            const factories = new Map<string, (...args: unknown[]) => void>()
+            const tt = {
+              define: (name: string, factory: (...args: unknown[]) => void) => {
+                factories.set(name, factory)
+              },
+              require: (name: string) => {
+                const mockModule = { exports: {} }
+                const args: unknown[] = Array(18).fill(undefined)
+                args[1] = mockModule
+                args[2] = mockModule.exports
+                args[10] = console
+                args[16] = lynx
+                factories.get(name)!(...args)
+                return mockModule.exports
+              },
+            }
+            const code = thread === 'background'
+              ? backgroundCode
+              : mainThreadCode
+            return withLeakedCoverageCountersStubbed(code, () => {
+              if (thread === 'background') {
+                const bundle = runInNewContext(code, target) as {
+                  init: (context: { tt: typeof tt }) => unknown
+                }
+                return bundle.init({ tt })
+              }
+              const bundle = runInNewContext(code, target) as (
+                entry: string,
+              ) => unknown
+              return bundle('standalone-et')
+            }, target) as {
+              runtime: typeof host
+              default: () => unknown
+            }
+          }
+
+          const bundleExports = execute()
+          for (const key of Object.keys(host) as (keyof typeof host)[]) {
+            expect(bundleExports.runtime[key]).toBe(host[key])
+          }
+          expect(bundleExports.default()).toBe(vnode)
+          for (const key of Object.keys(app) as (keyof typeof app)[]) {
+            expect(app[key]).toBe(originalCallbacks[key])
+            expect(app[key]).not.toHaveBeenCalled()
+          }
+
+          Object.defineProperty(target, backend, {
+            value: 'Snapshot',
+            configurable: true,
+          })
+          expect(execute).toThrow(
+            'Snapshot and Element Template templates cannot share lazy bundles.',
+          )
+          expect(target[backend]).toBe('Snapshot')
+          for (const key of Object.keys(app) as (keyof typeof app)[]) {
+            expect(app[key]).toBe(originalCallbacks[key])
+          }
+        }
+      } finally {
+        rstest.unstubAllEnvs()
+        await fs.rm(tmp, { recursive: true, force: true })
+      }
     })
   })
 

--- a/packages/rspeedy/plugin-react/test/lazy.test.ts
+++ b/packages/rspeedy/plugin-react/test/lazy.test.ts
@@ -312,14 +312,20 @@ describe('Lazy', () => {
           }
           const originalCallbacks = { ...app }
           const vnode = {}
-          const host = {
+          const hostReact = {
+            default: {},
             root: { render: rstest.fn() },
             useEffect: rstest.fn(),
             useState: rstest.fn(),
-            __root: {},
-            options: {},
-            jsx: rstest.fn(() => vnode),
-            jsxDEV: rstest.fn(() => vnode),
+          }
+          const hostInternal = { __root: {}, options: {} }
+          const hostJSX = { jsx: rstest.fn(() => vnode) }
+          const hostJSXDev = { jsxDEV: rstest.fn(() => vnode) }
+          const expectedRuntime = {
+            ...hostReact,
+            ...hostInternal,
+            ...hostJSX,
+            ...hostJSXDev,
           }
           // The emitted module reads the real lazy ABI. A finite host makes any
           // accidental native initialization fail instead of absorbing it.
@@ -332,11 +338,11 @@ describe('Lazy', () => {
           target[backend] = 'Element Template'
           for (
             const [entry, value] of Object.entries({
-              '@lynx-js/react': host,
-              '@lynx-js/react/lepus': host,
-              '@lynx-js/react/internal': host,
-              '@lynx-js/react/jsx-runtime': host,
-              '@lynx-js/react/jsx-dev-runtime': host,
+              '@lynx-js/react': hostReact,
+              '@lynx-js/react/lepus': {},
+              '@lynx-js/react/internal': hostInternal,
+              '@lynx-js/react/jsx-runtime': hostJSX,
+              '@lynx-js/react/jsx-dev-runtime': hostJSXDev,
             })
           ) {
             target[Symbol.for(`__REACT_LYNX_EXPORTS__(${entry})`)] = value
@@ -375,14 +381,18 @@ describe('Lazy', () => {
               ) => unknown
               return bundle('standalone-et')
             }, target) as {
-              runtime: typeof host
+              runtime: typeof expectedRuntime
               default: () => unknown
             }
           }
 
           const bundleExports = execute()
-          for (const key of Object.keys(host) as (keyof typeof host)[]) {
-            expect(bundleExports.runtime[key]).toBe(host[key])
+          for (
+            const key of Object.keys(
+              expectedRuntime,
+            ) as (keyof typeof expectedRuntime)[]
+          ) {
+            expect(bundleExports.runtime[key]).toBe(expectedRuntime[key])
           }
           expect(bundleExports.default()).toBe(vnode)
           for (const key of Object.keys(app) as (keyof typeof app)[]) {


### PR DESCRIPTION
Standalone Element Template producers currently resolve the ET root and internal imports to the full runtime, even with `experimental_isLazyBundle: true`. Loading such a bundle can initialize a second runtime and replace callbacks owned by the host page.

Add the `lazy` export condition for the four ET entry points and forward their exports through the existing host runtime symbols. The producer reuses the host's root, hooks, internal helpers, and thread-specific JSX runtime without bootstrapping another runtime. Each ET bridge checks the backend before reading host exports, preserving rejection of Snapshot/ET mismatches in production.

This fixes the existing standalone configuration; no new option is needed:

```js
pluginReactLynx({
  experimental_isLazyBundle: true,
  experimental_useElementTemplate: true,
})
```

The change covers standalone producer isolation. FetchBundle support and the external/UMD integration matrix remain separate work.

## Verification

Verified at `4efcdb883` after rebasing onto the framework logical VDOM adaptation in #3536.

- Full workspace build: 74/74 tasks passed.
- Runtime tests: Snapshot 799 passed (2 skipped, 4 todo), Core 56 passed, ET 820 passed. Snapshot and ET coverage gates passed at 100%.
- `plugin-react` tests with coverage: 217 passed, 1 skipped. The standalone regression builds development and production bundles, executes their background and main-thread scripts, and checks host export identity, preservation of host callbacks, and rejection of backend mismatches.

The production `examples/react-et-lazy-bundle-standalone` example also passed an iOS simulator smoke test using LynxExplorer with the matching native logical VDOM implementation. The page rendered `LazyComponent` with its yellow, bold styling; `add`, `minus`, `dynamic`, and the nested dynamic import loaded and returned the expected results. No hydration error appeared in the tested session. This covers loading, rendering, CSS, and dynamic imports; the example has no state/props update or unmount/remount interaction.

A controlled production build comparison kept the same framework baseline and changed only the aliases resolved through the four new lazy export conditions back to their default ET implementation paths:

| Bundle | Default ET entry resolution | Lazy bridges |
| --- | ---: | ---: |
| Example `dynamic.lynx.bundle` | 79,512 B | 9,000 B |
| Four-entry regression fixture | 93,849 B | 8,534 B |
| Example `LazyComponent.lynx.bundle` | 4,992 B | 5,086 B |

With default entry resolution, the dynamic bundle embeds ET initialization, including background-thread host callback assignments and main-thread native creation calls. With the lazy bridges, both threads read `__dynamicImport` from the host internal exports and omit that initialization. The static component's template definition and CSS remain identical; its small size increase comes with the bridge/backend check. No additional JSX/template compiler change is needed.

The comparison inspected the final encoder inputs and verified that the captured encoded buffers matched the emitted bundle files. The dynamic background script retrieved from the simulator independently confirmed the host internal bridge and absence of the callback initialization assignments. Executing the captured regression fixture preserved host identities and callbacks on both threads; restoring default entry resolution made both executions fail. These results do not cover the external/UMD integration matrix.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).

No changeset is required for this unpublished Element Template implementation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added lazy runtime support for Element Template React, internal, and JSX entry points.
  * Standalone lazy bundles now reuse the host runtime without reinitializing it.
  * Added validation to prevent Element Template and Snapshot templates from sharing lazy bundles.
  * Improved runtime export mapping for standalone lazy bundles.

* **Tests**
  * Added coverage for runtime reuse, backend compatibility, export mappings, and development/production lazy bundles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->