### PR TITLE
fix(react): preserve background component owner stacks

### DIFF
--- a/.changeset/preserve-component-stack-owners.md
+++ b/.changeset/preserve-component-stack-owners.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react": patch
+---
+
+Preserve component owners in development error stacks after scheduled state updates, and enable background component stacks for Element Template.

--- a/packages/react/runtime/__test__/element-template/runtime/background/component-stack.test.tsx
+++ b/packages/react/runtime/__test__/element-template/runtime/background/component-stack.test.tsx
@@ -1,0 +1,76 @@
+import { options } from 'preact';
+import type { ComponentChildren } from 'preact';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { installElementTemplateHydrationListener } from '../../../../src/element-template/background/hydration-listener.js';
+import { isElementTemplateRendering } from '../../../../src/element-template/background/render-scope.js';
+import { injectCalledByNative } from '../../../../src/element-template/native/main-thread-api.js';
+import { ElementTemplateEnvManager } from '../../test-utils/debug/envManager.js';
+
+describe('ElementTemplate background component stack', () => {
+  const envManager = new ElementTemplateEnvManager();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    envManager.resetEnv('background');
+  });
+
+  it('reports component owners for circular attributes in hydrated background updates', async () => {
+    const scheduledRenders: Array<() => void> = [];
+    const previousDebounce = options.debounceRendering;
+    const previousProfile = globalThis.__PROFILE__;
+    const dispatchEvent = vi.spyOn(lynx.getCoreContext(), 'dispatchEvent');
+    options.debounceRendering = callback => scheduledRenders.push(callback);
+    globalThis.__PROFILE__ = false;
+    const { root, useState } = await import('../../../../src/element-template/index.js');
+    const { renderCompiledFixtureOnMainThread } = await import('../../test-utils/debug/compiledThreadRunner.js');
+    let updateValue: (value: Record<string, unknown>) => void;
+
+    function PassThrough({ children }: { children: ComponentChildren }) {
+      return children;
+    }
+
+    function AttributeOwner() {
+      const [value, setValue] = useState<Record<string, unknown>>({ count: 0 });
+      if (__BACKGROUND__) updateValue = setValue;
+      return (
+        <view>
+          <text>prefix</text>
+          <view data-value={value} />
+        </view>
+      );
+    }
+
+    function App() {
+      return (
+        <PassThrough>
+          <AttributeOwner />
+        </PassThrough>
+      );
+    }
+
+    try {
+      installElementTemplateHydrationListener();
+      injectCalledByNative();
+      root.render(<App />);
+      renderCompiledFixtureOnMainThread({ App }, envManager);
+      dispatchEvent.mockClear();
+
+      updateValue!({ count: 1 });
+      scheduledRenders.shift()!();
+      expect(isElementTemplateRendering()).toBe(false);
+      expect(dispatchEvent).toHaveBeenCalled();
+
+      const circular: Record<string, unknown> = {};
+      circular['self'] = circular;
+      updateValue!(circular);
+      expect(() => scheduledRenders.shift()!()).toThrowError(
+        /Converting circular structure to JSON[\s\S]*in AttributeOwner\n  in App\n/,
+      );
+    } finally {
+      options.debounceRendering = previousDebounce;
+      globalThis.__PROFILE__ = previousProfile;
+      dispatchEvent.mockRestore();
+    }
+  });
+});

--- a/packages/react/runtime/__test__/snapshot/spread.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/spread.test.jsx
@@ -3,7 +3,7 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 */
-import { render } from 'preact';
+import { options, render } from 'preact';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useState } from '../../src/index';
@@ -690,7 +690,7 @@ describe('spreadUpdate', () => {
     `);
   });
 
-  it('circular reference', async () => {
+  it.each(['root', 'scheduled'])('circular reference during %s render', async (renderMode) => {
     await import('../../src/lynx');
     let patch;
     let setSpread_;
@@ -723,19 +723,26 @@ describe('spreadUpdate', () => {
     render(<Comp />, scratchBackground);
 
     initGlobalSnapshotPatch();
-    setSpread_(a);
+    const previousDebounce = options.debounceRendering;
+    let flushScheduledRender;
+    options.debounceRendering = callback => {
+      flushScheduledRender = callback;
+    };
+    try {
+      setSpread_(a);
 
-    expect(() => render(<Comp />, scratchBackground)).toThrowErrorMatchingInlineSnapshot(`
-      [TypeError: Converting circular structure to JSON
-          --> starting at object with constructor 'Object'
-          --- property 'a' closes the circle
-
-        in Bar
-        in Comp
-      ]
-    `);
-    patch = takeGlobalSnapshotPatch();
-    expect(patch).toMatchInlineSnapshot(`[]`);
+      expect(() => {
+        if (renderMode === 'scheduled') {
+          flushScheduledRender();
+        } else {
+          render(<Comp />, scratchBackground);
+        }
+      }).toThrowError(/Converting circular structure to JSON[\s\S]*in Bar\n  in Comp\n$/);
+      patch = takeGlobalSnapshotPatch();
+      expect(patch).toEqual([]);
+    } finally {
+      options.debounceRendering = previousDebounce;
+    }
   });
 
   it('should remove __self and __source when spreading props onto element', async function() {

--- a/packages/react/runtime/src/element-template/native/index.ts
+++ b/packages/react/runtime/src/element-template/native/index.ts
@@ -14,6 +14,7 @@ import { runWithForceRootRender } from '../../core/forceRootRender.js';
 import { updateGlobalProps as updateGlobalPropsCore } from '../../core/globalProps.js';
 import { installMainThreadHooks } from '../../core/hooks/mainThreadImpl.js';
 import { updateCardData } from '../../core/lynx-update-data.js';
+import { setupComponentStack } from '../../shared/component-stack.js';
 import { lynxQueueMicrotask } from '../../utils.js';
 import { installElementTemplateCommitHook } from '../background/commit-hook.js';
 import { setupBackgroundElementTemplateDocument } from '../background/document.js';
@@ -64,6 +65,9 @@ function init(): void {
   }
 
   if (__BACKGROUND__) {
+    if (__DEV__) {
+      setupComponentStack();
+    }
     options.requestAnimationFrame = lynxQueueMicrotask;
     console.log('experimental_useElementTemplate:', __USE_ELEMENT_TEMPLATE__);
     setRoot(new BackgroundPageRootInstance());

--- a/packages/react/runtime/src/shared/component-stack.ts
+++ b/packages/react/runtime/src/shared/component-stack.ts
@@ -154,7 +154,11 @@ export function setupComponentStack(): void {
   };
 
   options.vnode = (vnode: PatchedVNode) => {
-    vnode._owner = ownerStack.length > 0 ? ownerStack[ownerStack.length - 1]! : null;
+    // Scheduled component updates clone the vnode before entering its render scope.
+    // Preserve the original owner when Preact invokes this hook for that clone.
+    if (vnode._owner === undefined) {
+      vnode._owner = ownerStack.length > 0 ? ownerStack[ownerStack.length - 1]! : null;
+    }
     if (oldVNode) oldVNode(vnode);
   };
 


### PR DESCRIPTION
Element Template did not install the shared component-stack hooks in its background runtime, so development errors during attribute updates lacked component context. Enable these hooks for development background rendering.

Scheduled `setState` updates also clone a vnode before entering its render scope. Re-running the vnode hook overwrote its captured owner with `null`, losing the ancestor chain in both backends. Preserve existing owners, including explicit `null`, and initialize ownership only for new vnodes. A circular attribute update in a child component can now report both the child and its creating parent, while excluding components that only pass through `children`.

The regression covers a compiled Element Template tree through first-screen hydration, a successful scheduled update, and a circular attribute update. The existing Snapshot case now covers both root-driven and scheduled rendering. Main-thread owner tracking and source locations remain outside this change.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved component ownership details in development error stacks after scheduled state updates.
  - Enabled component stack reporting for Element Template background rendering, including errors caused by circular attribute values.
- **Tests**
  - Added coverage for component ownership in background rendering errors.
  - Expanded circular-reference error tests to include scheduled rendering scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->