### PR TITLE
fix(react): discard refs from failed element template renders

### DIFF
--- a/packages/react/runtime/__test__/core/ref.test.ts
+++ b/packages/react/runtime/__test__/core/ref.test.ts
@@ -142,9 +142,14 @@ describe('core/ref ordinary ref semantics', () => {
     });
     const unchangedRef = vi.fn();
     const reportError = stubReportError();
+    const owner = {};
+
+    queue.queue(null, oldRef, owner, 0, 'old-node');
+    queue.flush(token => `proxy:${token}`);
+    calls.length = 0;
 
     queue.queue(unchangedRef, unchangedRef, {}, 0, 'ignored');
-    queue.queue(oldRef, newRef, {}, 0, 'node');
+    queue.queue(oldRef, newRef, owner, 0, 'node');
     expect(queue.hasPending()).toBe(true);
 
     queue.flush(token => `proxy:${token}`);
@@ -213,6 +218,36 @@ describe('core/ref ordinary ref semantics', () => {
     expect(cleanup).toHaveBeenCalledTimes(1);
     expect(discardedRef).not.toHaveBeenCalled();
     expect(ref).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not detach a reentrant attachment when an aborted ref adds a duplicate clear', () => {
+    const queue = new OrdinaryRefEffectQueue<string, string>();
+    const owner = {};
+    const calls: string[] = [];
+    const replacement = vi.fn((value: string | null) => {
+      calls.push(`replacement:${value}`);
+    });
+    const cleanup = vi.fn(() => {
+      calls.push('cleanup');
+      queue.queue(null, replacement, owner, 0, 'replacement');
+      queue.flush(token => token);
+    });
+    const mountedRef = vi.fn(() => cleanup);
+    const abortedRef = vi.fn();
+
+    queue.queue(null, mountedRef, owner, 0, 'mounted');
+    queue.flush(token => token);
+    queue.queue(mountedRef, abortedRef, owner, 0, 'aborted');
+    queue.discardPendingAttachments();
+    queue.queue(abortedRef, null, owner, 0, 'aborted');
+    queue.flush(token => token);
+
+    expect(calls).toEqual(['cleanup', 'replacement:replacement']);
+    expect(abortedRef).not.toHaveBeenCalled();
+    expect(cleanup).toHaveBeenCalledTimes(1);
+    queue.queue(replacement, null, owner, 0, 'replacement');
+    queue.flush(token => token);
+    expect(calls).toEqual(['cleanup', 'replacement:replacement', 'replacement:null']);
   });
 
   it('consumes throwing cleanup before reporting its error', () => {

--- a/packages/react/runtime/__test__/element-template/fixtures/background/ref/failed-render/index.tsx
+++ b/packages/react/runtime/__test__/element-template/fixtures/background/ref/failed-render/index.tsx
@@ -1,0 +1,10 @@
+import type { ReactNode } from 'react';
+
+interface AppProps {
+  hostRef?: unknown;
+  children?: ReactNode;
+}
+
+export function App({ hostRef, children }: AppProps) {
+  return <view ref={hostRef}>{children}</view>;
+}

--- a/packages/react/runtime/__test__/element-template/runtime/background/ref/compiled-fixtures.test.tsx
+++ b/packages/react/runtime/__test__/element-template/runtime/background/ref/compiled-fixtures.test.tsx
@@ -1,6 +1,8 @@
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { createElement, options } from 'preact';
+import type { ReactNode } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
@@ -12,7 +14,8 @@ import {
   resetElementTemplateHydrationListener,
 } from '../../../../../src/element-template/background/hydration-listener.js';
 import { BackgroundElementTemplateInstance } from '../../../../../src/element-template/background/instance.js';
-import { clearRefState } from '../../../../../src/element-template/prop-adapters/ref.js';
+import { Component, Suspense, root, useState } from '../../../../../src/element-template/index.js';
+import { clearRefState, hasPendingRefs } from '../../../../../src/element-template/prop-adapters/ref.js';
 import { ElementTemplateLifecycleConstant } from '../../../../../src/element-template/protocol/lifecycle-constant.js';
 import { ElementTemplateUpdateOps } from '../../../../../src/element-template/protocol/opcodes.js';
 import type { ElementTemplateUpdateCommitContext } from '../../../../../src/element-template/protocol/types.js';
@@ -28,16 +31,22 @@ import {
   renderCompiledFixtureOnMainThread,
 } from '../../../test-utils/debug/compiledThreadRunner.js';
 import { ElementTemplateEnvManager } from '../../../test-utils/debug/envManager.js';
+import { resetPerformanceMocks } from '../../../test-utils/mock/performance.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const DIRECT_REF_FIXTURE = path.resolve(__dirname, '../../../fixtures/background/ref/direct-ref/index.tsx');
+const FAILED_RENDER_FIXTURE = path.resolve(__dirname, '../../../fixtures/background/ref/failed-render/index.tsx');
 const SPREAD_REF_FIXTURE = path.resolve(__dirname, '../../../fixtures/background/ref/spread-ref/index.tsx');
 const MULTI_REF_FIXTURE = path.resolve(__dirname, '../../../fixtures/background/ref/multi-ref/index.tsx');
 const NAMESPACED_REF_FIXTURE = path.resolve(__dirname, '../../../fixtures/background/ref/unsupported-ref/index.tsx');
 
 interface DirectFixtureProps {
   hostRef?: unknown;
+}
+
+interface FailedRenderFixtureProps extends DirectFixtureProps {
+  children?: ReactNode;
 }
 
 interface SpreadFixtureProps {
@@ -141,6 +150,272 @@ describe('Compiled ordinary ref background updates', () => {
     clearRefState();
     envManager.setUseElementTemplate(false);
   });
+
+  it('does not attach refs from an uncommitted render on a later empty commit', async () => {
+    const { backgroundModule } = await loadCompiledFixture<CompiledAppModule<FailedRenderFixtureProps>>(
+      FAILED_RENDER_FIXTURE,
+    );
+    const ref = vi.fn();
+    const error = new Error('failed child render');
+    function ThrowingChild(): never {
+      throw error;
+    }
+
+    expect(() =>
+      renderOnBackground(backgroundModule, {
+        hostRef: ref,
+        children: createElement(ThrowingChild, {}),
+      })
+    ).toThrow(error);
+    // The existing profiler does not close spans for aborted renders.
+    resetPerformanceMocks();
+    expect((__root as BackgroundElementTemplateInstance).firstChild).toBeNull();
+    expect(ref).not.toHaveBeenCalled();
+
+    root.render(null);
+
+    expect(ref).not.toHaveBeenCalled();
+    expect(hasPendingRefs()).toBe(false);
+  });
+
+  it('discards a failed state update without losing a committed ref cleanup', async () => {
+    const { backgroundModule: { App } } = await loadCompiledFixture<CompiledAppModule<FailedRenderFixtureProps>>(
+      FAILED_RENDER_FIXTURE,
+    );
+    const cleanup = vi.fn();
+    const committedRef = vi.fn(() => cleanup);
+    const failedRef = vi.fn();
+    const error = new Error('failed state update');
+    let update!: () => void;
+    function ThrowingChild(): never {
+      throw error;
+    }
+    function UpdatingChild() {
+      const [fail, setFail] = useState(false);
+      update = () => setFail(true);
+      return fail
+        ? createElement(App, { hostRef: failedRef, children: createElement(ThrowingChild, {}) })
+        : null;
+    }
+
+    root.render(createElement(App, { hostRef: committedRef, children: createElement(UpdatingChild, {}) }));
+    expect(committedRef).toHaveBeenCalledTimes(1);
+    const previousDebounce = options.debounceRendering;
+    let rerender!: () => void;
+    options.debounceRendering = callback => {
+      rerender = callback;
+    };
+    try {
+      update();
+      expect(() => rerender()).toThrow(error);
+      resetPerformanceMocks();
+    } finally {
+      options.debounceRendering = previousDebounce;
+    }
+    expect(failedRef).not.toHaveBeenCalled();
+    expect(cleanup).not.toHaveBeenCalled();
+
+    root.render(null);
+
+    expect(failedRef).not.toHaveBeenCalled();
+    expect(cleanup).toHaveBeenCalledTimes(1);
+    expect(committedRef).toHaveBeenCalledTimes(1);
+    expect(hasPendingRefs()).toBe(false);
+  });
+
+  it.each([
+    { hydrated: false, returnsCleanup: false },
+    { hydrated: false, returnsCleanup: true },
+    { hydrated: true, returnsCleanup: false },
+    { hydrated: true, returnsCleanup: true },
+  ])('preserves pending old-ref cleanup after a failed replacement: %j', async ({ hydrated, returnsCleanup }) => {
+    const { backgroundModule, mainModule } = await loadCompiledFixture<CompiledAppModule<FailedRenderFixtureProps>>(
+      FAILED_RENDER_FIXTURE,
+    );
+    const calls: string[] = [];
+    const oldRef = vi.fn((value: unknown) => {
+      calls.push(value === null ? 'old:null' : 'old:attach');
+      return value !== null && returnsCleanup
+        ? () => {
+          calls.push('old:cleanup');
+        }
+        : undefined;
+    });
+    const failedRef = vi.fn();
+    const nextRef = vi.fn((value: unknown) => {
+      calls.push(value === null ? 'next:null' : 'next:attach');
+    });
+    const error = new Error('failed ref replacement');
+    function ThrowingChild(): never {
+      throw error;
+    }
+
+    renderOnBackground(backgroundModule, { hostRef: oldRef });
+    if (hydrated) {
+      hydrateFromMainThread(mainModule, { hostRef: oldRef });
+    }
+    expect(() =>
+      renderOnBackground(backgroundModule, {
+        hostRef: failedRef,
+        children: createElement(ThrowingChild, {}),
+      })
+    ).toThrow(error);
+    resetPerformanceMocks();
+    expect(calls).toEqual(['old:attach']);
+
+    renderOnBackground(backgroundModule, { hostRef: nextRef });
+
+    expect(calls).toEqual(['old:attach', returnsCleanup ? 'old:cleanup' : 'old:null', 'next:attach']);
+    expect(failedRef).not.toHaveBeenCalled();
+    root.render(null);
+    expect(calls).toEqual(['old:attach', returnsCleanup ? 'old:cleanup' : 'old:null', 'next:attach', 'next:null']);
+    expect(hasPendingRefs()).toBe(false);
+  });
+
+  it.each([false, true])('does not detach an aborted state-update ref on unmount (hydrated: %s)', async (hydrated) => {
+    const { backgroundModule, mainModule } = await loadCompiledFixture<CompiledAppModule<FailedRenderFixtureProps>>(
+      FAILED_RENDER_FIXTURE,
+    );
+    const { App } = backgroundModule;
+    const cleanup = vi.fn();
+    const committedRef = vi.fn(() => cleanup);
+    const failedRef = vi.fn();
+    const error = new Error('failed same-host update');
+    let update!: () => void;
+    function ThrowingChild(): never {
+      throw error;
+    }
+    function StatefulApp() {
+      const [fail, setFail] = useState(false);
+      update = () => setFail(true);
+      return createElement(App, {
+        hostRef: fail ? failedRef : committedRef,
+        children: fail ? createElement(ThrowingChild, {}) : null,
+      });
+    }
+
+    root.render(createElement(StatefulApp, {}));
+    if (hydrated) {
+      hydrateFromMainThread(mainModule, { hostRef: committedRef });
+    }
+    const previousDebounce = options.debounceRendering;
+    let rerender!: () => void;
+    options.debounceRendering = callback => {
+      rerender = callback;
+    };
+    try {
+      update();
+      expect(() => rerender()).toThrow(error);
+      resetPerformanceMocks();
+    } finally {
+      options.debounceRendering = previousDebounce;
+    }
+    expect(cleanup).not.toHaveBeenCalled();
+    expect(failedRef).not.toHaveBeenCalled();
+
+    root.render(null);
+
+    expect(cleanup).toHaveBeenCalledTimes(1);
+    expect(committedRef).toHaveBeenCalledTimes(1);
+    expect(failedRef).not.toHaveBeenCalled();
+    expect(hasPendingRefs()).toBe(false);
+  });
+
+  it('keeps successful refs when an error boundary handles a sibling render failure', async () => {
+    const { backgroundModule: { App } } = await loadCompiledFixture<CompiledAppModule<FailedRenderFixtureProps>>(
+      FAILED_RENDER_FIXTURE,
+    );
+    const ref = vi.fn();
+    const fallbackRef = vi.fn();
+    const error = new Error('handled child render');
+    class ErrorBoundary extends Component<{ children?: ReactNode }, { failed: boolean }> {
+      state = { failed: false };
+      static getDerivedStateFromError() {
+        return { failed: true };
+      }
+      render() {
+        return this.state.failed ? createElement(App, { hostRef: fallbackRef }) : this.props.children;
+      }
+    }
+    function ThrowingChild(): never {
+      throw error;
+    }
+
+    root.render(createElement(App, {
+      hostRef: ref,
+      children: createElement(ErrorBoundary, {}, createElement(ThrowingChild, {})),
+    }));
+    expect(ref).toHaveBeenCalledTimes(1);
+    await Promise.resolve();
+    expect(fallbackRef).toHaveBeenCalledTimes(1);
+
+    root.render(null);
+    expect(ref).toHaveBeenLastCalledWith(null);
+    expect(fallbackRef).toHaveBeenLastCalledWith(null);
+  });
+
+  it('keeps successful refs when Suspense handles a pending sibling', async () => {
+    const { backgroundModule: { App } } = await loadCompiledFixture<CompiledAppModule<FailedRenderFixtureProps>>(
+      FAILED_RENDER_FIXTURE,
+    );
+    const ref = vi.fn();
+    const fallbackRef = vi.fn();
+    const pending = new Promise(() => {});
+    function SuspendingChild(): never {
+      throw pending;
+    }
+
+    root.render(createElement(App, {
+      hostRef: ref,
+      children: createElement(Suspense, {
+        fallback: createElement(App, { hostRef: fallbackRef }),
+        children: createElement(SuspendingChild, {}),
+      }),
+    }));
+    expect(ref).toHaveBeenCalledTimes(1);
+    await Promise.resolve();
+    expect(fallbackRef).toHaveBeenCalledTimes(1);
+
+    root.render(null);
+    expect(ref).toHaveBeenLastCalledWith(null);
+    expect(fallbackRef).toHaveBeenLastCalledWith(null);
+  });
+
+  it.each([false, true])(
+    'keeps a reentrant ref attachment after the old batch (same callback: %s)',
+    async (sameCallback) => {
+      const { backgroundModule: { App } } = await loadCompiledFixture<CompiledAppModule<MultiRefAppProps>>(
+        MULTI_REF_FIXTURE,
+      );
+      const calls: string[] = [];
+      const previous = vi.fn((value: unknown) => {
+        calls.push(value === null ? 'previous:null' : 'previous:attach');
+      });
+      const next = sameCallback
+        ? previous
+        : vi.fn((value: unknown) => {
+          calls.push(value === null ? 'next:null' : 'next:attach');
+        });
+      const first = vi.fn(() => () => {
+        calls.push('first:cleanup');
+        root.render(createElement(App, { directRef: null, objectRef: next }));
+      });
+
+      root.render(createElement(App, { directRef: first, objectRef: previous }));
+      root.render(createElement(App, { directRef: null, objectRef: null }));
+
+      const nextName = sameCallback ? 'previous' : 'next';
+      expect(calls).toEqual(['previous:attach', 'first:cleanup', 'previous:null', `${nextName}:attach`]);
+      root.render(null);
+      expect(calls).toEqual([
+        'previous:attach',
+        'first:cleanup',
+        'previous:null',
+        `${nextName}:attach`,
+        `${nextName}:null`,
+      ]);
+    },
+  );
 
   it('hydrates compiled direct refs and applies later ref-only updates without native patches', async () => {
     const { backgroundModule, mainModule } = await loadCompiledFixture<CompiledAppModule<DirectFixtureProps>>(

--- a/packages/react/runtime/__test__/element-template/runtime/template/element-template-attr-slot-plan.test.ts
+++ b/packages/react/runtime/__test__/element-template/runtime/template/element-template-attr-slot-plan.test.ts
@@ -305,8 +305,13 @@ describe('ElementTemplate attr slot plan registry', () => {
     const oldRef = vi.fn();
     const newRef = vi.fn();
     __etAttrPlanMap._et_ref = [0, adaptRefAttrSlot];
+    const instance = { instanceId: -2 };
 
-    queueRefAttributeSlotUpdates('_et_ref', { instanceId: -2 }, [oldRef], [newRef]);
+    queueRefAttributeSlotUpdates('_et_ref', instance, undefined, [oldRef]);
+    flushPendingRefs();
+    oldRef.mockClear();
+
+    queueRefAttributeSlotUpdates('_et_ref', instance, [oldRef], [newRef]);
     flushPendingRefs();
 
     expect(oldRef).toHaveBeenCalledWith(null);
@@ -359,9 +364,15 @@ describe('ElementTemplate attr slot plan registry', () => {
       adaptSpreadAttrSlot,
     ];
 
+    const instance = { instanceId: -7 };
+    queueRefAttributeSlotUpdates('_et_multi_ref', instance, undefined, [directRef, { ref: spreadRef }]);
+    flushPendingRefs();
+    directRef.mockClear();
+    spreadRef.mockClear();
+
     queueRefAttributeSlotUpdates(
       '_et_multi_ref',
-      { instanceId: -7 },
+      instance,
       [directRef, { ref: spreadRef }],
       [directRef, { ref: undefined }],
     );

--- a/packages/react/runtime/__test__/element-template/vitest.config.ts
+++ b/packages/react/runtime/__test__/element-template/vitest.config.ts
@@ -107,6 +107,8 @@ const config: UserConfigExport = defineConfig({
     name: 'react/runtime-et',
     include: ['**/__test__/element-template/**/*.{test,spec}.{js,ts,jsx,tsx}'],
     coverage: {
+      // Both backends run before upload; do not overwrite Snapshot/core coverage.
+      reportsDirectory: './coverage/element-template',
       include: ['src/element-template/**', 'lazy/element-template*.js'],
       exclude: [
         'src/element-template/**/*.d.ts',

--- a/packages/react/runtime/src/core/ref.ts
+++ b/packages/react/runtime/src/core/ref.ts
@@ -78,9 +78,16 @@ export function applyOrdinaryRef<T>(
 export class OrdinaryRefEffectQueue<TProxy, TToken> {
   // A host instance survives hydration's numeric ID remapping. Each ref slot
   // owns its cleanup independently, even when callbacks are shared.
-  private readonly bindings = new WeakMap<object, Map<number, OrdinaryRefBinding>>();
-  private readonly refsToClear: Array<[ref: OrdinaryRef<TProxy>, binding: OrdinaryRefBinding]> = [];
-  private readonly refsToApply: Array<[ref: OrdinaryRef<TProxy>, token: TToken, binding: OrdinaryRefBinding]> = [];
+  private readonly bindings = new WeakMap<object, Map<number, OrdinaryRefEffectBinding<TProxy>>>();
+  private readonly refsToClear: Array<[
+    binding: OrdinaryRefEffectBinding<TProxy>,
+    attachment: OrdinaryRefAttachment<TProxy>,
+  ]> = [];
+  private readonly refsToApply: Array<[
+    ref: OrdinaryRef<TProxy>,
+    token: TToken,
+    binding: OrdinaryRefEffectBinding<TProxy>,
+  ]> = [];
 
   queue(
     oldRef: OrdinaryRef<TProxy> | null | undefined,
@@ -94,14 +101,14 @@ export class OrdinaryRefEffectQueue<TProxy, TToken> {
     }
     let slots = this.bindings.get(owner);
     if (!slots) {
-      this.bindings.set(owner, slots = new Map<number, OrdinaryRefBinding>());
+      this.bindings.set(owner, slots = new Map<number, OrdinaryRefEffectBinding<TProxy>>());
     }
     let binding = slots.get(slot);
     if (!binding) {
       slots.set(slot, binding = {});
     }
-    if (oldRef) {
-      this.refsToClear.push([oldRef, binding]);
+    if (binding.attachment) {
+      this.refsToClear.push([binding, binding.attachment]);
     }
     if (newRef) {
       this.refsToApply.push([newRef, token, binding]);
@@ -116,22 +123,41 @@ export class OrdinaryRefEffectQueue<TProxy, TToken> {
     const refsToClearNow = this.refsToClear.splice(0);
     const refsToApplyNow = this.refsToApply.splice(0);
 
-    for (const [ref, binding] of refsToClearNow) {
-      applyOrdinaryRef(ref, null, binding);
+    for (const [binding, attachment] of refsToClearNow) {
+      // A stale raw ref or duplicate detach must not consume a new attachment
+      // established by a reentrant callback, even when its ref is unchanged.
+      if (binding.attachment === attachment) {
+        binding.attachment = undefined;
+        applyOrdinaryRef(attachment.ref, null, binding);
+      }
     }
     for (const [ref, token, binding] of refsToApplyNow) {
-      applyOrdinaryRef(ref, createValue(token), binding);
+      const value = createValue(token);
+      binding.attachment = { ref };
+      applyOrdinaryRef(ref, value, binding);
     }
   }
 
   clear(): void {
     this.refsToClear.length = 0;
+    this.discardPendingAttachments();
+  }
+
+  discardPendingAttachments(): void {
     this.refsToApply.length = 0;
   }
 
   hasPending(): boolean {
     return this.refsToClear.length > 0 || this.refsToApply.length > 0;
   }
+}
+
+interface OrdinaryRefEffectBinding<T> extends OrdinaryRefBinding {
+  attachment?: OrdinaryRefAttachment<T> | undefined;
+}
+
+interface OrdinaryRefAttachment<T> {
+  readonly ref: OrdinaryRef<T>;
 }
 
 export abstract class SelectorRefProxy<TProxy extends SelectorRefProxy<TProxy>> {

--- a/packages/react/runtime/src/element-template/background/render-scope.ts
+++ b/packages/react/runtime/src/element-template/background/render-scope.ts
@@ -4,8 +4,9 @@
 
 import { options } from 'preact';
 
-import { RENDER_COMPONENT, ROOT } from '../../shared/render-constants.js';
+import { CATCH_ERROR, RENDER_COMPONENT, ROOT } from '../../shared/render-constants.js';
 import { hook, lynxQueueMicrotask } from '../../utils.js';
+import { discardPendingRefAttachments } from '../prop-adapters/ref.js';
 
 let installed = false;
 let elementTemplateRendering = false;
@@ -32,6 +33,20 @@ export function installElementTemplateRenderScopeHooks(): void {
 
   hook(options, RENDER_COMPONENT, onPreactRenderHook);
   hook(options, ROOT, onPreactRenderHook);
+  hook(options, CATCH_ERROR, (old, ...args) => {
+    try {
+      old!(...args);
+    } catch (error) {
+      if (__BACKGROUND__ && elementTemplateRendering) {
+        // Error boundaries and Suspense return through the original hook. Only
+        // an unhandled render must lose its pending attaches; old refs still
+        // need their queued cleanup even if Preact abandons their host VNodes.
+        discardPendingRefAttachments();
+        clearElementTemplateRenderScope();
+      }
+      throw error;
+    }
+  });
 }
 
 function onPreactRenderHook<T extends unknown[]>(old: ((...args: T) => void) | undefined, ...args: T): void {

--- a/packages/react/runtime/src/element-template/prop-adapters/ref.ts
+++ b/packages/react/runtime/src/element-template/prop-adapters/ref.ts
@@ -136,6 +136,10 @@ export function clearPendingRefs(): void {
   refEffectQueue.clear();
 }
 
+export function discardPendingRefAttachments(): void {
+  refEffectQueue.discardPendingAttachments();
+}
+
 export function hasPendingRefs(): boolean {
   return refEffectQueue.hasPending();
 }

--- a/packages/react/runtime/vitest.config.ts
+++ b/packages/react/runtime/vitest.config.ts
@@ -122,6 +122,7 @@ export default defineConfig({
       },
     },
     coverage: {
+      reportsDirectory: './coverage/snapshot',
       exclude: [
         'debug',
         'jsx-runtime',


### PR DESCRIPTION
## Summary

Element Template can queue ordinary ref attachments before a background render finishes. If that render throws without a handling error boundary, a later unrelated commit can attach refs for work that never committed:

```tsx
try {
  root.render(<view ref={ref}><ThrowingChild /></view>);
} catch (error) {
  report(error);
}
root.render(null); // Must not attach the ref from the failed render.
```

Discard pending attachments when the existing Preact error handler rethrows during an ET background render. This covers both root renders and component state updates while preserving handled error-boundary and Suspense commits, queued cleanup for old refs, and the original error.

The shared ordinary-ref queue now targets detach work at the actual attachment of each host/slot, rather than a raw ref value from a failed render. Attachment identity also prevents an old detach batch from clearing a new ref established by a synchronous cleanup render, including when the callback is reused. Existing clear-all behavior and detach-before-attach ordering remain intact.

Keep Snapshot/core and Element Template coverage reports in separate directories so the sequential runtime test runs retain both reports for CI upload. Coverage thresholds and exclusions are unchanged.

This change does not add VNode, host-tree, or native mutation rollback for failed renders.
