### PR TITLE
ci: give each Deploy build leg its own concurrency group

### DIFF
--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -54,7 +54,7 @@ jobs:
   # See: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache
   build-all:
     concurrency:
-      group: ${{ github.workflow }}-build-${{ github.ref }}
+      group: ${{ github.workflow }}-build-${{ matrix.runs-on.name }}-${{ github.ref }}
       cancel-in-progress: false
     strategy:
       fail-fast: false


### PR DESCRIPTION
`build-all`'s Ubuntu and Windows legs shared one concurrency group. When a push lands while the previous Deploy build is still running, both legs compete for the single pending slot and one evicts the other, so the newest commit gets half a build and every `needs: build-all` job (`test-rust`, `coverage*`, `benchmark`, `bundle-analysis`, `website-*`) is skipped. Recent examples: `716d77df9`, `3fd7a2234`.

Keying the group by leg removes that, and lets the two legs run in parallel instead of back to back.

Deploy only runs on push to `main`, so this PR's CI does not exercise it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved deployment workflow concurrency handling so parallel builds on different runners can proceed independently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->