### PR TITLE
fix(web-elements): align inline SVG layout with images

### DIFF
--- a/.changeset/tidy-svg-text-layout.md
+++ b/.changeset/tidy-svg-text-layout.md
@@ -1,0 +1,5 @@
+---
+'@lynx-js/web-elements': patch
+---
+
+Apply inline image layout styles to `x-svg` inside text and custom truncation content.

--- a/.github/web-elements-x-text.instructions.md
+++ b/.github/web-elements-x-text.instructions.md
@@ -4,6 +4,8 @@ applyTo: "packages/web-platform/web-elements/src/elements/XText/**"
 
 When updating `x-text` truncation measurement, keep text-like inline containers such as `x-text`, `inline-text`, `raw-text`, and `lynx-wrapper` transparent so their descendants are measured with DFS. Treat `x-view` as one atomic inline box; measuring both the `x-view` and its child boxes can double-count inline views and make one visual line look like multiple lines.
 
+Keep `x-svg` alongside `x-image` in text layout selectors, including `lynx-wrapper` and `inline-truncation` contexts. Both render through an `img` shadow part and use the existing generic element handling in `XTextTruncation` for character counting and clipping.
+
 Text selection changes originate from `document.selectionchange`. Attach that listener through the element-reactive event enablement hook so it only exists while `selectionchange` is bound, track the exact `Document` used for registration so node adoption removes the listener from the original document, and dispatch the Lynx-facing event from the target text element without bubbling to avoid feeding it back into the document listener.
 
 When reading a selection inside a shadow tree, keep the direct anchor/focus path for browsers that expose the text nodes, but fall back to `Selection.getComposedRanges({ shadowRoots })` when those endpoints are retargeted outside the text element. WebKit may report a non-empty selected string while `document.getSelection()` exposes collapsed endpoints at the shadow host.

--- a/packages/web-platform/web-elements/src/elements/XText/x-text.css
+++ b/packages/web-platform/web-elements/src/elements/XText/x-text.css
@@ -68,16 +68,22 @@ inline-truncation > lynx-wrapper > x-text {
 
 x-text > inline-image,
 x-text > x-image,
+x-text > x-svg,
 inline-truncation > inline-image,
 inline-truncation > x-image,
+inline-truncation > x-svg,
 inline-text > inline-image,
 inline-text > x-image,
+inline-text > x-svg,
 x-text > lynx-wrapper > inline-image,
 x-text > lynx-wrapper > x-image,
+x-text > lynx-wrapper > x-svg,
 inline-truncation > lynx-wrapper > inline-image,
 inline-truncation > lynx-wrapper > x-image,
+inline-truncation > lynx-wrapper > x-svg,
 inline-text > lynx-wrapper > inline-image,
-inline-text > lynx-wrapper > x-image {
+inline-text > lynx-wrapper > x-image,
+inline-text > lynx-wrapper > x-svg {
   display: contents !important;
 }
 
@@ -118,9 +124,13 @@ inline-image::part(img) {
 }
 
 x-text > x-image::part(img),
+x-text > x-svg::part(img),
 x-text > lynx-wrapper > x-image::part(img),
+x-text > lynx-wrapper > x-svg::part(img),
 inline-truncation > x-image::part(img),
-inline-truncation > lynx-wrapper > x-image::part(img) {
+inline-truncation > x-svg::part(img),
+inline-truncation > lynx-wrapper > x-image::part(img),
+inline-truncation > lynx-wrapper > x-svg::part(img) {
   display: inline-block;
   height: inherit !important;
   width: inherit !important;
@@ -159,11 +169,13 @@ x-text[text-selection] > inline-text,
 x-text[text-selection] > x-text,
 x-text[text-selection] > inline-image,
 x-text[text-selection] > x-image,
+x-text[text-selection] > x-svg,
 x-text[text-selection] > inline-truncation,
 x-text[text-selection] > lynx-wrapper > inline-text,
 x-text[text-selection] > lynx-wrapper > x-text,
 x-text[text-selection] > lynx-wrapper > inline-image,
 x-text[text-selection] > lynx-wrapper > x-image,
+x-text[text-selection] > lynx-wrapper > x-svg,
 x-text[text-selection] > lynx-wrapper > inline-truncation {
   -webkit-user-select: auto;
   user-select: auto;

--- a/packages/web-platform/web-elements/tests/x-svg-inline.spec.ts
+++ b/packages/web-platform/web-elements/tests/x-svg-inline.spec.ts
@@ -4,8 +4,8 @@
 import { expect, test } from '@lynx-js/playwright-fixtures';
 import type { Page } from '@playwright/test';
 
-const goto = async (page: Page) => {
-  await page.goto('/tests/fixtures/x-text/inline-image.html', {
+const goto = async (page: Page, fixtureName: string) => {
+  await page.goto(`/tests/fixtures/x-text/${fixtureName}.html`, {
     waitUntil: 'load',
   });
   await page.evaluate(() => document.fonts.ready);
@@ -14,7 +14,7 @@ const goto = async (page: Page) => {
 for (const parent of ['x-text', 'inline-truncation']) {
   for (const wrapped of [false, true]) {
     test(`x-svg inline layout in ${parent}, wrapped=${wrapped}`, async ({ page }) => {
-      await goto(page);
+      await goto(page, 'inline-image');
       await page.evaluate(({ parent, wrapped }) => {
         document.body.replaceChildren();
         const src = 'data:image/svg+xml,'
@@ -113,7 +113,7 @@ for (const parent of ['x-text', 'inline-truncation']) {
 }
 
 test('x-svg counts as one character and is restored after truncation changes', async ({ page }) => {
-  await goto(page);
+  await goto(page, 'inline-image');
   await page.evaluate(() => {
     const text = document.querySelector('x-text')!;
     text.replaceChildren();
@@ -142,11 +142,7 @@ test('x-svg counts as one character and is restored after truncation changes', a
 
 test('x-svg sizes custom line truncation like x-image', async ({ page }) => {
   await page.setViewportSize({ width: 390, height: 844 });
-  await page.goto(
-    '/tests/fixtures/x-text/inline-truncation-with-inline-image.html',
-    { waitUntil: 'load' },
-  );
-  await page.evaluate(() => document.fonts.ready);
+  await goto(page, 'inline-truncation-with-inline-image');
   const truncation = page.locator('inline-truncation');
   await expect(truncation).toBeVisible();
   const before = await truncation.boundingBox();

--- a/packages/web-platform/web-elements/tests/x-svg-inline.spec.ts
+++ b/packages/web-platform/web-elements/tests/x-svg-inline.spec.ts
@@ -1,0 +1,165 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { expect, test } from '@lynx-js/playwright-fixtures';
+import type { Page } from '@playwright/test';
+
+const goto = async (page: Page) => {
+  await page.goto('/tests/fixtures/x-text/inline-image.html', {
+    waitUntil: 'load',
+  });
+  await page.evaluate(() => document.fonts.ready);
+};
+
+for (const parent of ['x-text', 'inline-truncation']) {
+  for (const wrapped of [false, true]) {
+    test(`x-svg inline layout in ${parent}, wrapped=${wrapped}`, async ({ page }) => {
+      await goto(page);
+      await page.evaluate(({ parent, wrapped }) => {
+        document.body.replaceChildren();
+        const src = 'data:image/svg+xml,'
+          + encodeURIComponent(
+            '<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100"><rect width="100" height="100" fill="green"/></svg>',
+          );
+        for (const tag of ['x-image', 'x-svg']) {
+          const text = document.createElement('x-text');
+          text.id = `${tag}-text`;
+          text.style.cssText =
+            'width: 240px; font-size: 20px; line-height: 40px';
+          text.setAttribute('text-selection', 'true');
+          let container: HTMLElement = text;
+          if (parent === 'inline-truncation') {
+            text.setAttribute('x-show-inline-truncation', '');
+            container = document.createElement(parent);
+            text.append(container);
+          }
+          container.append('Before');
+          if (wrapped) {
+            const wrapper = document.createElement('lynx-wrapper');
+            container.append(wrapper);
+            container = wrapper;
+          }
+          const image = document.createElement(tag);
+          image.setAttribute('src', src);
+          image.style.cssText =
+            'width: 28px; height: 24px; margin: 2px 7px; vertical-align: middle; border: 2px solid blue; border-radius: 4px; background-color: red';
+          container.append(image, 'After');
+          document.body.append(text);
+        }
+      }, { parent, wrapped });
+      if (parent === 'inline-truncation') {
+        await page.locator('x-text').evaluateAll(elements => {
+          for (const element of elements) {
+            element.setAttribute('x-show-inline-truncation', '');
+          }
+        });
+      }
+
+      const geometry = () =>
+        page.evaluate(() => {
+          return ['x-image', 'x-svg'].map(tag => {
+            const host = document.querySelector(tag)!;
+            const img = host.shadowRoot!.querySelector('img')!;
+            const rect = img.getBoundingClientRect();
+            const textRect = document.querySelector(`#${tag}-text`)!
+              .getBoundingClientRect();
+            const style = getComputedStyle(img);
+            return {
+              x: rect.x - textRect.x,
+              y: rect.y - textRect.y,
+              width: rect.width,
+              height: rect.height,
+              textHeight: textRect.height,
+              margin: style.margin,
+              verticalAlign: style.verticalAlign,
+              border: style.border,
+              borderRadius: style.borderRadius,
+              backgroundColor: style.backgroundColor,
+            };
+          });
+        });
+
+      await expect(page.locator('x-svg')).toHaveCSS('display', 'contents');
+      await expect(page.locator('x-svg').locator('img')).toHaveCSS(
+        'width',
+        '28px',
+      );
+      const [image, svg] = await geometry();
+      expect(svg).toEqual(image);
+
+      await page.locator('x-image, x-svg').evaluateAll(elements => {
+        for (const element of elements) {
+          (element as HTMLElement).style.width = '42px';
+          (element as HTMLElement).style.verticalAlign = 'bottom';
+        }
+      });
+      await expect(page.locator('x-svg').locator('img')).toHaveCSS(
+        'width',
+        '42px',
+      );
+      const [updatedImage, updatedSvg] = await geometry();
+      expect(updatedSvg).toEqual(updatedImage);
+      if (parent === 'x-text') {
+        expect(
+          await page.locator('x-svg').evaluate(element => {
+            const style = getComputedStyle(element);
+            return style.getPropertyValue('user-select')
+              || style.getPropertyValue('-webkit-user-select');
+          }),
+        ).toMatch(/^(auto|text)$/);
+      }
+    });
+  }
+}
+
+test('x-svg counts as one character and is restored after truncation changes', async ({ page }) => {
+  await goto(page);
+  await page.evaluate(() => {
+    const text = document.querySelector('x-text')!;
+    text.replaceChildren();
+    const svg = document.createElement('x-svg');
+    svg.style.cssText = 'width: 22px; height: 22px';
+    svg.setAttribute(
+      'content',
+      '<svg xmlns="http://www.w3.org/2000/svg" width="22" height="22"><circle cx="11" cy="11" r="10" fill="green"/></svg>',
+    );
+    text.append('A', svg, 'BC');
+    text.setAttribute('text-maxlength', '2');
+  });
+  const text = page.locator('x-text');
+  const svg = page.locator('x-svg');
+  await expect(text).toHaveText('A');
+  await expect(svg.locator('img')).toBeVisible();
+
+  await text.evaluate(element => element.setAttribute('text-maxlength', '1'));
+  await expect(svg).toHaveAttribute('x-text-clipped', '');
+  await expect(svg.locator('img')).toBeHidden();
+
+  await text.evaluate(element => element.removeAttribute('text-maxlength'));
+  await expect(svg).not.toHaveAttribute('x-text-clipped');
+  await expect(svg.locator('img')).toBeVisible();
+});
+
+test('x-svg sizes custom line truncation like x-image', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto(
+    '/tests/fixtures/x-text/inline-truncation-with-inline-image.html',
+    { waitUntil: 'load' },
+  );
+  await page.evaluate(() => document.fonts.ready);
+  const truncation = page.locator('inline-truncation');
+  await expect(truncation).toBeVisible();
+  const before = await truncation.boundingBox();
+  await page.locator('x-image').evaluate(image => {
+    const svg = document.createElement('x-svg');
+    svg.setAttribute('style', image.getAttribute('style')!);
+    svg.setAttribute(
+      'content',
+      '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12"><rect width="12" height="12" fill="green"/></svg>',
+    );
+    image.replaceWith(svg);
+  });
+  await expect(truncation.locator('x-svg').locator('img')).toBeVisible();
+  await expect.poll(() => truncation.boundingBox()).toEqual(before);
+  await expect(page.locator('x-text')).toHaveAttribute('x-text-clipped', '');
+});


### PR DESCRIPTION
`x-svg` inside `x-text` missed the inline image styles, so SVGs did not follow the same text flow, sizing, margins, and alignment as `x-image`. Apply the existing image selectors to SVGs, including `lynx-wrapper`, inline text, custom truncation content, and text selection.

Add browser regression coverage comparing SVG and image geometry, dynamic style updates, character-count clipping and SVG visibility restoration, and custom truncation sizing. Include a patch changeset for `@lynx-js/web-elements`.

The existing generic TypeScript element handling applies to both image types. Its shared limitation of measuring host rectangles rather than the shadow image is outside this change's scope.

## Validation

- `pnpm turbo build`: 74 tasks passed.
- `pnpm --filter @lynx-js/web-elements exec playwright test tests/x-svg-inline.spec.ts --reporter=line --workers=3`: 18 tests passed across Chromium, Firefox, and WebKit.
- `pnpm turbo api-extractor -- --local`: passed.
- dprint and `git diff --check`: passed.
- `pnpm changeset status --since=origin/main`: passed.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved inline SVG rendering within text content to match inline image behavior.
  - Corrected SVG sizing and layout in wrapped text and custom truncation scenarios.
  - Ensured inline SVGs count as a single character for text-length truncation and reappear when truncation limits are removed.

- **Documentation**
  - Added guidance for text truncation measurement and text selection handling, including inline SVG layout behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->