### PR TITLE
fix(react-umd): stop publishing intermediate files

### DIFF
--- a/.changeset/react-umd-intermediates.md
+++ b/.changeset/react-umd-intermediates.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react-umd": patch
+---
+
+Stop publishing the intermediate files of the development External Bundle in `dist/.lynx`.

--- a/packages/react-umd/package.json
+++ b/packages/react-umd/package.json
@@ -31,6 +31,7 @@
   "files": [
     "src",
     "dist",
+    "!dist/.lynx",
     "CHANGELOG.md",
     "README.md"
   ],


### PR DESCRIPTION
The development build of the External Bundle keeps its intermediate files under `dist/.lynx`, and `files` published the whole `dist` directory, so `@lynx-js/react-umd@0.126.1` shipped `dist/.lynx/react-dev/*` (`tasm.json`, `debug-metadata.json` and the pre-encode JS). Exclude `dist/.lynx` from the package.

`npm pack --dry-run` now lists no file under `dist/.lynx`.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Development intermediate files are no longer included in published `@lynx-js/react-umd` packages.
- **Chores**
  - Updated package publishing configuration to exclude the `dist/.lynx` directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->