### PR TITLE
fix(react): type the queries render returns without a queries option

### DIFF
--- a/.changeset/testing-library-render-default-queries.md
+++ b/.changeset/testing-library-render-default-queries.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react": patch
+---
+
+Fix the queries returned by `render` from `@lynx-js/react/testing-library` being typed as a union of every query's result when no `queries` option is passed, which made `fireEvent.tap(await findByText(...))` fail to type-check.

--- a/packages/react/testing-library/etc/react-lynx-testing-library.api.md
+++ b/packages/react/testing-library/etc/react-lynx-testing-library.api.md
@@ -21,7 +21,7 @@ export { ElementTree }
 export { LynxTestingEnv }
 
 // @public
-export function render<Q extends Queries>(
+export function render<Q extends Queries = typeof queries>(
 ui: ComponentChild,
 options?: RenderOptions<Q>,
 ): RenderResult<Q>;

--- a/packages/react/testing-library/types/entry.d.ts
+++ b/packages/react/testing-library/types/entry.d.ts
@@ -178,7 +178,7 @@ export type RenderResult<Q extends Queries = typeof queries> = {
  *
  * @public
  */
-export function render<Q extends Queries>(
+export function render<Q extends Queries = typeof queries>(
   ui: React.ReactNode,
   options?: RenderOptions<Q>,
 ): RenderResult<Q>;

--- a/packages/testing-library/examples/basic/src/__tests__/types/render.test-d.tsx
+++ b/packages/testing-library/examples/basic/src/__tests__/types/render.test-d.tsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom';
-import { expect, test } from 'vitest';
-import { render } from '@lynx-js/react/testing-library';
+import { expect, expectTypeOf, test } from 'vitest';
+import { fireEvent, render } from '@lynx-js/react/testing-library';
 
 test('render basic component', () => {
   const Comp = () => {
@@ -30,4 +30,12 @@ test('render ReactNode types other than ReactElement', () => {
   ].forEach((node) => {
     render(node);
   });
+});
+
+test('render without options keeps the default query types', async () => {
+  const { findByText } = render(<text>Hello</text>);
+
+  expectTypeOf(findByText).returns.toEqualTypeOf<Promise<HTMLElement>>();
+
+  fireEvent.tap(await findByText('Hello'));
 });


### PR DESCRIPTION
`render<Q extends Queries>` from `@lynx-js/react/testing-library` had no default, so when `queries` is not passed `Q` falls back to its constraint and every bound query is typed as the generic `Query`: `await findByText(...)` becomes `HTMLElement | Error | HTMLElement[] | null`, and passing it to `fireEvent.tap` fails to type-check.

Default `Q` to `typeof queries`, as `RenderOptions` and `RenderResult` already do. The new case in `render.test-d.tsx` fails without the change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed TypeScript typing when using `render` without custom query options.
  * Asynchronous text lookups now return correctly typed elements, allowing follow-up interactions such as tap events to type-check successfully.

* **Tests**
  * Added coverage for default query typing and interactions with asynchronously found elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->