### PR TITLE
fix(rsbuild-plugin): respect selected environments when printing URLs

### DIFF
--- a/.changeset/quiet-urls-filter.md
+++ b/.changeset/quiet-urls-filter.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/rsbuild-plugin": patch
+---
+
+Use the active Rsbuild environments and their resolved entries when printing dev server URLs. This fixes startup failures when `--environment` excludes an environment declared in the configuration.

--- a/.github/rspeedy-networking.instructions.md
+++ b/.github/rspeedy-networking.instructions.md
@@ -3,3 +3,5 @@ applyTo: "packages/rspeedy/plugin-lynx/**/dev.plugin*.ts"
 ---
 
 Keep automatically selected dev-server bind addresses separate from client-facing hostnames. Bind IPv4 on `0.0.0.0` and IPv6 on `::`, while using the detected concrete address for asset and HMR URLs. Do not narrow the listener to the advertised address because loopback clients use a different local address.
+
+Resolve printed bundle URLs from the active environment contexts at print time. Environments collected during `modifyRsbuildConfig` may later be excluded by `--environment`; use the resolved environment entries so root entries remain merged with environment-specific entries.

--- a/packages/rspeedy/core/test/createStubRspeedy.ts
+++ b/packages/rspeedy/core/test/createStubRspeedy.ts
@@ -23,9 +23,11 @@ interface RsbuildHelper {
 export async function createStubRspeedy(
   config: Config,
   cwd?: string,
+  environment: string[] = [],
 ): Promise<RspeedyInstance & RsbuildHelper> {
   const rsbuild = await createRspeedy({
     rspeedyConfig: config,
+    environment,
     // Pin to the package root: rstest's cwd differs between per-package runs
     // and the root CI run, which would make cwd-derived snapshots unstable.
     cwd: cwd ?? path.join(path.dirname(fileURLToPath(import.meta.url)), '..'),

--- a/packages/rspeedy/core/test/plugins/dev.plugin.test.ts
+++ b/packages/rspeedy/core/test/plugins/dev.plugin.test.ts
@@ -848,6 +848,36 @@ describe('Plugins - Dev', () => {
     })
   })
 
+  test.each(['lynx', 'web'])('dev respects --environment %s', async (name) => {
+    const rsbuild = await createStubRspeedy(
+      {
+        source: {
+          entry: path.resolve(__dirname, './fixtures/hello-world/index.js'),
+        },
+        dev: { assetPrefix: 'http://example.com:<port>/' },
+        environments: { web: {}, lynx: {} },
+      },
+      undefined,
+      [name],
+    )
+    const printed = capturePrintUrls(rsbuild)
+    await using server = await rsbuild.usingDevServer()
+    await server.waitDevCompileDone()
+    expect(printed.urls).toStrictEqual([
+      {
+        label: name === 'lynx' ? 'Lynx' : 'Web',
+        url: `http://example.com:${server.port}/main.${name}.bundle`,
+      },
+      ...(name === 'web'
+        ? [{
+          label: '∟ Preview',
+          url:
+            `http://example.com:${server.port}/__web_preview?casename=main.web.bundle`,
+        }]
+        : []),
+    ])
+  })
+
   test('dev prints one URL per environment', async () => {
     const rsbuild = await createStubRspeedy({
       source: {

--- a/packages/rspeedy/plugin-lynx/src/plugins/dev.plugin.ts
+++ b/packages/rspeedy/plugin-lynx/src/plugins/dev.plugin.ts
@@ -155,19 +155,6 @@ export function pluginDev(): RsbuildPlugin {
           config.server?.printUrls === undefined
           || config.server?.printUrls === true
         ) {
-          // A root entry is merged into every environment (the way Rsbuild
-          // itself resolves entries), not replaced by an environment's own.
-          const entriesByEnvironment = Object.entries(
-            config.environments ?? {},
-          ).map(([environmentName, environmentConfig]) =>
-            [
-              environmentName,
-              Object.keys({
-                ...config.source?.entry,
-                ...environmentConfig.source?.entry,
-              }),
-            ] as const
-          )
           return mergeRsbuildConfig(config, {
             server: {
               printUrls: (param) => {
@@ -189,13 +176,14 @@ export function pluginDev(): RsbuildPlugin {
 
                 const finalUrls: { label: string, url: string }[] = []
                 for (
-                  const [environmentName, entries] of entriesByEnvironment
+                  const [environmentName, environmentConfig] of Object.entries(
+                    api.getNormalizedConfig().environments,
+                  )
                 ) {
+                  // Resolve after --environment filtering and config hooks,
+                  // using the same merged entries as the active build.
                   // `dev.assetPrefix`/`dev.client.host` can be set per
                   // environment, so each environment gets its own base URL.
-                  const environmentConfig = api.getNormalizedConfig({
-                    environment: environmentName,
-                  })
                   const assetPrefix = environmentConfig.dev.assetPrefix
                   const hostname = environmentConfig.dev.client.host
                     ?? formatHostname(environmentConfig.server.host)
@@ -205,7 +193,11 @@ export function pluginDev(): RsbuildPlugin {
                       : `http://${hostname}:<port>/`
                   ).replaceAll('<port>', String(param.port))
 
-                  for (const entry of entries) {
+                  for (
+                    const entry of Object.keys(
+                      environmentConfig.source.entry ?? {},
+                    )
+                  ) {
                     const pathname = resolveName(entry, environmentName)
                     finalUrls.push({
                       label: environmentName,

--- a/packages/rspeedy/plugin-lynx/test/createStubRsbuild.ts
+++ b/packages/rspeedy/plugin-lynx/test/createStubRsbuild.ts
@@ -30,8 +30,10 @@ export async function createStubRsbuild(
   rsbuildConfig: RsbuildConfig = {},
   cwd?: string,
   lynxOptions?: LynxPluginOptions,
+  environment?: string[],
 ): Promise<RsbuildInstance & RsbuildHelper> {
   const rsbuild = await createRsbuild({
+    ...(environment ? { environment } : {}),
     cwd: cwd ?? path.dirname(fileURLToPath(import.meta.url)),
     rsbuildConfig: {
       environments: { lynx: {} },

--- a/packages/rspeedy/plugin-lynx/test/dev.plugin.test.ts
+++ b/packages/rspeedy/plugin-lynx/test/dev.plugin.test.ts
@@ -1280,6 +1280,58 @@ describe('pluginDev', () => {
     })
   })
 
+  test.each(['lynx', 'web'])(
+    'printUrls respects --environment %s',
+    async (name) => {
+      const entry = path.resolve(__dirname, './fixtures/hello-world/index.js')
+      const rsbuild = await createStubRsbuild(
+        {
+          mode: 'development',
+          source: { entry: { main: entry } },
+          dev: { assetPrefix: 'http://example.com:<port>/' },
+          environments: {
+            web: { source: { entry: { webOnly: entry } } },
+            lynx: { source: { entry: { lynxOnly: entry } } },
+          },
+        },
+        undefined,
+        undefined,
+        [name],
+      )
+
+      await rsbuild.initConfigs()
+      expect(Object.keys(rsbuild.getNormalizedConfig().environments))
+        .toStrictEqual([name])
+      const { printUrls } = rsbuild.getNormalizedConfig().server
+      invariant(typeof printUrls === 'function')
+      const urls = printUrls({
+        urls: ['http://example.com:8098/'],
+        port: 8098,
+        routes: [],
+        protocol: 'http',
+      })
+      const label = name === 'lynx' ? 'Lynx' : 'Web'
+      expect(urls).toStrictEqual([
+        { label, url: `http://example.com:8098/main.${name}.bundle` },
+        ...(name === 'web'
+          ? [{
+            label: '∟ Preview',
+            url:
+              'http://example.com:8098/__web_preview?casename=main.web.bundle',
+          }]
+          : []),
+        { label, url: `http://example.com:8098/${name}Only.${name}.bundle` },
+        ...(name === 'web'
+          ? [{
+            label: '∟ Preview',
+            url:
+              'http://example.com:8098/__web_preview?casename=webOnly.web.bundle',
+          }]
+          : []),
+      ])
+    },
+  )
+
   test('preview prints the bundle path exactly once', async () => {
     const rsbuild = await createDevStubRsbuild({
       source: {


### PR DESCRIPTION
## Summary

Fix dev server startup when a configuration declares both `web` and `lynx`, but the CLI selects only one with `--environment`.

The URL printer previously captured all environments in `modifyRsbuildConfig`, before Rsbuild applied environment selection. At print time, it requested the normalized config for an excluded environment and threw `Cannot find normalized config by environment: web` (or `lynx`).

- Read the final normalized environments and merged entries at URL-print time.
- Cover both `--environment lynx` and `--environment web`, including shared and environment-specific entries and web preview URLs.
- Include a patch changeset for `@lynx-js/rsbuild-plugin`.

## Validation

- Baseline source with new regression tests: 2 failures, reproducing the missing normalized environment error; 56 existing tests pass.
- Fixed source: all 171 plugin tests across 16 files pass.
- Root TypeScript build through Turbo, package typecheck, targeted ESLint, Biome and dprint checks pass.
- Full repository build was attempted but blocked by `cargo: command not found` on this machine; no full native/e2e build claim.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed development server startup failures when using `--environment` to select specific environments.
  * Development server URLs now reflect the active environment and its resolved entry points.
  * Prevented URLs from displaying entries belonging to excluded environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->