### PR TITLE
fix(rsbuild-plugin): keep a plugin-set dev.assetPrefix

### DIFF
--- a/.changeset/dev-asset-prefix-plugin.md
+++ b/.changeset/dev-asset-prefix-plugin.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/rsbuild-plugin": patch
+---
+
+Fix `dev.assetPrefix` set by another plugin being replaced with the dev server address. It was resolved from the original user config only, so a plugin pointing the Lynx client at a proxy or a tunnel had its value silently discarded.

--- a/packages/rspeedy/core/test/config/dev/asset-prefix.test.ts
+++ b/packages/rspeedy/core/test/config/dev/asset-prefix.test.ts
@@ -1,0 +1,61 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import type { RsbuildPlugin } from '@rsbuild/core'
+import { describe, expect, test } from '@rstest/core'
+
+import { createStubRspeedy } from '../../createStubRspeedy.js'
+
+const pluginAssetPrefix = {
+  name: 'test:asset-prefix',
+  setup(api) {
+    api.modifyRsbuildConfig((config, { mergeRsbuildConfig }) =>
+      mergeRsbuildConfig(config, { dev: { assetPrefix: 'http://my-cdn/' } })
+    )
+  },
+} satisfies RsbuildPlugin
+
+describe('dev.assetPrefix', () => {
+  test('defaults to the dev server address', async () => {
+    const rspeedy = await createStubRspeedy({ mode: 'development' })
+
+    const config = await rspeedy.unwrapConfig()
+
+    expect(config.output?.publicPath).toMatch(/^http:\/\/.+:3000\/$/)
+  })
+
+  test('keeps a value set by a plugin', async () => {
+    const rspeedy = await createStubRspeedy({
+      mode: 'development',
+      plugins: [pluginAssetPrefix],
+    })
+
+    const config = await rspeedy.unwrapConfig()
+
+    expect(config.output?.publicPath).toBe('http://my-cdn/')
+  })
+
+  test('a plugin wins over the config', async () => {
+    const rspeedy = await createStubRspeedy({
+      mode: 'development',
+      dev: { assetPrefix: 'http://from-config/' },
+      plugins: [pluginAssetPrefix],
+    })
+
+    const config = await rspeedy.unwrapConfig()
+
+    expect(config.output?.publicPath).toBe('http://my-cdn/')
+  })
+
+  test('server.base does not count as a plugin-set value', async () => {
+    const rspeedy = await createStubRspeedy({
+      mode: 'development',
+      server: { base: '/sub' },
+    })
+
+    const config = await rspeedy.unwrapConfig()
+
+    expect(config.output?.publicPath).toMatch(/^http:\/\/.+:3000\/sub\/$/)
+  })
+})

--- a/packages/rspeedy/plugin-lynx/src/plugins/dev.plugin.ts
+++ b/packages/rspeedy/plugin-lynx/src/plugins/dev.plugin.ts
@@ -72,7 +72,9 @@ export function pluginDev(): RsbuildPlugin {
             originalServer?.host,
           )
 
-          let assetPrefix = original.dev?.assetPrefix
+          let assetPrefix = config.dev?.assetPrefix === config.server?.base
+            ? undefined
+            : config.dev?.assetPrefix
 
           switch (typeof assetPrefix) {
             case 'string': {

--- a/packages/rspeedy/plugin-lynx/test/dev.plugin.test.ts
+++ b/packages/rspeedy/plugin-lynx/test/dev.plugin.test.ts
@@ -303,6 +303,59 @@ describe('pluginDev', () => {
     expect(rsbuild.getRsbuildConfig().dev!.client!.host).toBe('10.0.0.2')
   })
 
+  test('dev.assetPrefix set by a plugin is kept', async () => {
+    const rsbuild = await createDevStubRsbuild({
+      plugins: [
+        {
+          name: 'test:asset-prefix',
+          setup(api) {
+            api.modifyRsbuildConfig((config, { mergeRsbuildConfig }) =>
+              mergeRsbuildConfig(config, {
+                dev: { assetPrefix: 'http://my-cdn/' },
+              })
+            )
+          },
+        } satisfies RsbuildPlugin,
+      ],
+    })
+
+    const config = await rsbuild.unwrapConfig()
+
+    expect(config.output?.publicPath).toBe('http://my-cdn/')
+  })
+
+  test('dev.assetPrefix set by a plugin wins over the config', async () => {
+    const rsbuild = await createDevStubRsbuild({
+      dev: { assetPrefix: 'http://from-config/' },
+      plugins: [
+        {
+          name: 'test:asset-prefix',
+          setup(api) {
+            api.modifyRsbuildConfig((config, { mergeRsbuildConfig }) =>
+              mergeRsbuildConfig(config, {
+                dev: { assetPrefix: 'http://my-cdn/' },
+              })
+            )
+          },
+        } satisfies RsbuildPlugin,
+      ],
+    })
+
+    const config = await rsbuild.unwrapConfig()
+
+    expect(config.output?.publicPath).toBe('http://my-cdn/')
+  })
+
+  test('server.base does not count as a plugin-set dev.assetPrefix', async () => {
+    const rsbuild = await createDevStubRsbuild({
+      server: { base: '/sub' },
+    })
+
+    const config = await rsbuild.unwrapConfig()
+
+    expect(config.output!.publicPath as string).toMatch(/^http:\/\/.+\/sub\/$/)
+  })
+
   test('provide HMR variables', async () => {
     const rsbuild = await createDevStubRsbuild()
 


### PR DESCRIPTION
`pluginDev` resolved `dev.assetPrefix` from the original user config only, so a value another plugin had already merged into the config was replaced with `http://<lan-ip>:<port>/`. Its handler runs at `order: 'post'` because it needs the final `server.host`, so the value was overwritten under both CLIs.

It now falls back to the value in the current config when that differs from the `server.base` Rsbuild derives the default from.

Follow-up to #3865 and #3866, from auditing the remaining config-modifying hooks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved development asset prefixes configured by plugins, including proxy and tunnel addresses.
  - Ensured user-configured asset prefixes take precedence over plugin-provided values.
  - Corrected development public path resolution when only a server base path is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->