### PR TITLE
ci: raise Valgrind's thread limit for the pnpm 12 benchmark runs

### DIFF
--- a/.github/workflows/workflow-bench.yml
+++ b/.github/workflows/workflow-bench.yml
@@ -94,6 +94,13 @@ jobs:
           # dedicated directory so that raw profile can be collected as an
           # artifact below.
           TMPDIR: ${{ runner.temp }}/codspeed-valgrind-tmp
+          # pnpm 12's native binary sizes its rayon pool at 2x the CPU count
+          # and its tokio runtime at the CPU count, which on the larger
+          # physical-exclusive runners exceeds Valgrind's default
+          # --max-threads=500 and makes Valgrind abort before pnpm prints
+          # anything. The codspeed runner does not forward Valgrind flags,
+          # so raise the limit through the variable Valgrind reads itself.
+          VALGRIND_OPTS: --max-threads=4096
         run: |
           export HOME=/root
           . "$HOME/.cargo/env"


### PR DESCRIPTION
Since the pnpm 12 upgrade (#3860), every `benchmark / nodejs-benchmark` job scheduled on the `physical-2` runner fails with `failed to execute the benchmark process, exit code: 1` before pnpm prints anything (58 in a row; `physical-3`/`physical-4` pass). The Valgrind log in the uploaded `codspeed-valgrind-tmp` artifact shows why:

```
valgrind: the 'impossible' happened:
   Max number of threads is too low
```

The aborted process is `pnpm-native`. pnpm 12 sizes its rayon pool at 2 × `available_parallelism` and runs a tokio multi-thread runtime on top, so on the runner with the most cores it passes Valgrind's default `--max-threads=500`. The codspeed runner does not forward Valgrind flags, so this raises the limit through `VALGRIND_OPTS`, which Valgrind reads itself.

Only reproducible when the job lands on `physical-2`, so the benchmark job may need a rerun or two to cover it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Increased the simulation benchmark’s Valgrind thread limit to support larger concurrent workloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->