### PR TITLE
test: run the Element Template suite from the root vitest config

### DIFF
--- a/packages/react/runtime/__test__/element-template/vitest.config.ts
+++ b/packages/react/runtime/__test__/element-template/vitest.config.ts
@@ -5,7 +5,7 @@ import type { Plugin, UserConfigExport } from 'vitest/config';
 import { defineConfig } from 'vitest/config';
 
 const require = createRequire(import.meta.url);
-const elementTemplateRuntimePkg = require.resolve('../../src/element-template/internal.ts');
+const elementTemplateRuntimePkg = require.resolve('../../src/element-template/internal.ts').split(path.sep).join('/');
 
 function transformReactLynxPlugin(): Plugin {
   return {

--- a/packages/react/runtime/__test__/element-template/vitest.config.ts
+++ b/packages/react/runtime/__test__/element-template/vitest.config.ts
@@ -105,6 +105,7 @@ const config: UserConfigExport = defineConfig({
   },
   test: {
     name: 'react/runtime-et',
+    root: path.resolve(__dirname, '../..'),
     include: ['**/__test__/element-template/**/*.{test,spec}.{js,ts,jsx,tsx}'],
     coverage: {
       include: ['src/element-template/**', 'lazy/element-template*.js'],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -71,6 +71,7 @@ export default defineConfig({
       'examples/*/vitest.config.ts',
       'packages/react/*/vitest.config.ts',
       'packages/react/*/vitest.**.config.ts',
+      'packages/react/runtime/__test__/element-template/vitest.config.ts',
       'packages/rspeedy/*/vitest.config.ts',
       'packages/testing-library/*/vitest.config.mts',
       'packages/testing-library/examples/*/vitest.config.ts',


### PR DESCRIPTION
The Element Template suite has its own vitest config and only runs through `@lynx-js/react-runtime`'s `test:et`, which only the PR-only `test-react` job calls. Deploy's `coverage` job runs the root vitest, so `src/element-template/**` and `lazy/element-template*.js` are 0% in main's coverage.

Adds the config to the root `projects`, and pins its `root` to the package so its `include` globs resolve the same from the repo root.

Locally, the suite runs the same 78 files / 823 tests from the root and from the package; from the root, `lazy/element-template*.js` is 100% and `src/element-template/**` 99.96%.

This is the suite's first run on Windows (`test-vitest-windows`). There, `require.resolve` returned a backslash path for the transform's `runtimePkg`, which the transform only recognizes by a `/internal.ts` suffix, so it emitted `.../internal.ts/internal`. The config now passes it with forward slashes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved test configuration for the element-template runtime tests across platforms.
  - Added the test suite to the project’s Vitest test collection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
