### PR TITLE
fix(autolink-codegen): isolate Node-API shim global types

### DIFF
--- a/.changeset/calm-native-globals.md
+++ b/.changeset/calm-native-globals.md
@@ -1,0 +1,6 @@
+---
+"@lynx-js/autolink-codegen": patch
+---
+
+Avoid intersecting the generated Node-API shim's dynamic global access with
+host-specific NativeModules declarations, which may require fields such as bridge.

--- a/.github/autolink-node-api.instructions.md
+++ b/.github/autolink-node-api.instructions.md
@@ -10,3 +10,7 @@ and may otherwise throw `proxy: inconsistent get`.
 
 Keep `lynx.getModuleLoader()` as the standard Node-API loader fallback in
 addition to compatibility loaders exposed on `globalThis`.
+
+Type-check generated module entries with a host ambient NativeModules declaration
+that requires bridge. Internal dynamic global access must not intersect with that
+host type or weaken the consumer's global declaration.

--- a/packages/lynx/autolink-codegen/src/index.ts
+++ b/packages/lynx/autolink-codegen/src/index.ts
@@ -1781,7 +1781,7 @@ declare const lynx: {
 };
 
 function getNativeModules(): Record<string, unknown> | undefined {
-  const globalObject = globalThis as typeof globalThis & {
+  const globalObject = globalThis as unknown as {
     NativeModules?: Record<string, unknown>;
   };
   return typeof NativeModules !== 'undefined'
@@ -1796,7 +1796,7 @@ ${
     NativeModules = nativeModules;
     return;
   }
-  const globalObject = globalThis as typeof globalThis & {
+  const globalObject = globalThis as unknown as {
     NativeModules?: Record<string, unknown>;
   };
   globalObject.NativeModules = nativeModules;

--- a/packages/lynx/create-lynx-library/test/create.test.ts
+++ b/packages/lynx/create-lynx-library/test/create.test.ts
@@ -722,6 +722,18 @@ describe('create-lynx-library', () => {
       path.join(dir, 'consumer.ts'),
       `
 import { StorageModule, StorageModuleNapi } from '@example/dual-native-modules';
+declare global {
+  interface NativeModules {
+    bridge: {
+      call(name: string, params: Record<string, unknown>, cb: (...args: unknown[]) => void): void;
+      on(name: string, cb: (...args: unknown[]) => void): void;
+    };
+  }
+  var NativeModules: NativeModules;
+}
+globalThis.NativeModules.bridge.call('test', {}, () => {});
+// @ts-expect-error The shim must not weaken the host's global type.
+globalThis.NativeModules = {};
 StorageModule.setValue('key', 'value');
 const value: string | null = StorageModule.getValue('key');
 StorageModule.clear();


### PR DESCRIPTION
## Summary
- Fix TS2322 in generated Node-API shims when the host declares NativeModules with required properties such as bridge.
- Use a local structural view of globalThis instead of intersecting with the host ambient type; preserve the consumer global declaration and runtime behavior.
- Extend generated-package consumer regression coverage to include a required host bridge and verify its type is not weakened.
- Add an autolink-codegen patch changeset. Element JSX declarations are out of scope.

## Validation
- Formatting and lint pre-commit checks passed.
- Fresh builds, targeted tests and independent local-tgz consumer acceptance are in progress; results will follow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility with host applications that define a typed `NativeModules` global, including required fields such as `bridge`.
  - Prevented generated native-module integration code from weakening or conflicting with existing global type definitions.
  - Added validation to ensure generated integrations preserve host-provided type safety during TypeScript checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->