### PR TITLE
fix(web): support enableCSSInheritance for text in views

### DIFF
--- a/.changeset/quiet-text-inheritance.md
+++ b/.changeset/quiet-text-inheritance.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/web-core": patch
+---
+
+Support `enableCSSInheritance` for text inside views, including gradient text colors, in client rendering and SSR.

--- a/.github/web-core-css-inheritance.instructions.md
+++ b/.github/web-core-css-inheritance.instructions.md
@@ -1,0 +1,5 @@
+---
+applyTo: "packages/web-platform/web-core/**,packages/web-platform/web-core-e2e/**"
+---
+
+Implement page-level CSS inheritance through the same page-attribute path in client element APIs and SSR. WebEncodePlugin already merges sourceContent.config into pageConfig. Text color inheritance must include `--lynx-text-bg-color`, `background-clip`, and `-webkit-background-clip`: the color transformer represents gradient colors as transparent text plus a background image, and x-text.css resets that image at view-to-text boundaries. Keep inheritance rules below authored text styles in specificity and test both solid and gradient overrides, wrapper elements, and disabled configurations.

--- a/packages/web-platform/web-core-e2e/tests/reactlynx.spec.ts
+++ b/packages/web-platform/web-core-e2e/tests/reactlynx.spec.ts
@@ -95,6 +95,132 @@ const goto = async (
 };
 
 test.describe('reactlynx3 tests', () => {
+  test.describe('CSS inheritance', () => {
+    for (const setting of ['true', 'false', 'default']) {
+      test(`config-css-inheritance-${setting}`, async ({ page }, { title }) => {
+        await goto(page, title);
+        const enabled = setting === 'true';
+        const pageElement = page.locator('[part="page"]');
+        if (enabled) {
+          await expect(pageElement).toHaveAttribute(
+            'lynx-enable-css-inheritance',
+            'true',
+          );
+        } else {
+          await expect(pageElement).not.toHaveAttribute(
+            'lynx-enable-css-inheritance',
+          );
+        }
+        for (const id of ['solid-text', 'wrapped-text', 'nested-text']) {
+          await expect(page.locator(`#${id}`)).toHaveCSS(
+            'color',
+            enabled ? 'rgb(255, 0, 0)' : 'rgb(0, 0, 0)',
+          );
+        }
+        const gradient = page.locator('#gradient-text');
+        await expect(page.locator('#wrapped-gradient')).toHaveCSS(
+          'background-image',
+          enabled ? 'linear-gradient(rgb(255, 0, 0), rgb(0, 0, 255))' : 'none',
+        );
+        if (enabled) {
+          await expect(page.locator('#wrapped-gradient')).toHaveCSS(
+            'background-clip',
+            'text',
+          );
+          await expect(page.locator('#wrapped-text')).toHaveCSS(
+            'text-decoration-line',
+            'underline',
+          );
+        }
+        await expect(gradient).toHaveCSS(
+          'color',
+          enabled ? 'rgba(0, 0, 0, 0)' : 'rgb(0, 0, 0)',
+        );
+        await expect(gradient).toHaveCSS(
+          'background-image',
+          enabled ? 'linear-gradient(rgb(255, 0, 0), rgb(0, 0, 255))' : 'none',
+        );
+        if (enabled) {
+          await expect(gradient).toHaveCSS('background-clip', 'text');
+          await expect(gradient.locator('[part="inner-box"]')).toHaveCSS(
+            'background-clip',
+            'text',
+          );
+          for (
+            const [property, value] of Object.entries({
+              direction: 'rtl',
+              'font-family': 'monospace',
+              'font-size': '24px',
+              'font-style': 'italic',
+              'font-weight': '700',
+              'letter-spacing': '2px',
+              'line-height': '32px',
+              'text-align': 'right',
+              'text-decoration-line': 'underline',
+              'text-shadow': 'rgb(0, 0, 255) 1px 2px 3px',
+            })
+          ) {
+            await expect(page.locator('#solid-text')).toHaveCSS(
+              property,
+              value,
+            );
+          }
+        }
+        await expect(page.locator('#override-text')).toHaveCSS(
+          'color',
+          'rgb(0, 128, 0)',
+        );
+        await expect(page.locator('#override-text')).toHaveCSS(
+          'background-image',
+          'none',
+        );
+        await expect(page.locator('#override-text')).toHaveCSS(
+          'background-clip',
+          'border-box',
+        );
+        await expect(page.locator('#override-text')).toHaveCSS(
+          'font-size',
+          '18px',
+        );
+        await expect(page.locator('#override-text')).toHaveCSS(
+          'text-decoration-line',
+          'none',
+        );
+        await expect(page.locator('#own-gradient')).toHaveCSS(
+          'background-image',
+          'linear-gradient(rgb(255, 0, 0), rgb(0, 0, 255))',
+        );
+        await page.locator('#update').click();
+        if (enabled) {
+          await expect(page.locator('#solid-text')).toHaveCSS(
+            'font-size',
+            '30px',
+          );
+          await expect(page.locator('#solid-text')).toHaveCSS(
+            'color',
+            'rgba(0, 0, 0, 0)',
+          );
+          await expect(page.locator('#solid-text')).toHaveCSS(
+            'background-image',
+            'linear-gradient(rgb(0, 128, 0), rgb(0, 0, 255))',
+          );
+          await expect(page.locator('#solid-text')).toHaveCSS(
+            'background-clip',
+            'text',
+          );
+        } else {
+          await expect(page.locator('#solid-text')).toHaveCSS(
+            'color',
+            'rgb(0, 0, 0)',
+          );
+          await expect(page.locator('#solid-text')).toHaveCSS(
+            'background-image',
+            'none',
+          );
+        }
+      });
+    }
+  });
   test.describe('basic', () => {
     test('basic-pink-rect', async ({ page }, { title }) => {
       await goto(page, title);

--- a/packages/web-platform/web-core-e2e/tests/reactlynx/config-css-inheritance-default/rspeedy.config.ts
+++ b/packages/web-platform/web-core-e2e/tests/reactlynx/config-css-inheritance-default/rspeedy.config.ts
@@ -1,0 +1,18 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import path from 'node:path';
+import { defineConfig } from '@lynx-js/rspeedy';
+import { commonConfig } from '../commonConfig.js';
+
+export default defineConfig({
+  ...commonConfig(),
+  source: {
+    entry: {
+      'config-css-inheritance-default': path.join(
+        import.meta.dirname,
+        '../config-css-inheritance-true/index.jsx',
+      ),
+    },
+  },
+});

--- a/packages/web-platform/web-core-e2e/tests/reactlynx/config-css-inheritance-false/rspeedy.config.ts
+++ b/packages/web-platform/web-core-e2e/tests/reactlynx/config-css-inheritance-false/rspeedy.config.ts
@@ -1,0 +1,18 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import path from 'node:path';
+import { defineConfig } from '@lynx-js/rspeedy';
+import { commonConfig } from '../commonConfig.js';
+
+export default defineConfig({
+  ...commonConfig({ enableCSSInheritance: false }),
+  source: {
+    entry: {
+      'config-css-inheritance-false': path.join(
+        import.meta.dirname,
+        '../config-css-inheritance-true/index.jsx',
+      ),
+    },
+  },
+});

--- a/packages/web-platform/web-core-e2e/tests/reactlynx/config-css-inheritance-true/index.css
+++ b/packages/web-platform/web-core-e2e/tests/reactlynx/config-css-inheritance-true/index.css
@@ -1,0 +1,31 @@
+/* Copyright 2026 The Lynx Authors. All rights reserved.
+ * Licensed under the Apache License Version 2.0 that can be found in the
+ * LICENSE file in the root directory of this source tree. */
+.typography {
+  color: red;
+  direction: rtl;
+  font-family: monospace;
+  font-size: 24px;
+  font-style: italic;
+  font-weight: 700;
+  letter-spacing: 2px;
+  line-height: 32px;
+  text-align: right;
+  text-decoration: underline;
+  text-shadow: 1px 2px 3px blue;
+}
+
+.gradient {
+  color: linear-gradient(red, blue);
+}
+
+.override {
+  color: green;
+  font-size: 18px;
+  text-decoration: none;
+}
+
+.updated {
+  color: linear-gradient(green, blue);
+  font-size: 30px;
+}

--- a/packages/web-platform/web-core-e2e/tests/reactlynx/config-css-inheritance-true/index.jsx
+++ b/packages/web-platform/web-core-e2e/tests/reactlynx/config-css-inheritance-true/index.jsx
@@ -1,0 +1,40 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { root, useState } from '@lynx-js/react';
+import './index.css';
+
+function App() {
+  const [updated, setUpdated] = useState(false);
+  return (
+    <view>
+      <view
+        id='solid-parent'
+        class={updated ? 'typography updated' : 'typography'}
+      >
+        <text id='solid-text'>Inherited text</text>
+        <wrapper>
+          <text id='wrapped-text'>Wrapped text</text>
+        </wrapper>
+        <text id='nested-parent'>
+          <text id='nested-text'>Nested text</text>
+        </text>
+      </view>
+      <view class='gradient'>
+        <text id='gradient-text'>Gradient text</text>
+        <wrapper>
+          <text id='wrapped-gradient'>Wrapped gradient</text>
+        </wrapper>
+        <text id='override-text' class='override'>Explicit solid color</text>
+      </view>
+      <view class='typography'>
+        <text id='own-gradient' class='gradient'>Explicit gradient color</text>
+      </view>
+      <view id='update' bindtap={() => setUpdated(true)}>
+        <text>Update</text>
+      </view>
+    </view>
+  );
+}
+
+root.render(<App />);

--- a/packages/web-platform/web-core-e2e/tests/reactlynx/config-css-inheritance-true/rspeedy.config.ts
+++ b/packages/web-platform/web-core-e2e/tests/reactlynx/config-css-inheritance-true/rspeedy.config.ts
@@ -1,0 +1,18 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import path from 'node:path';
+import { defineConfig } from '@lynx-js/rspeedy';
+import { commonConfig } from '../commonConfig.js';
+
+export default defineConfig({
+  ...commonConfig({ enableCSSInheritance: true }),
+  source: {
+    entry: {
+      'config-css-inheritance-true': path.join(
+        import.meta.dirname,
+        '../config-css-inheritance-true/index.jsx',
+      ),
+    },
+  },
+});

--- a/packages/web-platform/web-core-e2e/tests/ssr-no-js.spec.ts
+++ b/packages/web-platform/web-core-e2e/tests/ssr-no-js.spec.ts
@@ -3,6 +3,48 @@ import { test, expect } from '@lynx-js/playwright-fixtures';
 test.describe('SSR No JS', () => {
   test.use({ javaScriptEnabled: false });
 
+  for (const setting of ['true', 'false', 'default']) {
+    test(`config-css-inheritance-${setting}`, async ({ page }) => {
+      await page.goto(`/ssr?casename=config-css-inheritance-${setting}`, {
+        waitUntil: 'load',
+      });
+      const enabled = setting === 'true';
+      const pageElement = page.locator('[part="page"]');
+      if (enabled) {
+        await expect(pageElement).toHaveAttribute(
+          'lynx-enable-css-inheritance',
+          'true',
+        );
+      } else {
+        await expect(pageElement).not.toHaveAttribute(
+          'lynx-enable-css-inheritance',
+        );
+      }
+      await expect(page.locator('#solid-text')).toHaveCSS(
+        'color',
+        enabled ? 'rgb(255, 0, 0)' : 'rgb(0, 0, 0)',
+      );
+      await expect(page.locator('#gradient-text')).toHaveCSS(
+        'background-image',
+        enabled ? 'linear-gradient(rgb(255, 0, 0), rgb(0, 0, 255))' : 'none',
+      );
+      if (enabled) {
+        await expect(page.locator('#gradient-text')).toHaveCSS(
+          'background-clip',
+          'text',
+        );
+        await expect(page.locator('#wrapped-gradient')).toHaveCSS(
+          'background-clip',
+          'text',
+        );
+      }
+      await expect(page.locator('#override-text')).toHaveCSS(
+        'color',
+        'rgb(0, 128, 0)',
+      );
+    });
+  }
+
   test('basic-pink-rect', async ({ page }) => {
     // 1. Navigate to SSR page
     await page.goto('/ssr?casename=basic-pink-rect', {

--- a/packages/web-platform/web-core/css/in_shadow.css
+++ b/packages/web-platform/web-core/css/in_shadow.css
@@ -9,3 +9,25 @@
 [lynx-default-overflow-visible="true"] x-view {
   overflow: visible;
 }
+
+/* Keep specificity low enough for authored text styles to override inheritance.
+ * Gradient text also needs the background and clipping used by x-text.css. */
+[lynx-enable-css-inheritance="true"]
+  :where(x-view > x-text, x-view > lynx-wrapper, x-view
+    > lynx-wrapper
+    > x-text) {
+  color: inherit;
+  --lynx-text-bg-color: inherit;
+  background-clip: inherit;
+  -webkit-background-clip: inherit;
+  direction: inherit;
+  font-family: inherit;
+  font-size: inherit;
+  font-style: inherit;
+  font-weight: inherit;
+  letter-spacing: inherit;
+  line-height: inherit;
+  text-align: inherit;
+  text-decoration: inherit;
+  text-shadow: inherit;
+}

--- a/packages/web-platform/web-core/tests/element-apis.spec.ts
+++ b/packages/web-platform/web-core/tests/element-apis.spec.ts
@@ -68,6 +68,26 @@ describe('Element APIs', () => {
       true,
     );
   });
+  test.each([true, false, undefined])(
+    'creates a page with CSS inheritance config %s',
+    (enabled) => {
+      const api = createElementAPI(
+        rootDom,
+        mtsBinding,
+        true,
+        true,
+        false,
+        false,
+        false,
+        false,
+        enabled,
+      );
+      const page = api.__CreatePage('0', 0);
+      expect(page.getAttribute('lynx-enable-css-inheritance')).toBe(
+        enabled ? 'true' : null,
+      );
+    },
+  );
   test('#commonEventHandler should filter out -1 uniqueId', () => {
     mtsBinding.wasmContext = Object.assign(mtsBinding.wasmContext || {}, {
       common_event_handler: rstest.fn(),

--- a/packages/web-platform/web-core/tests/server-ssr.spec.ts
+++ b/packages/web-platform/web-core/tests/server-ssr.spec.ts
@@ -55,6 +55,24 @@ const X_ELEMENT_COMPATIBLE_TAGS = [
 ] as const;
 
 describe('Server SSR', () => {
+  it.each([true, false, undefined])(
+    'serializes CSS inheritance config %s',
+    (enableCSSInheritance) => {
+      const binding: SSRBinding = { ssrResult: '' };
+      const { globalThisAPIs: api, wasmContext } = createElementAPI(
+        binding,
+        undefined,
+        '',
+        { ...X_ELEMENT_TEST_CONFIG, enableCSSInheritance },
+      );
+      api.__CreatePage('0', 0);
+      api.__FlushElementTree();
+      expect(binding.ssrResult.includes('lynx-enable-css-inheritance="true"'))
+        .toBe(enableCSSInheritance === true);
+      wasmContext.free();
+    },
+  );
+
   it('should generate html correctly', () => {
     const binding: SSRBinding = {
       ssrResult: '',

--- a/packages/web-platform/web-core/ts/client/mainthread/LynxViewInstance.ts
+++ b/packages/web-platform/web-core/ts/client/mainthread/LynxViewInstance.ts
@@ -170,6 +170,7 @@ export class LynxViewInstance implements AsyncDisposable {
         this.transformVW,
         this.transformVH,
         this.transformREM,
+        config['enableCSSInheritance'] === 'true',
       ),
       createMainThreadGlobalAPIs(
         this,

--- a/packages/web-platform/web-core/ts/client/mainthread/elementAPIs/createElementAPI.ts
+++ b/packages/web-platform/web-core/ts/client/mainthread/elementAPIs/createElementAPI.ts
@@ -8,6 +8,7 @@ import {
   lynxDefaultDisplayLinearAttribute,
   lynxDefaultOverflowVisibleAttribute,
   lynxDisposedAttribute,
+  lynxEnableCSSInheritanceAttribute,
   lynxEntryNameAttribute,
   uniqueIdSymbol,
 } from '../../../constants.js';
@@ -85,6 +86,7 @@ export function createElementAPI(
   transform_vw: boolean,
   transform_vh: boolean,
   transform_rem: boolean,
+  config_enable_css_inheritance = false,
 ): ElementPAPIs {
   let wasmContext = new MainThreadWasmContext(
     rootDom,
@@ -306,6 +308,9 @@ export function createElementAPI(
         dom.setAttribute(lynxDefaultDisplayLinearAttribute, 'false');
       }
       dom.setAttribute('part', 'page');
+      if (config_enable_css_inheritance) {
+        dom.setAttribute(lynxEnableCSSInheritanceAttribute, 'true');
+      }
       page = dom;
       return dom;
     },

--- a/packages/web-platform/web-core/ts/constants.ts
+++ b/packages/web-platform/web-core/ts/constants.ts
@@ -18,6 +18,9 @@ export const lynxPartIdAttribute = /*#__PURE__*/ 'dirtyID' as const;
 export const lynxDefaultDisplayLinearAttribute = /*#__PURE__*/
   'lynx-default-display-linear' as const;
 
+export const lynxEnableCSSInheritanceAttribute = /*#__PURE__*/
+  'lynx-enable-css-inheritance' as const;
+
 export const lynxDefaultOverflowVisibleAttribute /*#__PURE__*/ =
   'lynx-default-overflow-visible' as const;
 

--- a/packages/web-platform/web-core/ts/server/deploy.ts
+++ b/packages/web-platform/web-core/ts/server/deploy.ts
@@ -32,6 +32,7 @@ export function executeTemplate(
     viewAttributes ?? '',
     {
       enableCSSSelector: config['enableCSSSelector'] === 'true',
+      enableCSSInheritance: config['enableCSSInheritance'] === 'true',
       defaultOverflowVisible: config['defaultOverflowVisible'] === 'true',
       defaultDisplayLinear: config['defaultDisplayLinear'] !== 'false', // Default to true if not present or 'true'
       transformVW: transformVW,

--- a/packages/web-platform/web-core/ts/server/elementAPIs/createElementAPI.ts
+++ b/packages/web-platform/web-core/ts/server/elementAPIs/createElementAPI.ts
@@ -12,6 +12,7 @@ import {
   uniqueIdSymbol,
   lynxDefaultDisplayLinearAttribute,
   lynxDefaultOverflowVisibleAttribute,
+  lynxEnableCSSInheritanceAttribute,
   lynxEntryNameAttribute,
   lynxUniqueIdAttribute,
 } from '../../constants.js';
@@ -103,6 +104,7 @@ export function createElementAPI(
     enableCSSSelector: boolean;
     defaultOverflowVisible: boolean;
     defaultDisplayLinear: boolean;
+    enableCSSInheritance?: boolean;
     transformVW: boolean;
     transformVH: boolean;
     transformREM: boolean;
@@ -390,6 +392,14 @@ export function createElementAPI(
           wasmContext.set_attribute(id, lynxUniqueIdAttribute, id.toString());
         }
         wasmContext.set_attribute(id, 'part', 'page');
+
+        if (config.enableCSSInheritance === true) {
+          wasmContext.set_attribute(
+            id,
+            lynxEnableCSSInheritanceAttribute,
+            'true',
+          );
+        }
 
         if (config.defaultDisplayLinear === false) {
           wasmContext.set_attribute(

--- a/packages/web-platform/web-core/ts/types/PageConfig.ts
+++ b/packages/web-platform/web-core/ts/types/PageConfig.ts
@@ -5,6 +5,7 @@ export interface PageConfig {
   enableCSSSelector: 'true' | 'false';
   enableRemoveCSSScope: 'true' | 'false';
   defaultDisplayLinear: 'true' | 'false';
+  enableCSSInheritance?: 'true' | 'false';
   defaultOverflowVisible: 'true' | 'false';
   enableJSDataProcessor: 'true' | 'false';
   isLazy: 'true' | 'false';


### PR DESCRIPTION
When `enableCSSInheritance: true` is configured, text inside a view now inherits its typography in both client rendering and SSR. Previously, Web ignored this flag and `x-text` reset inherited colors at the view-to-text boundary.

The runtime sets a page attribute using the same path as `defaultDisplayLinear`. Scoped defaults inherit text properties along with `--lynx-text-bg-color` and background clipping, so gradient text remains visible. Wrapper elements propagate these properties, explicit text styles take precedence, and disabled or omitted configuration preserves existing behavior.

Validation:
- `pnpm turbo build` and `pnpm turbo api-extractor -- --local` passed.
- 138 client element API and SSR unit tests passed.
- 18 Playwright cases passed across Chromium, Firefox, and WebKit, including SSR with JavaScript disabled. Cases cover enabled/disabled/default settings, gradients, wrappers, explicit overrides, and parent style updates.
- Formatting and production TypeScript ESLint checks passed. The repository-wide Biome check reports errors in generated `examples/react-debug-metadata/dist-consumer/.rsbuild` files.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional CSS inheritance for text within views, including typography properties and gradient colors.
  * Supported the setting in both client-rendered pages and server-rendered HTML.
  * Explicit text styles continue to override inherited styles.

* **Bug Fixes**
  * CSS inheritance configuration is now correctly reflected on generated pages.

* **Tests**
  * Added coverage for enabled, disabled, and default configurations, including dynamic updates and no-JavaScript rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->