### PR TITLE
fix(react): clean up callback refs cleared after hydration

### DIFF
--- a/.changeset/snapshot-null-ref-cleanup.md
+++ b/.changeset/snapshot-null-ref-cleanup.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react": patch
+---
+
+Clean up direct callback refs when they are set to `null` or `undefined` after hydration in the Snapshot backend. Call the binding's returned cleanup, or pass `null` to the callback when no cleanup was returned, without repeating cleanup on a later unmount.

--- a/packages/react/runtime/__test__/snapshot/ref.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/ref.test.jsx
@@ -2170,7 +2170,7 @@ describe('applyRef before hydration', () => {
   });
 });
 
-describe.each([false, true])('shared callback ref bindings (hydrated: %s)', (hydrated) => {
+describe.each([false, true])('callback ref bindings (hydrated: %s)', (hydrated) => {
   function applyMainThreadUpdates() {
     const updates = lynx.getNativeApp().callLepusMethod.mock.calls.slice();
     lynx.getNativeApp().callLepusMethod.mockClear();
@@ -2214,6 +2214,53 @@ describe.each([false, true])('shared callback ref bindings (hydrated: %s)', (hyd
     });
     return { callback, active, cleanups };
   }
+
+  it.each([
+    { clearedRef: null, returnsCleanup: false },
+    { clearedRef: undefined, returnsCleanup: false },
+    { clearedRef: null, returnsCleanup: true },
+    { clearedRef: undefined, returnsCleanup: true },
+  ])(
+    'cleans a callback ref set to $clearedRef (returns cleanup: $returnsCleanup)',
+    ({ clearedRef, returnsCleanup }) => {
+      const cleanup = vi.fn();
+      const callback = vi.fn(() => returnsCleanup ? cleanup : undefined);
+
+      function App({ elementRef }) {
+        return <view ref={elementRef} />;
+      }
+
+      mount(() => <App elementRef={callback} />);
+      expect(callback).toHaveBeenCalledTimes(1);
+      const [[node]] = callback.mock.calls;
+      expect(node).toBeInstanceOf(RefProxy);
+      expect(cleanup).not.toHaveBeenCalled();
+
+      update(<App elementRef={clearedRef} />);
+      const detachedCalls = returnsCleanup ? [[node]] : [[node], [null]];
+      expect(callback.mock.calls).toEqual(detachedCalls);
+      expect(cleanup).toHaveBeenCalledTimes(returnsCleanup ? 1 : 0);
+
+      update(<App elementRef={clearedRef} />);
+      expect(callback.mock.calls).toEqual(detachedCalls);
+      expect(cleanup).toHaveBeenCalledTimes(returnsCleanup ? 1 : 0);
+
+      update(<App elementRef={callback} />);
+      const [reboundNode] = callback.mock.calls.at(-1);
+      expect(reboundNode).toBeInstanceOf(RefProxy);
+      expect(callback.mock.calls).toEqual([...detachedCalls, [reboundNode]]);
+      expect(cleanup).toHaveBeenCalledTimes(returnsCleanup ? 1 : 0);
+
+      update(<App elementRef={clearedRef} />);
+      const finalCalls = [...detachedCalls, [reboundNode], ...(returnsCleanup ? [] : [[null]])];
+      expect(callback.mock.calls).toEqual(finalCalls);
+      expect(cleanup).toHaveBeenCalledTimes(returnsCleanup ? 2 : 0);
+
+      update(null);
+      expect(callback.mock.calls).toEqual(finalCalls);
+      expect(cleanup).toHaveBeenCalledTimes(returnsCleanup ? 2 : 0);
+    },
+  );
 
   it('replaces one ref slot without cleaning another slot using the same callback', () => {
     const shared = trackRefBindings();

--- a/packages/react/runtime/src/snapshot/snapshot/backgroundSnapshot.ts
+++ b/packages/react/runtime/src/snapshot/snapshot/backgroundSnapshot.ts
@@ -441,9 +441,9 @@ export class BackgroundSnapshotInstance {
     valueToCommit: unknown;
   } {
     if (!newValue) {
-      // `oldValue` can't be a spread.
-      if (oldValue && typeof oldValue === 'object' && '__ref' in oldValue) {
-        queueRefAttrUpdate(oldValue as Ref, null, this, index);
+      const oldRef = getRefFromValue(oldValue);
+      if (oldRef) {
+        queueRefAttrUpdate(oldRef, null, this, index);
       }
       return { needUpdate: oldValue !== newValue, valueToCommit: newValue };
     }


### PR DESCRIPTION
## Summary

Fix cleanup of direct callback refs that are cleared after hydration in the Snapshot backend.

For example, changing `enabled` from `true` to `false` must detach the existing binding:

```jsx
<view ref={enabled ? attach : null} />
```

The post-hydration empty-value path only recognized object refs, so a callback changed to `null` or `undefined` never queued its cleanup. The old ref was then removed from the stored values, so a later unmount could not recover the missed cleanup.

Use the existing `getRefFromValue` helper to recognize both callback and object refs and queue teardown through the existing binding machinery. A returned cleanup runs instead of `attach(null)`; callbacks without a cleanup receive `null`. Cleanup timing and native patch behavior are unchanged.

Add regression coverage for `null` and `undefined`, with and without returned cleanup, before and after hydration. The cases also cover repeated empty values, rebinding the same slot, and final unmount without duplicate cleanup.

This change is limited to the Snapshot adapter and does not alter Element Template, shared ref queue semantics, or public APIs.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed callback references so they are properly cleaned up when set to `null` or `undefined` after hydration.
  * Prevented duplicate cleanup during later unmounts.
  * Improved handling of reference removal across repeated updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->