### PR TITLE
ci: post codecov patch statuses only on pull requests

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -23,6 +23,7 @@ coverage:
     patch:
       default:
         threshold: "1%"
+        only_pulls: true
 
 ignore:
   - ".github/**"
@@ -60,6 +61,7 @@ component_management:
         target: auto
       - type: patch
         threshold: "1%"
+        only_pulls: true
   individual_components:
     - component_id: react
       name: React


### PR DESCRIPTION
Main commits keep uploading coverage, which pull requests use as their base, but no longer get a `codecov/patch` status.

On `main` that status compares against the nearest ancestor with a report. When a commit's Deploy uploads nothing, its changes get charged to the next commit — e.g. `c25b0ba` (#3898, genui-only) failed with `0.00% of diff hit` on files from #3894.

Validated with `https://codecov.io/validate`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Code coverage checks now apply only to pull requests for the default patch and component management rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->