### PR TITLE
fix(create-lynx-library): align public module types with runtime exports

### DIFF
--- a/.changeset/fresh-module-types.md
+++ b/.changeset/fresh-module-types.md
@@ -1,0 +1,7 @@
+---
+"create-lynx-library": patch
+---
+
+Export generated module objects from the public type entry to match the runtime
+entry. Keep annotated class declarations as codegen inputs, not consumer-facing
+constructors, for both platform and N-API native modules.

--- a/.github/autolink-library.instructions.md
+++ b/.github/autolink-library.instructions.md
@@ -6,6 +6,11 @@ applyTo:
 
 # Lynx Library Instructions
 
+Keep the public type entry aligned with the runtime entry by re-exporting the
+generated module objects. Annotated class declarations describe codegen inputs,
+not constructible public module APIs. Validate both platform and N-API module
+calls through the package entry after codegen.
+
 Use the current Lynx library package names and marker names when creating or
 updating Lynx libraries.
 

--- a/packages/lynx/create-lynx-library/src/index.ts
+++ b/packages/lynx/create-lynx-library/src/index.ts
@@ -827,11 +827,15 @@ function typesIndex(context: TemplateContext): string {
   const exportLines: string[] = [];
 
   if (context.features.has('native-module')) {
-    exportLines.push(`export * from './platform-native-module';`);
+    exportLines.push(
+      `export { ${context.moduleName} } from '../generated/${context.moduleName}';`,
+    );
   }
 
   if (hasNapiNativeModule(context)) {
-    exportLines.push(`export * from './napi-native-module';`);
+    exportLines.push(
+      `export { ${context.napiModuleName} } from '../generated/${context.napiModuleName}';`,
+    );
   }
 
   if (exportLines.length === 0) {

--- a/packages/lynx/create-lynx-library/test/create.test.ts
+++ b/packages/lynx/create-lynx-library/test/create.test.ts
@@ -3,6 +3,7 @@
 // LICENSE file in the root directory of this source tree.
 import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
+import { createRequire } from 'node:module';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -332,7 +333,7 @@ describe('create-lynx-library', () => {
       's.platform = :ios, \'10.0\'',
     );
     expect(read(dir, 'types/index.d.ts')).toContain(
-      'export * from \'./platform-native-module\';',
+      'export { ButtonModule } from \'../generated/ButtonModule\';',
     );
     expect(read(dir, 'types/platform-native-module.d.ts')).toContain(
       '/** @lynxmodule */',
@@ -717,6 +718,38 @@ describe('create-lynx-library', () => {
       stdio: 'pipe',
     });
 
+    fs.writeFileSync(
+      path.join(dir, 'consumer.ts'),
+      `
+import { StorageModule, StorageModuleNapi } from '@example/dual-native-modules';
+StorageModule.setValue('key', 'value');
+const value: string | null = StorageModule.getValue('key');
+StorageModule.clear();
+StorageModuleNapi.setValue('key', 'value');
+const napiValue: string | null = StorageModuleNapi.getValue('key');
+StorageModuleNapi.clear();
+// @ts-expect-error Modules are objects, not constructors.
+new StorageModule();
+// @ts-expect-error Values must be strings.
+StorageModuleNapi.setValue('key', 123);
+`,
+    );
+    const tsc = createRequire(import.meta.url).resolve('typescript/bin/tsc');
+    execFileSync(process.execPath, [
+      tsc,
+      '--ignoreConfig',
+      '--noEmit',
+      '--strict',
+      '--skipLibCheck',
+      '--target',
+      'ES2022',
+      '--module',
+      'preserve',
+      '--moduleResolution',
+      'bundler',
+      'consumer.ts',
+    ], { cwd: dir, stdio: 'pipe' });
+
     expect(read(dir, 'generated/StorageModule.ts')).not.toContain(
       'setNativeModules(new Proxy',
     );
@@ -760,7 +793,7 @@ describe('create-lynx-library', () => {
       'android/src/main/java/com/example/storage/StorageModule.java',
     );
     expect(read(dir, 'types/index.d.ts')).toContain(
-      'export * from \'./napi-native-module\';',
+      'export { StorageModule } from \'../generated/StorageModule\';',
     );
     expect(read(dir, 'types/napi-native-module.d.ts')).toContain(
       'export declare class StorageModule',


### PR DESCRIPTION
## Summary

Fix the public type entry emitted by create-lynx-library for platform and N-API native modules.

The runtime entry exports a generated module object (Proxy), but the type entry re-exported the annotated class used as codegen input. As a result, documented calls such as `FreshModule.setValue()` failed with TS2339 because TypeScript saw a constructor with instance methods.

Re-export the same generated module objects from both entries. Preserve annotated class declarations for codegen; no native ABI or codegen behavior changes.

Includes a patch changeset for create-lynx-library.

## Validation

- 37 create-lynx-library tests pass.
- Regression test runs real codegen for both module kinds, then checks package-root imports with TypeScript: setValue/getValue/clear work; construction and invalid argument types are rejected.
- Targeted Turbo builds of autolink-codegen and create-lynx-library pass.
- ESLint, dprint, Biome, and diff whitespace checks pass.
- Full repository build was attempted but blocked by missing Cargo on the local machine; no full native/e2e build claim.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected generated library typings so public type exports now align with the modules available at runtime.
  * Improved typing support for platform and N-API native modules, including projects that use both module types.
  * Ensured generated module objects are exposed through the package’s public type entry, while code-generation declarations remain non-constructible implementation inputs.

* **Documentation**
  * Added guidance for keeping public typings synchronized with runtime exports and validating generated module usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->