### PR TITLE
fix(react): scope ordinary ref cleanup to each binding

### DIFF
--- a/.changeset/ordinary-ref-binding-cleanup.md
+++ b/.changeset/ordinary-ref-binding-cleanup.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react": patch
+---
+
+Keep ordinary callback ref cleanup separate for each node binding. Sharing one callback between multiple nodes no longer cleans up another node's binding during attachment, replacement, or removal. Bindings retain their cleanup across hydration and keyed moves in both Snapshot and Element Template.

--- a/packages/react/runtime/__test__/core/ref.test.ts
+++ b/packages/react/runtime/__test__/core/ref.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { OrdinaryRefEffectQueue, SelectorRefProxy, applyOrdinaryRef, normalizeRefValue } from '../../src/core/ref.js';
-import type { RefProxyForwardedMethods } from '../../src/core/ref.js';
+import type { OrdinaryRefBinding, RefProxyForwardedMethods } from '../../src/core/ref.js';
 
 class TestSelectorRefProxy extends SelectorRefProxy<TestSelectorRefProxy> {
   constructor(
@@ -60,60 +60,62 @@ describe('core/ref ordinary ref semantics', () => {
 
   it('assigns object refs', () => {
     const ref = { current: null as string | null };
+    const binding: OrdinaryRefBinding = {};
     const reportError = stubReportError();
 
-    applyOrdinaryRef(ref, 'node');
+    applyOrdinaryRef(ref, 'node', binding);
     expect(ref.current).toBe('node');
 
-    applyOrdinaryRef(ref, null);
+    applyOrdinaryRef(ref, null, binding);
     expect(ref.current).toBeNull();
     expect(reportError).not.toHaveBeenCalled();
   });
 
   it('runs function cleanup instead of calling null when cleanup exists', () => {
+    const binding: OrdinaryRefBinding = {};
     const cleanup = vi.fn();
     const ref = vi.fn(() => cleanup);
     const reportError = stubReportError();
 
-    applyOrdinaryRef(ref, 'node');
-    expect(ref._unmount).toBe(cleanup);
+    applyOrdinaryRef(ref, 'node', binding);
+    expect(binding.cleanup).toBe(cleanup);
     ref.mockClear();
 
-    applyOrdinaryRef(ref, null);
+    applyOrdinaryRef(ref, null, binding);
 
     expect(cleanup).toHaveBeenCalledTimes(1);
     expect(ref).not.toHaveBeenCalled();
-    expect(ref._unmount).toBeUndefined();
+    expect(binding.cleanup).toBeUndefined();
     expect(reportError).not.toHaveBeenCalled();
   });
 
   it('calls function refs with null when no cleanup exists', () => {
+    const binding: OrdinaryRefBinding = {};
     const ref = vi.fn();
     const reportError = stubReportError();
 
-    applyOrdinaryRef(ref, 'node');
+    applyOrdinaryRef(ref, 'node', binding);
     ref.mockClear();
 
-    applyOrdinaryRef(ref, null);
+    applyOrdinaryRef(ref, null, binding);
 
     expect(ref).toHaveBeenCalledWith(null);
     expect(reportError).not.toHaveBeenCalled();
   });
 
   it('ignores non-function cleanup return values', () => {
+    const binding: OrdinaryRefBinding = {};
     const refMock = vi.fn(() => null);
-    const ref = refMock as unknown as ((value: string | null) => void) & {
-      _unmount?: (() => void) | void;
-    };
+    const ref = refMock as unknown as (value: string | null) => void;
     const reportError = stubReportError();
 
-    applyOrdinaryRef(ref, 'node');
+    applyOrdinaryRef(ref, 'node', binding);
     refMock.mockClear();
 
-    applyOrdinaryRef(ref, null);
+    applyOrdinaryRef(ref, null, binding);
 
     expect(refMock).toHaveBeenCalledWith(null);
-    expect(ref._unmount).toBeUndefined();
+    expect(binding.cleanup).toBeUndefined();
     expect(reportError).not.toHaveBeenCalled();
   });
 
@@ -124,7 +126,7 @@ describe('core/ref ordinary ref semantics', () => {
     });
     const reportError = stubReportError();
 
-    applyOrdinaryRef(ref, 'node');
+    applyOrdinaryRef(ref, 'node', {});
 
     expect(reportError).toHaveBeenCalledWith(error);
   });
@@ -141,8 +143,8 @@ describe('core/ref ordinary ref semantics', () => {
     const unchangedRef = vi.fn();
     const reportError = stubReportError();
 
-    queue.queue(unchangedRef, unchangedRef, 'ignored');
-    queue.queue(oldRef, newRef, 'node');
+    queue.queue(unchangedRef, unchangedRef, {}, 0, 'ignored');
+    queue.queue(oldRef, newRef, {}, 0, 'node');
     expect(queue.hasPending()).toBe(true);
 
     queue.flush(token => `proxy:${token}`);
@@ -154,6 +156,81 @@ describe('core/ref ordinary ref semantics', () => {
     expect(unchangedRef).not.toHaveBeenCalled();
     expect(queue.hasPending()).toBe(false);
     expect(reportError).not.toHaveBeenCalled();
+  });
+
+  it('keeps shared callback cleanup per owner and slot across token remapping', () => {
+    const queue = new OrdinaryRefEffectQueue<string, string>();
+    const ownerA = {};
+    const ownerB = {};
+    const cleanups = new Map<string, ReturnType<typeof vi.fn>>();
+    const ref = vi.fn((value: string | null) => {
+      const cleanup = vi.fn();
+      cleanups.set(value!, cleanup);
+      return cleanup;
+    });
+
+    queue.queue(null, ref, ownerA, 0, 'A:0');
+    queue.queue(null, ref, ownerA, 1, 'A:1');
+    queue.queue(null, ref, ownerB, 0, 'B:0');
+    queue.flush(token => token);
+
+    expect(ref).toHaveBeenCalledTimes(3);
+    for (const cleanup of cleanups.values()) {
+      expect(cleanup).not.toHaveBeenCalled();
+    }
+
+    queue.queue(ref, null, ownerA, 0, 'remapped-A:0');
+    queue.flush(token => token);
+    expect(cleanups.get('A:0')).toHaveBeenCalledTimes(1);
+    expect(cleanups.get('A:1')).not.toHaveBeenCalled();
+    expect(cleanups.get('B:0')).not.toHaveBeenCalled();
+
+    queue.queue(ref, null, ownerA, 1, 'remapped-A:1');
+    queue.queue(ref, null, ownerB, 0, 'remapped-B:0');
+    queue.flush(token => token);
+    for (const cleanup of cleanups.values()) {
+      expect(cleanup).toHaveBeenCalledTimes(1);
+    }
+    expect(ref).toHaveBeenCalledTimes(3);
+  });
+
+  it('clears pending effects without dropping mounted binding cleanup', () => {
+    const queue = new OrdinaryRefEffectQueue<string, string>();
+    const owner = {};
+    const cleanup = vi.fn();
+    const ref = vi.fn(() => cleanup);
+    const discardedRef = vi.fn();
+
+    queue.queue(null, ref, owner, 0, 'node');
+    queue.flush(token => token);
+    queue.queue(ref, discardedRef, owner, 0, 'node');
+    queue.clear();
+
+    expect(queue.hasPending()).toBe(false);
+    expect(cleanup).not.toHaveBeenCalled();
+    queue.queue(ref, null, owner, 0, 'node');
+    queue.flush(token => token);
+    expect(cleanup).toHaveBeenCalledTimes(1);
+    expect(discardedRef).not.toHaveBeenCalled();
+    expect(ref).toHaveBeenCalledTimes(1);
+  });
+
+  it('consumes throwing cleanup before reporting its error', () => {
+    const error = new Error('cleanup failed');
+    const cleanup = vi.fn(() => {
+      throw error;
+    });
+    const ref = vi.fn(() => cleanup);
+    const binding: OrdinaryRefBinding = {};
+    const reportError = stubReportError();
+
+    applyOrdinaryRef(ref, 'node', binding);
+    applyOrdinaryRef(ref, null, binding);
+
+    expect(cleanup).toHaveBeenCalledTimes(1);
+    expect(binding.cleanup).toBeUndefined();
+    expect(ref).toHaveBeenCalledTimes(1);
+    expect(reportError).toHaveBeenCalledWith(error);
   });
 
   it('forwards NodesRef methods through backend-provided selector and scheduler', () => {

--- a/packages/react/runtime/__test__/element-template/runtime/background/commit-hook.test.ts
+++ b/packages/react/runtime/__test__/element-template/runtime/background/commit-hook.test.ts
@@ -257,7 +257,7 @@ describe('ElementTemplate commit hook', () => {
 
     try {
       markElementTemplateHydrated();
-      queueRefAttrUpdate(null, ref, -2, 0);
+      queueRefAttrUpdate(null, ref, { instanceId: -2 }, 0);
       markRemovedSubtreeForPostDispatchTeardown(removedRoot);
       globalCommitContext.ops = createRawTextOps(1, throwingValue);
       enqueueDelayedRunOnMainThreadData({
@@ -677,7 +677,7 @@ describe('ElementTemplate commit hook', () => {
   it('flushes ref-only updates without dispatching native ops', () => {
     const ref = vi.fn();
     markElementTemplateHydrated();
-    queueRefAttrUpdate(null, ref, -2, 0);
+    queueRefAttrUpdate(null, ref, { instanceId: -2 }, 0);
 
     options.__c?.({} as unknown as object, []);
 
@@ -693,7 +693,7 @@ describe('ElementTemplate commit hook', () => {
     const ref = vi.fn();
     markElementTemplateHydrated();
     globalCommitContext.flushOptions = { triggerDataUpdated: true };
-    queueRefAttrUpdate(null, ref, -2, 0);
+    queueRefAttrUpdate(null, ref, { instanceId: -2 }, 0);
 
     options.__c?.({} as unknown as object, []);
 
@@ -714,7 +714,7 @@ describe('ElementTemplate commit hook', () => {
 
   it('flushes pre-hydration ref effects on commit without dispatching native ops', () => {
     const ref = vi.fn();
-    queueRefAttrUpdate(null, ref, 1, 0);
+    queueRefAttrUpdate(null, ref, { instanceId: 1 }, 0);
 
     options.__c?.({} as unknown as object, []);
 

--- a/packages/react/runtime/__test__/element-template/runtime/background/instance.test.ts
+++ b/packages/react/runtime/__test__/element-template/runtime/background/instance.test.ts
@@ -31,6 +31,7 @@ import {
   clearEtAttrPlanMap,
 } from '../../../../src/element-template/runtime/template/attr-slot-plan.js';
 import { clearRefState, flushPendingRefs } from '../../../../src/element-template/prop-adapters/ref.js';
+import { hydrateBackground } from '../../test-utils/debug/hydrate.js';
 
 function createTextNode(text: string): BackgroundElementTemplateInstance {
   return new BackgroundElementTemplateInstance(BUILTIN_RAW_TEXT_TEMPLATE_KEY, [text]);
@@ -1943,6 +1944,144 @@ describe('BackgroundElementTemplateInstance', () => {
 
     expect(spreadRef).toHaveBeenCalledWith(null);
     expect(directRef).not.toHaveBeenCalled();
+  });
+
+  it.each(['direct', 'spread'])(
+    'keeps shared %s ref cleanups isolated through hydration, moves and replacement',
+    (kind) => {
+      const cleanupA = vi.fn();
+      const cleanupB = vi.fn();
+      const replacementCleanup = vi.fn();
+      const ref = vi.fn<(value: { selector: string } | null) => () => void>()
+        .mockReturnValueOnce(cleanupA)
+        .mockReturnValueOnce(cleanupB);
+      const replacement = vi.fn(() => replacementCleanup);
+      const slots = (value: unknown) => [kind === 'spread' ? { ref: value } : value];
+      __etAttrPlanMap.view = [0, kind === 'spread' ? adaptSpreadAttrSlot : adaptRefAttrSlot];
+      const parent = new BackgroundElementTemplateInstance('root');
+      const childA = new BackgroundElementTemplateInstance('view');
+      const childB = new BackgroundElementTemplateInstance('view');
+      childA.setAttribute('attributeSlots', slots(ref));
+      childB.setAttribute('attributeSlots', slots(ref));
+      parent.appendChild(childA);
+      parent.appendChild(childB);
+      flushPendingRefs();
+
+      expect(ref).toHaveBeenCalledTimes(2);
+      expect(ref).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          selector: `[ref=${childA.instanceId}-0]`,
+        }),
+      );
+      expect(ref).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          selector: `[ref=${childB.instanceId}-0]`,
+        }),
+      );
+      expect(cleanupA).not.toHaveBeenCalled();
+      expect(cleanupB).not.toHaveBeenCalled();
+      const proxyA = ref.mock.calls[0]![0];
+      const proxyB = ref.mock.calls[1]![0];
+
+      hydrateBackground({
+        templateKey: 'root',
+        uid: -1,
+        childSlots: [[
+          {
+            templateKey: 'view',
+            uid: -2,
+            attributeSlots: [kind === 'spread' ? { ref: '-2-0' } : '-2-0'],
+          },
+          {
+            templateKey: 'view',
+            uid: -3,
+            attributeSlots: [kind === 'spread' ? { ref: '-3-0' } : '-3-0'],
+          },
+        ]],
+      }, parent);
+      markElementTemplateHydrated();
+      flushPendingRefs();
+
+      expect(childA.instanceId).toBe(-2);
+      expect(childB.instanceId).toBe(-3);
+      expect(proxyA).toMatchObject({ selector: '[ref=-2-0]' });
+      expect(proxyB).toMatchObject({ selector: '[ref=-3-0]' });
+      expect(ref).toHaveBeenCalledTimes(2);
+      expect(cleanupA).not.toHaveBeenCalled();
+      expect(cleanupB).not.toHaveBeenCalled();
+
+      parent.insertBefore(childB, childA);
+      childA.setAttribute('attributeSlots', slots(ref));
+      childB.setAttribute('attributeSlots', slots(ref));
+      flushPendingRefs();
+
+      expect(ref).toHaveBeenCalledTimes(2);
+      expect(cleanupA).not.toHaveBeenCalled();
+      expect(cleanupB).not.toHaveBeenCalled();
+
+      childA.setAttribute('attributeSlots', slots(replacement));
+      flushPendingRefs();
+
+      expect(cleanupA).toHaveBeenCalledTimes(1);
+      expect(cleanupB).not.toHaveBeenCalled();
+      expect(replacement).toHaveBeenCalledTimes(1);
+      expect(replacement).toHaveBeenCalledWith(expect.objectContaining({ selector: '[ref=-2-0]' }));
+      expect(ref).toHaveBeenCalledTimes(2);
+
+      parent.removeChild(childA);
+      flushPendingRefs();
+
+      expect(replacementCleanup).toHaveBeenCalledTimes(1);
+      expect(cleanupA).toHaveBeenCalledTimes(1);
+      expect(cleanupB).not.toHaveBeenCalled();
+
+      parent.removeChild(childB);
+      flushPendingRefs();
+
+      expect(cleanupB).toHaveBeenCalledTimes(1);
+      expect(cleanupA).toHaveBeenCalledTimes(1);
+      expect(replacementCleanup).toHaveBeenCalledTimes(1);
+      expect(ref).toHaveBeenCalledTimes(2);
+      expect(replacement).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it('keeps a shared callback cleanup separate for direct and spread slots on the same instance', () => {
+    const directCleanup = vi.fn();
+    const spreadCleanup = vi.fn();
+    const ref = vi.fn()
+      .mockReturnValueOnce(directCleanup)
+      .mockReturnValueOnce(spreadCleanup);
+    __etAttrPlanMap.view = [0, adaptRefAttrSlot, 1, adaptSpreadAttrSlot];
+    const instance = new BackgroundElementTemplateInstance('view');
+    backgroundElementTemplateInstanceManager.updateId(instance.instanceId, -2);
+    instance.markMaterializedByHydration();
+    markElementTemplateHydrated();
+
+    instance.setAttribute('attributeSlots', [ref, { ref }]);
+    flushPendingRefs();
+
+    expect(ref).toHaveBeenCalledTimes(2);
+    expect(ref).toHaveBeenNthCalledWith(1, expect.objectContaining({ selector: '[ref=-2-0]' }));
+    expect(ref).toHaveBeenNthCalledWith(2, expect.objectContaining({ selector: '[ref=-2-1]' }));
+    expect(directCleanup).not.toHaveBeenCalled();
+    expect(spreadCleanup).not.toHaveBeenCalled();
+
+    instance.setAttribute('attributeSlots', [null, { ref }]);
+    flushPendingRefs();
+
+    expect(directCleanup).toHaveBeenCalledTimes(1);
+    expect(spreadCleanup).not.toHaveBeenCalled();
+    expect(ref).toHaveBeenCalledTimes(2);
+
+    instance.setAttribute('attributeSlots', [null, {}]);
+    flushPendingRefs();
+
+    expect(directCleanup).toHaveBeenCalledTimes(1);
+    expect(spreadCleanup).toHaveBeenCalledTimes(1);
+    expect(ref).toHaveBeenCalledTimes(2);
   });
 
   it('does not let explicit undefined spread refs detach sibling direct refs', () => {

--- a/packages/react/runtime/__test__/element-template/runtime/prop-adapters/ref.test.ts
+++ b/packages/react/runtime/__test__/element-template/runtime/prop-adapters/ref.test.ts
@@ -35,7 +35,7 @@ describe('ElementTemplate ref prop adapter', () => {
   it('attaches function refs with an ET selector proxy', () => {
     const ref = vi.fn();
 
-    queueRefAttrUpdate(null, ref, -2, 0);
+    queueRefAttrUpdate(null, ref, { instanceId: -2 }, 0);
     flushPendingRefs();
 
     expect(ref).toHaveBeenCalledTimes(1);
@@ -47,12 +47,13 @@ describe('ElementTemplate ref prop adapter', () => {
   it('detaches function refs through cleanup when the callback returned one', () => {
     const cleanup = vi.fn();
     const ref = vi.fn(() => cleanup);
+    const instance = { instanceId: -2 };
 
-    queueRefAttrUpdate(null, ref, -2, 0);
+    queueRefAttrUpdate(null, ref, instance, 0);
     flushPendingRefs();
     ref.mockClear();
 
-    queueRefAttrUpdate(ref, null, -2, 0);
+    queueRefAttrUpdate(ref, null, instance, 0);
     flushPendingRefs();
 
     expect(cleanup).toHaveBeenCalledTimes(1);
@@ -61,12 +62,13 @@ describe('ElementTemplate ref prop adapter', () => {
 
   it('detaches function refs with null when there is no cleanup', () => {
     const ref = vi.fn();
+    const instance = { instanceId: -2 };
 
-    queueRefAttrUpdate(null, ref, -2, 0);
+    queueRefAttrUpdate(null, ref, instance, 0);
     flushPendingRefs();
     ref.mockClear();
 
-    queueRefAttrUpdate(ref, null, -2, 0);
+    queueRefAttrUpdate(ref, null, instance, 0);
     flushPendingRefs();
 
     expect(ref).toHaveBeenCalledWith(null);
@@ -74,8 +76,9 @@ describe('ElementTemplate ref prop adapter', () => {
 
   it('updates object refs and skips unchanged identities', () => {
     const ref = { current: null };
+    const instance = { instanceId: -2 };
 
-    queueRefAttrUpdate(null, ref, -2, 0);
+    queueRefAttrUpdate(null, ref, instance, 0);
     flushPendingRefs();
 
     expect(ref.current).toMatchObject({
@@ -83,11 +86,11 @@ describe('ElementTemplate ref prop adapter', () => {
     });
     const proxy = ref.current;
 
-    queueRefAttrUpdate(ref, ref, -2, 0);
+    queueRefAttrUpdate(ref, ref, instance, 0);
     flushPendingRefs();
     expect(ref.current).toBe(proxy);
 
-    queueRefAttrUpdate(ref, null, -2, 0);
+    queueRefAttrUpdate(ref, null, instance, 0);
     flushPendingRefs();
     expect(ref.current).toBeNull();
   });
@@ -101,7 +104,7 @@ describe('ElementTemplate ref prop adapter', () => {
 
     try {
       const ref = vi.fn();
-      queueRefAttrUpdate(null, ref, -2, 0);
+      queueRefAttrUpdate(null, ref, { instanceId: -2 }, 0);
       flushPendingRefs();
 
       ref.mock.calls[0]![0].setNativeProps({ opacity: 1 }).exec();
@@ -135,7 +138,7 @@ describe('ElementTemplate ref prop adapter', () => {
 
     try {
       const ref = vi.fn();
-      queueRefAttrUpdate(null, ref, 1, 0);
+      queueRefAttrUpdate(null, ref, { instanceId: 1 }, 0);
       flushPendingRefs();
 
       ref.mock.calls[0]![0].setNativeProps({ opacity: 1 }).exec();

--- a/packages/react/runtime/__test__/element-template/runtime/template/element-template-attr-slot-plan.test.ts
+++ b/packages/react/runtime/__test__/element-template/runtime/template/element-template-attr-slot-plan.test.ts
@@ -297,7 +297,7 @@ describe('ElementTemplate attr slot plan registry', () => {
 
   it('skips queued ref effects for templates without attr plans', () => {
     expect(() => {
-      queueRefAttributeSlotUpdates('_et_without_backend_attrs', -2, [() => {}]);
+      queueRefAttributeSlotUpdates('_et_without_backend_attrs', { instanceId: -2 }, [() => {}]);
     }).not.toThrow();
   });
 
@@ -306,7 +306,7 @@ describe('ElementTemplate attr slot plan registry', () => {
     const newRef = vi.fn();
     __etAttrPlanMap._et_ref = [0, adaptRefAttrSlot];
 
-    queueRefAttributeSlotUpdates('_et_ref', -2, [oldRef], [newRef]);
+    queueRefAttributeSlotUpdates('_et_ref', { instanceId: -2 }, [oldRef], [newRef]);
     flushPendingRefs();
 
     expect(oldRef).toHaveBeenCalledWith(null);
@@ -335,7 +335,7 @@ describe('ElementTemplate attr slot plan registry', () => {
       '-7-1',
       { ref: '-7-2' },
     ]);
-    queueRefAttributeSlotUpdates('_et_multi_ref', -7, undefined, rawSlots);
+    queueRefAttributeSlotUpdates('_et_multi_ref', { instanceId: -7 }, undefined, rawSlots);
     flushPendingRefs();
 
     expect(directRef).toHaveBeenCalledWith(expect.objectContaining({
@@ -361,7 +361,7 @@ describe('ElementTemplate attr slot plan registry', () => {
 
     queueRefAttributeSlotUpdates(
       '_et_multi_ref',
-      -7,
+      { instanceId: -7 },
       [directRef, { ref: spreadRef }],
       [directRef, { ref: undefined }],
     );

--- a/packages/react/runtime/__test__/snapshot/ref.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/ref.test.jsx
@@ -2170,6 +2170,144 @@ describe('applyRef before hydration', () => {
   });
 });
 
+describe.each([false, true])('shared callback ref bindings (hydrated: %s)', (hydrated) => {
+  function applyMainThreadUpdates() {
+    const updates = lynx.getNativeApp().callLepusMethod.mock.calls.slice();
+    lynx.getNativeApp().callLepusMethod.mockClear();
+    globalEnvManager.switchToMainThread();
+    updates.forEach(([name, data]) => globalThis[name](data));
+    globalEnvManager.switchToBackground();
+  }
+
+  function mount(createJsx) {
+    globalThis.__OnLifecycleEvent.mockClear();
+    lynx.getNativeApp().callLepusMethod.mockClear();
+    if (hydrated) {
+      __root.__jsx = createJsx();
+      renderPage();
+    }
+    globalEnvManager.switchToBackground();
+    render(createJsx(), __root);
+    if (hydrated) {
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      applyMainThreadUpdates();
+    }
+  }
+
+  function update(jsx) {
+    render(jsx, __root);
+    if (hydrated) {
+      applyMainThreadUpdates();
+    }
+  }
+
+  function trackRefBindings() {
+    const active = new Set();
+    const cleanups = new Map();
+    const callback = vi.fn((node) => {
+      active.add(node);
+      const cleanup = vi.fn(() => {
+        active.delete(node);
+      });
+      cleanups.set(node, cleanup);
+      return cleanup;
+    });
+    return { callback, active, cleanups };
+  }
+
+  it('replaces one ref slot without cleaning another slot using the same callback', () => {
+    const shared = trackRefBindings();
+    const replacement = trackRefBindings();
+
+    function App({ firstRef }) {
+      return (
+        <view>
+          <view ref={firstRef} />
+          <view ref={shared.callback} />
+        </view>
+      );
+    }
+
+    mount(() => <App firstRef={shared.callback} />);
+    expect(shared.callback).toHaveBeenCalledTimes(2);
+    const [[first], [second]] = shared.callback.mock.calls;
+    expect(first).toBeInstanceOf(RefProxy);
+    expect(second).toBeInstanceOf(RefProxy);
+    expect(first.selector).not.toBe(second.selector);
+    expect(shared.active).toEqual(new Set([first, second]));
+    expect(shared.cleanups.get(first)).not.toHaveBeenCalled();
+    expect(shared.cleanups.get(second)).not.toHaveBeenCalled();
+
+    update(<App firstRef={replacement.callback} />);
+    expect(shared.cleanups.get(first)).toHaveBeenCalledTimes(1);
+    expect(shared.cleanups.get(second)).not.toHaveBeenCalled();
+    expect(shared.active).toEqual(new Set([second]));
+    expect(shared.callback).toHaveBeenCalledTimes(2);
+    expect(replacement.callback).toHaveBeenCalledTimes(1);
+    const [[replaced]] = replacement.callback.mock.calls;
+    expect(replaced.selector).toBe(first.selector);
+    expect(replacement.active).toEqual(new Set([replaced]));
+
+    update(<App firstRef={replacement.callback} />);
+    expect(shared.callback).toHaveBeenCalledTimes(2);
+    expect(replacement.callback).toHaveBeenCalledTimes(1);
+    expect(shared.cleanups.get(second)).not.toHaveBeenCalled();
+    expect(replacement.cleanups.get(replaced)).not.toHaveBeenCalled();
+
+    update(null);
+    expect(shared.cleanups.get(first)).toHaveBeenCalledTimes(1);
+    expect(shared.cleanups.get(second)).toHaveBeenCalledTimes(1);
+    expect(replacement.cleanups.get(replaced)).toHaveBeenCalledTimes(1);
+    expect(shared.active.size).toBe(0);
+    expect(replacement.active.size).toBe(0);
+    expect(shared.callback).toHaveBeenCalledTimes(2);
+    expect(replacement.callback).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps shared bindings through a keyed move and cleans only the removed item', () => {
+    const shared = trackRefBindings();
+
+    function Item({ id }) {
+      return <view id={id} ref={shared.callback} />;
+    }
+
+    function App({ ids }) {
+      return <view id='items'>{ids.map(id => <Item key={id} id={id} />)}</view>;
+    }
+
+    mount(() => <App ids={['first', 'second']} />);
+    expect(shared.callback).toHaveBeenCalledTimes(2);
+    const [[first], [second]] = shared.callback.mock.calls;
+    expect(shared.active).toEqual(new Set([first, second]));
+    expect(shared.cleanups.get(first)).not.toHaveBeenCalled();
+    expect(shared.cleanups.get(second)).not.toHaveBeenCalled();
+
+    update(<App ids={['second', 'first']} />);
+    expect(shared.callback).toHaveBeenCalledTimes(2);
+    expect(shared.active).toEqual(new Set([first, second]));
+    expect(shared.cleanups.get(first)).not.toHaveBeenCalled();
+    expect(shared.cleanups.get(second)).not.toHaveBeenCalled();
+    if (hydrated) {
+      expect(elementTree.getElementById('items').children.map(node => node.props.id)).toEqual(['second', 'first']);
+    }
+
+    update(<App ids={['second']} />);
+    expect(shared.cleanups.get(first)).toHaveBeenCalledTimes(1);
+    expect(shared.cleanups.get(second)).not.toHaveBeenCalled();
+    expect(shared.active).toEqual(new Set([second]));
+    expect(shared.callback).toHaveBeenCalledTimes(2);
+    if (hydrated) {
+      expect(elementTree.getElementById('items').children.map(node => node.props.id)).toEqual(['second']);
+    }
+
+    update(null);
+    expect(shared.cleanups.get(first)).toHaveBeenCalledTimes(1);
+    expect(shared.cleanups.get(second)).toHaveBeenCalledTimes(1);
+    expect(shared.active.size).toBe(0);
+    expect(shared.callback).toHaveBeenCalledTimes(2);
+  });
+});
+
 describe('runDelayedUiOps helper', () => {
   it('should reset shouldDelayUiOps when no tasks queued', () => {
     // flush any queued tasks from previous tests

--- a/packages/react/runtime/src/core/ref.ts
+++ b/packages/react/runtime/src/core/ref.ts
@@ -5,9 +5,10 @@
 import type { NodesRef, SelectorQuery } from '@lynx-js/types';
 
 export type RefCleanup = (() => void) | void;
-export type RefCallback<T> = ((ref: T | null) => RefCleanup) & {
-  _unmount?: RefCleanup;
-};
+export type RefCallback<T> = (ref: T | null) => RefCleanup;
+export interface OrdinaryRefBinding {
+  cleanup?: RefCleanup;
+}
 export interface RefObject<T> {
   current: T | null;
 }
@@ -47,20 +48,21 @@ export function normalizeRefValue<T>(value: unknown): OrdinaryRef<T> | null | un
 export function applyOrdinaryRef<T>(
   ref: OrdinaryRef<T>,
   value: T | null,
+  binding: OrdinaryRefBinding,
 ): void {
   try {
     if (typeof ref === 'function') {
-      const cleanup = ref._unmount;
+      const cleanup = binding.cleanup;
       const hasCleanup = typeof cleanup === 'function';
+      binding.cleanup = undefined;
       if (hasCleanup) {
         cleanup();
       }
-      ref._unmount = undefined;
 
       if (!hasCleanup || value !== null) {
         const nextCleanup = ref(value);
         if (typeof nextCleanup === 'function') {
-          ref._unmount = nextCleanup;
+          binding.cleanup = nextCleanup;
         }
       }
     } else {
@@ -74,22 +76,35 @@ export function applyOrdinaryRef<T>(
 // Keeps the Snapshot/ET ordinary ref ordering shared without owning backend
 // timing: each backend decides when to queue/flush and how to build the proxy.
 export class OrdinaryRefEffectQueue<TProxy, TToken> {
-  private readonly refsToClear: OrdinaryRef<TProxy>[] = [];
-  private readonly refsToApply: Array<[ref: OrdinaryRef<TProxy>, token: TToken]> = [];
+  // A host instance survives hydration's numeric ID remapping. Each ref slot
+  // owns its cleanup independently, even when callbacks are shared.
+  private readonly bindings = new WeakMap<object, Map<number, OrdinaryRefBinding>>();
+  private readonly refsToClear: Array<[ref: OrdinaryRef<TProxy>, binding: OrdinaryRefBinding]> = [];
+  private readonly refsToApply: Array<[ref: OrdinaryRef<TProxy>, token: TToken, binding: OrdinaryRefBinding]> = [];
 
   queue(
     oldRef: OrdinaryRef<TProxy> | null | undefined,
     newRef: OrdinaryRef<TProxy> | null | undefined,
+    owner: object,
+    slot: number,
     token: TToken,
   ): void {
     if (oldRef === newRef) {
       return;
     }
+    let slots = this.bindings.get(owner);
+    if (!slots) {
+      this.bindings.set(owner, slots = new Map<number, OrdinaryRefBinding>());
+    }
+    let binding = slots.get(slot);
+    if (!binding) {
+      slots.set(slot, binding = {});
+    }
     if (oldRef) {
-      this.refsToClear.push(oldRef);
+      this.refsToClear.push([oldRef, binding]);
     }
     if (newRef) {
-      this.refsToApply.push([newRef, token]);
+      this.refsToApply.push([newRef, token, binding]);
     }
   }
 
@@ -101,11 +116,11 @@ export class OrdinaryRefEffectQueue<TProxy, TToken> {
     const refsToClearNow = this.refsToClear.splice(0);
     const refsToApplyNow = this.refsToApply.splice(0);
 
-    for (const ref of refsToClearNow) {
-      applyOrdinaryRef(ref, null);
+    for (const [ref, binding] of refsToClearNow) {
+      applyOrdinaryRef(ref, null, binding);
     }
-    for (const [ref, token] of refsToApplyNow) {
-      applyOrdinaryRef(ref, createValue(token));
+    for (const [ref, token, binding] of refsToApplyNow) {
+      applyOrdinaryRef(ref, createValue(token), binding);
     }
   }
 

--- a/packages/react/runtime/src/element-template/background/attr-slots.ts
+++ b/packages/react/runtime/src/element-template/background/attr-slots.ts
@@ -34,7 +34,7 @@ function normalizeAttributeSlots(rawSlots: readonly unknown[]): SerializableValu
 }
 
 function queuePlannedRefAttributeSlotUpdates(
-  handleId: number,
+  instance: { readonly instanceId: number },
   attrPlan: readonly (number | EtAttrAdapter)[],
   previousRawSlots?: readonly unknown[],
   nextRawSlots?: readonly unknown[],
@@ -47,7 +47,7 @@ function queuePlannedRefAttributeSlotUpdates(
       queueRefAttrUpdate(
         previousRawSlots?.[attrSlotIndex],
         nextRawSlots?.[attrSlotIndex],
-        handleId,
+        instance,
         attrSlotIndex,
       );
       continue;
@@ -62,7 +62,7 @@ function queuePlannedRefAttributeSlotUpdates(
       queueRefAttrUpdate(
         previousSpreadRef,
         nextSpreadRef ?? null,
-        handleId,
+        instance,
         attrSlotIndex,
       );
     }
@@ -104,7 +104,7 @@ export function prepareAttributeSlots(
 
 export function queueRefAttributeSlotUpdates(
   templateKey: string,
-  handleId: number,
+  instance: { readonly instanceId: number },
   previousRawSlots?: readonly unknown[],
   nextRawSlots?: readonly unknown[],
   attributePlan?: EtAttrPlan,
@@ -114,7 +114,7 @@ export function queueRefAttributeSlotUpdates(
     return;
   }
 
-  queuePlannedRefAttributeSlotUpdates(handleId, attrPlan, previousRawSlots, nextRawSlots);
+  queuePlannedRefAttributeSlotUpdates(instance, attrPlan, previousRawSlots, nextRawSlots);
 }
 
 export function getAttributeSlotUpdateOp(

--- a/packages/react/runtime/src/element-template/background/instance.ts
+++ b/packages/react/runtime/src/element-template/background/instance.ts
@@ -403,7 +403,7 @@ export class BackgroundElementTemplateInstance {
     if (this.rawAttributeSlots) {
       queueRefAttributeSlotUpdates(
         this.type,
-        this.instanceId,
+        this,
         this.rawAttributeSlots,
         undefined,
         this.getAttributeSlotPlan(),
@@ -445,7 +445,7 @@ export class BackgroundElementTemplateInstance {
     if (options?.publishRefEffects ?? true) {
       queueRefAttributeSlotUpdates(
         this.type,
-        this.instanceId,
+        this,
         undefined,
         this.rawAttributeSlots,
         this.getAttributeSlotPlan(),
@@ -492,7 +492,7 @@ export class BackgroundElementTemplateInstance {
       if (shouldQueueRefEffects) {
         queueRefAttributeSlotUpdates(
           this.type,
-          this.instanceId,
+          this,
           previousRawSlots,
           value,
           this.getAttributeSlotPlan(),

--- a/packages/react/runtime/src/element-template/prop-adapters/ref.ts
+++ b/packages/react/runtime/src/element-template/prop-adapters/ref.ts
@@ -120,12 +120,12 @@ export function prepareSpreadRefAttrValue(
 export function queueRefAttrUpdate(
   oldValue: unknown,
   newValue: unknown,
-  handleId: number,
+  instance: { readonly instanceId: number },
   attrSlotIndex: number,
 ): void {
   const oldRef = getRefFromValue(oldValue);
   const newRef = getRefFromValue(newValue);
-  refEffectQueue.queue(oldRef, newRef, [handleId, attrSlotIndex]);
+  refEffectQueue.queue(oldRef, newRef, instance, attrSlotIndex, [instance.instanceId, attrSlotIndex]);
 }
 
 export function flushPendingRefs(): void {

--- a/packages/react/runtime/src/snapshot/snapshot/backgroundSnapshot.ts
+++ b/packages/react/runtime/src/snapshot/snapshot/backgroundSnapshot.ts
@@ -16,7 +16,7 @@ import { DynamicPartType } from './dynamicPartType.js';
 import { getListItemPlatformInfoFromIndexedValue } from './platformInfo.js';
 import type { PlatformInfo } from './platformInfo.js';
 import { reconstructInstanceTree } from './reconstructInstanceTree.js';
-import { clearQueuedRefs, clearRef, getRefFromValue, queueRefAttrUpdate } from './ref.js';
+import { clearQueuedRefs, getRefFromValue, queueRefAttrUpdate } from './ref.js';
 import type { Ref } from './ref.js';
 import { snapshotCreatorMap } from './snapshot.js';
 import { snapshotCreatorRuntime } from './snapshotCreatorMap.js';
@@ -305,27 +305,16 @@ export class BackgroundSnapshotInstance {
     node.__previousSibling = null;
     node.__nextSibling = null;
 
-    queueRefAttrUpdate(
-      () => {
-        traverseSnapshotInstance(node, v => {
-          if (v.__values) {
-            v.__snapshot_def.refAndSpreadIndexes?.forEach((i) => {
-              const value = v.__values![i];
-              if (value && (typeof value === 'object' || typeof value === 'function')) {
-                if ('__spread' in value && 'ref' in value && value.ref) {
-                  clearRef(value.ref as Ref);
-                } else if ('__ref' in value) {
-                  clearRef(value as Ref);
-                }
-              }
-            });
+    traverseSnapshotInstance(node, instance => {
+      if (instance.__values) {
+        instance.__snapshot_def.refAndSpreadIndexes?.forEach(index => {
+          const ref = getRefFromValue(instance.__values![index]);
+          if (ref) {
+            queueRefAttrUpdate(ref, null, instance, index);
           }
         });
-      },
-      null,
-      0,
-      0,
-    );
+      }
+    });
 
     globalBackgroundSnapshotInstancesToRemove.push(node.__id);
   }
@@ -391,7 +380,7 @@ export class BackgroundSnapshotInstance {
           // In next rerenders before hydration, this.__values is not undefined.
           const oldValue: unknown = this.__values?.[index];
           const v = (value as unknown[])[index];
-          queueRefAttrUpdate(getRefFromValue(oldValue), getRefFromValue(v), this.__id, index);
+          queueRefAttrUpdate(getRefFromValue(oldValue), getRefFromValue(v), this, index);
         });
       }
       this.__values = value as unknown[];
@@ -454,7 +443,7 @@ export class BackgroundSnapshotInstance {
     if (!newValue) {
       // `oldValue` can't be a spread.
       if (oldValue && typeof oldValue === 'object' && '__ref' in oldValue) {
-        queueRefAttrUpdate(oldValue as Ref, null, this.__id, index);
+        queueRefAttrUpdate(oldValue as Ref, null, this, index);
       }
       return { needUpdate: oldValue !== newValue, valueToCommit: newValue };
     }
@@ -471,7 +460,7 @@ export class BackgroundSnapshotInstance {
         queueRefAttrUpdate(
           oldSpread && ((oldValue as { ref?: Ref }).ref),
           newValueObj['ref'] as Ref,
-          this.__id,
+          this,
           index,
         );
         return {
@@ -480,7 +469,7 @@ export class BackgroundSnapshotInstance {
         };
       }
       if ('__ref' in newValueObj) {
-        queueRefAttrUpdate(oldValue as Ref, newValueObj as unknown as Ref, this.__id, index);
+        queueRefAttrUpdate(oldValue as Ref, newValueObj as unknown as Ref, this, index);
         return { needUpdate: false, valueToCommit: 1 };
       }
       if ('_wkltId' in newValueObj) {
@@ -515,7 +504,7 @@ export class BackgroundSnapshotInstance {
     }
     if (newType === 'function') {
       if ((newValue as { __ref?: unknown }).__ref) {
-        queueRefAttrUpdate(oldValue as Ref, newValue as Ref, this.__id, index);
+        queueRefAttrUpdate(oldValue as Ref, newValue as Ref, this, index);
         return { needUpdate: false, valueToCommit: 1 };
       }
       /* event */

--- a/packages/react/runtime/src/snapshot/snapshot/ref.ts
+++ b/packages/react/runtime/src/snapshot/snapshot/ref.ts
@@ -4,7 +4,7 @@
 import type { Element, Worklet, WorkletRefImpl } from '@lynx-js/react/worklet-runtime/bindings';
 
 import { workletUnRef } from './workletRef.js';
-import { OrdinaryRefEffectQueue, applyOrdinaryRef, normalizeRefValue } from '../../core/ref.js';
+import { OrdinaryRefEffectQueue, normalizeRefValue } from '../../core/ref.js';
 import type { OrdinaryRef } from '../../core/ref.js';
 import { RefProxy } from '../lifecycle/ref/delay.js';
 import type { SnapshotInstance } from '../snapshot/snapshot.js';
@@ -30,10 +30,6 @@ function unref(snapshot: SnapshotInstance, recursive: boolean): void {
       unref(it, recursive);
     });
   }
-}
-
-function clearRef(ref: Ref): void {
-  applyOrdinaryRef(ref, null);
 }
 
 function updateRef(
@@ -95,10 +91,10 @@ function applyQueuedRefs(): void {
 function queueRefAttrUpdate(
   oldRef: Ref | null | undefined,
   newRef: Ref | null | undefined,
-  snapshotInstanceId: number,
+  snapshot: { readonly __id: number },
   expIndex: number,
 ): void {
-  refEffectQueue.queue(oldRef, newRef, [snapshotInstanceId, expIndex]);
+  refEffectQueue.queue(oldRef, newRef, snapshot, expIndex, [snapshot.__id, expIndex]);
 }
 
 function clearQueuedRefs(): void {
@@ -113,7 +109,6 @@ export {
   updateRef,
   unref,
   transformRef,
-  clearRef,
   applyQueuedRefs,
   clearQueuedRefs,
   getRefFromValue,


### PR DESCRIPTION
## Summary

Ordinary callback refs currently store the cleanup returned by the callback on the callback function itself. When the same callback is attached to two nodes, attaching the second node prematurely cleans up the first; later removing the first node can run the second node's cleanup.

For example, each of these bindings should keep its own resource until that node is detached or its ref changes:

```jsx
const attach = node => {
  const resource = connect(node);
  return () => resource.disconnect();
};

return <view><view ref={attach} /><view ref={attach} /></view>;
```

Keep cleanup in the shared ordinary-ref effect queue, keyed by the stable backend instance and ref slot. Callback identity remains shareable, while each node binding owns its cleanup. Using the instance rather than its numeric selector ID preserves that ownership across hydration ID remapping.

Both Snapshot and Element Template now queue detach effects with their binding identity. Snapshot subtree removal collects those effects during removal and still executes user cleanup at the existing commit-time flush. Detach-before-attach ordering, unchanged-ref behavior, selector proxies, and error reporting remain in their existing layers. Cleanup is consumed before invoking it so a throwing cleanup is not retained for reuse.

Regression coverage exercises shared callbacks across nodes and slots, ref replacement, keyed moves, hydration, and independent removal. This change is limited to ordinary background-thread node refs; it does not change main-thread worklet refs, imperative handles, error-boundary routing, or failed-render scheduling.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed callback refs being cleaned up incorrectly when the same callback is used by multiple elements or ref slots.
  * Ref cleanup now remains isolated during updates, replacement, removal, hydration, and keyed list reordering.
  * Improved handling when direct and spread refs share the same callback, preventing one ref from affecting another.
* **Release**
  * Included in a patch release for the React runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->