### PR TITLE
fix(web-elements): defer image load events until connected

### DIFF
--- a/.changeset/quiet-images-connect.md
+++ b/.changeset/quiet-images-connect.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/web-elements": patch
+---
+
+Defer `x-image` and `inline-image` load events received while detached until the host connects to the document, preserving the image dimensions at load time.

--- a/.github/web-elements-image-events.instructions.md
+++ b/.github/web-elements-image-events.instructions.md
@@ -1,0 +1,5 @@
+---
+applyTo: "packages/web-platform/web-elements/src/elements/{XImage,XText}/**"
+---
+
+Keep `x-image` and `inline-image` load event forwarding in the shared `ImageEvents` reactive class. Image loads can complete while the host is in a detached fragment, so preserve dimensions when the inner image fires `load` and defer host dispatch until `isConnected` is true. Flush pending events from the reactive class's `connectedCallback`, removing each event before dispatch so reconnecting cannot replay it.

--- a/packages/web-platform/web-elements/src/elements/XImage/ImageEvents.ts
+++ b/packages/web-platform/web-elements/src/elements/XImage/ImageEvents.ts
@@ -15,6 +15,7 @@ export class ImageEvents
 {
   static observedAttributes = [];
   #dom: HTMLElement;
+  #pendingLoadEvents: CustomEvent[] = [];
 
   #getImg = genDomGetter<HTMLImageElement>(() => this.#dom.shadowRoot!, '#img');
 
@@ -26,6 +27,7 @@ export class ImageEvents
       });
     } else {
       this.#getImg().removeEventListener('load', this.#teleportLoadEvent);
+      this.#pendingLoadEvents = [];
     }
   }
 
@@ -41,16 +43,26 @@ export class ImageEvents
   }
 
   #teleportLoadEvent = () => {
-    this.#dom.dispatchEvent(
-      new CustomEvent('load', {
-        ...commonComponentEventSetting,
-        detail: {
-          width: this.#getImg().naturalWidth,
-          height: this.#getImg().naturalHeight,
-        },
-      }),
-    );
+    const event = new CustomEvent('load', {
+      ...commonComponentEventSetting,
+      detail: {
+        width: this.#getImg().naturalWidth,
+        height: this.#getImg().naturalHeight,
+      },
+    });
+    if (this.#dom.isConnected) {
+      this.#dom.dispatchEvent(event);
+    } else {
+      // Preserve the dimensions at load time until the host joins the document.
+      this.#pendingLoadEvents.push(event);
+    }
   };
+
+  connectedCallback() {
+    while (this.#dom.isConnected && this.#pendingLoadEvents.length) {
+      this.#dom.dispatchEvent(this.#pendingLoadEvents.shift()!);
+    }
+  }
 
   #teleportErrorEvent = () => {
     this.#dom.dispatchEvent(

--- a/packages/web-platform/web-elements/src/elements/XText/InlineImage.ts
+++ b/packages/web-platform/web-elements/src/elements/XText/InlineImage.ts
@@ -10,6 +10,7 @@ import {
   registerAttributeHandler,
 } from '../../element-reactive/index.js';
 import { templateInlineImage } from '../htmlTemplates.js';
+import { ImageEvents } from '../XImage/ImageEvents.js';
 
 export class InlineImageAttributes
   implements InstanceType<AttributeReactiveClass<typeof InlineImage>>
@@ -33,7 +34,7 @@ export class InlineImageAttributes
  */
 @Component<typeof InlineImage>(
   'inline-image',
-  [InlineImageAttributes],
+  [InlineImageAttributes, ImageEvents],
   templateInlineImage({}),
 )
 export class InlineImage extends HTMLElement {}

--- a/packages/web-platform/web-elements/tests/web-elements.spec.ts
+++ b/packages/web-platform/web-elements/tests/web-elements.spec.ts
@@ -1711,6 +1711,88 @@ test.describe('web-elements test suite', () => {
     });
   });
   test.describe('x-image', () => {
+    for (const tagName of ['x-image', 'inline-image']) {
+      test(`${tagName} defers detached load events until connected`, async ({ page }) => {
+        await gotoWebComponentPage(page, 'x-image/basic');
+        const result = await page.evaluate(async (tagName) => {
+          const host = document.createElement(tagName);
+          const fragment = document.createDocumentFragment();
+          fragment.append(host);
+          const img = host.shadowRoot!.querySelector<HTMLImageElement>('#img')!;
+          const events: {
+            width: number;
+            height: number;
+            connected: boolean;
+            targetIsHost: boolean;
+          }[] = [];
+          host.addEventListener('load', (event) => {
+            const { width, height } = (event as CustomEvent).detail;
+            events.push({
+              width,
+              height,
+              connected: host.isConnected,
+              targetIsHost: event.target === host,
+            });
+          });
+          const load = async (width: number, height: number) => {
+            const loaded = new Promise<void>((resolve) => {
+              img.addEventListener('load', () => resolve(), { once: true });
+            });
+            host.setAttribute(
+              'src',
+              `data:image/svg+xml,${
+                encodeURIComponent(
+                  `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}"/>`,
+                )
+              }`,
+            );
+            await loaded;
+          };
+
+          await load(8, 6);
+          await load(12, 9);
+          const beforeConnect = events.slice();
+          document.body.append(fragment);
+          const afterConnect = events.slice();
+
+          host.remove();
+          document.body.append(host);
+          const afterReconnect = events.slice();
+
+          await load(16, 10);
+          const afterConnectedLoad = events.slice();
+          host.remove();
+          await load(20, 15);
+          const afterDetachedLoad = events.slice();
+          document.body.append(host);
+
+          return {
+            beforeConnect,
+            afterConnect,
+            afterReconnect,
+            afterConnectedLoad,
+            afterDetachedLoad,
+            afterReattach: events,
+          };
+        }, tagName);
+
+        const expectedEvents = [[8, 6], [12, 9], [16, 10], [20, 15]].map(
+          ([width, height]) => ({
+            width,
+            height,
+            connected: true,
+            targetIsHost: true,
+          }),
+        );
+        expect(result.beforeConnect).toEqual([]);
+        expect(result.afterConnect).toEqual(expectedEvents.slice(0, 2));
+        expect(result.afterReconnect).toEqual(result.afterConnect);
+        expect(result.afterConnectedLoad).toEqual(expectedEvents.slice(0, 3));
+        expect(result.afterDetachedLoad).toEqual(result.afterConnectedLoad);
+        expect(result.afterReattach).toEqual(expectedEvents);
+      });
+    }
+
     test('basic', async ({ page }, { titlePath }) => {
       const title = getTitle(titlePath);
       await gotoWebComponentPage(page, title);


### PR DESCRIPTION
## Summary

An inner image can finish loading while its host is still in a detached fragment. Queue these `load` events with their original image dimensions and dispatch them from the host during `connectedCallback`. Remove each queued event before dispatch so reconnecting does not replay it.

Register the shared `ImageEvents` reactive class for `inline-image` so it uses the same event forwarding as `x-image`. Add regression coverage for multiple detached loads, connected loads, and disconnect/reconnect behavior for both elements.

## Validation

- `pnpm turbo build` — 74 tasks passed.
- `pnpm turbo api-extractor -- --local` — 26 tasks passed.
- Targeted Playwright tests — 12 passed across Chromium, Firefox, and WebKit, including existing image load/error tests.
- Changed files formatted with dprint; `git diff --check` passed.
- `pnpm changeset status --since=origin/main` passed.
- ESLint and Biome exclude this package in the repository configuration.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Image `load` events for `x-image` and `inline-image` are now deferred when elements are created outside the document.
  - Deferred events are delivered when the element is connected, preserving image dimensions and event targets.
  - Image loads occurring while elements are connected continue to dispatch immediately.

- **Tests**
  - Added coverage for detached and connected image-loading scenarios across both supported elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->