### PR TITLE
fix(rspeedy): write stats.json in chunks

### DIFF
--- a/.changeset/stats-json-stream.md
+++ b/.changeset/stats-json-stream.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/rspeedy": patch
+---
+
+Write `stats.json` in chunks, so that a large project no longer fails with `RangeError: Invalid string length` when `performance.profile` is enabled.

--- a/packages/rspeedy/core/src/plugins/statsJson.plugin.ts
+++ b/packages/rspeedy/core/src/plugins/statsJson.plugin.ts
@@ -1,13 +1,14 @@
 // Copyright 2024 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
-import { mkdir, writeFile } from 'node:fs/promises'
+import { mkdir } from 'node:fs/promises'
 import path from 'node:path'
 
 import type { RsbuildPlugin } from '@rsbuild/core'
 
 import { BUNDLE_STATS_JSON_OPTIONS } from './statsJsonOptions.js'
 import type { Config } from '../config/index.js'
+import { writeJson } from '../utils/write-json.js'
 
 export function pluginStatsJson(config: Config): RsbuildPlugin {
   return {
@@ -24,10 +25,7 @@ export function pluginStatsJson(config: Config): RsbuildPlugin {
 
         const statsPath = path.join(api.context.distPath, 'stats.json')
         await mkdir(path.dirname(statsPath), { recursive: true })
-        await writeFile(
-          statsPath,
-          JSON.stringify(stats.toJson(BUNDLE_STATS_JSON_OPTIONS)),
-        )
+        await writeJson(statsPath, stats.toJson(BUNDLE_STATS_JSON_OPTIONS))
       })
     },
   }

--- a/packages/rspeedy/core/src/utils/write-json.ts
+++ b/packages/rspeedy/core/src/utils/write-json.ts
@@ -1,0 +1,75 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { createWriteStream } from 'node:fs'
+import { Readable } from 'node:stream'
+import { pipeline } from 'node:stream/promises'
+
+const CHUNK_SIZE = 1 << 20
+
+function* serialize(value: unknown, depth: number): Generator<string> {
+  if (
+    depth === 0 || value === null || typeof value !== 'object'
+    || typeof (value as { toJSON?: unknown }).toJSON === 'function'
+  ) {
+    yield JSON.stringify(value) ?? 'null'
+    return
+  }
+
+  if (Array.isArray(value)) {
+    yield '['
+    for (let i = 0; i < value.length; i++) {
+      if (i > 0) {
+        yield ','
+      }
+      yield* serialize(value[i], depth - 1)
+    }
+    yield ']'
+    return
+  }
+
+  yield '{'
+  let first = true
+  for (const [key, item] of Object.entries(value)) {
+    if (
+      item === undefined || typeof item === 'function'
+      || typeof item === 'symbol'
+    ) {
+      continue
+    }
+    yield `${first ? '' : ','}${JSON.stringify(key)}:`
+    first = false
+    yield* serialize(item, depth - 1)
+  }
+  yield '}'
+}
+
+function* buffered(chunks: Iterable<string>): Generator<string> {
+  let buffer = ''
+  for (const chunk of chunks) {
+    buffer += chunk
+    if (buffer.length >= CHUNK_SIZE) {
+      yield buffer
+      buffer = ''
+    }
+  }
+  if (buffer) {
+    yield buffer
+  }
+}
+
+/**
+ * Write `value` as minified JSON, the same text `JSON.stringify` returns,
+ * without ever holding all of it in one string: V8 caps a string at about
+ * 512 MiB, which the stats of a large project exceed.
+ */
+export async function writeJson(
+  filePath: string,
+  value: unknown,
+  depth = 4,
+): Promise<void> {
+  await pipeline(
+    Readable.from(buffered(serialize(value, depth))),
+    createWriteStream(filePath),
+  )
+}

--- a/packages/rspeedy/core/src/utils/write-json.ts
+++ b/packages/rspeedy/core/src/utils/write-json.ts
@@ -7,11 +7,18 @@ import { pipeline } from 'node:stream/promises'
 
 const CHUNK_SIZE = 1 << 20
 
-function* serialize(value: unknown, depth: number): Generator<string> {
+function applyToJSON(value: unknown, key: string): unknown {
   if (
-    depth === 0 || value === null || typeof value !== 'object'
-    || typeof (value as { toJSON?: unknown }).toJSON === 'function'
+    value !== null && typeof value === 'object'
+    && typeof (value as { toJSON?: unknown }).toJSON === 'function'
   ) {
+    return (value as { toJSON: (key: string) => unknown }).toJSON(key)
+  }
+  return value
+}
+
+function* serialize(value: unknown): Generator<string> {
+  if (value === null || typeof value !== 'object') {
     yield JSON.stringify(value) ?? 'null'
     return
   }
@@ -22,7 +29,7 @@ function* serialize(value: unknown, depth: number): Generator<string> {
       if (i > 0) {
         yield ','
       }
-      yield* serialize(value[i], depth - 1)
+      yield* serialize(applyToJSON(value[i], String(i)))
     }
     yield ']'
     return
@@ -30,7 +37,8 @@ function* serialize(value: unknown, depth: number): Generator<string> {
 
   yield '{'
   let first = true
-  for (const [key, item] of Object.entries(value)) {
+  for (const [key, raw] of Object.entries(value)) {
+    const item = applyToJSON(raw, key)
     if (
       item === undefined || typeof item === 'function'
       || typeof item === 'symbol'
@@ -39,7 +47,7 @@ function* serialize(value: unknown, depth: number): Generator<string> {
     }
     yield `${first ? '' : ','}${JSON.stringify(key)}:`
     first = false
-    yield* serialize(item, depth - 1)
+    yield* serialize(item)
   }
   yield '}'
 }
@@ -66,10 +74,9 @@ function* buffered(chunks: Iterable<string>): Generator<string> {
 export async function writeJson(
   filePath: string,
   value: unknown,
-  depth = 4,
 ): Promise<void> {
   await pipeline(
-    Readable.from(buffered(serialize(value, depth))),
+    Readable.from(buffered(serialize(applyToJSON(value, '')))),
     createWriteStream(filePath),
   )
 }

--- a/packages/rspeedy/core/test/utils/write-json.test.ts
+++ b/packages/rspeedy/core/test/utils/write-json.test.ts
@@ -1,0 +1,72 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, test } from '@rstest/core'
+
+import { writeJson } from '../../src/utils/write-json.js'
+
+describe('writeJson', () => {
+  let dir: string
+
+  beforeEach(async () => {
+    dir = await mkdtemp(path.join(tmpdir(), 'rspeedy-write-json-'))
+  })
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true })
+  })
+
+  async function write(value: unknown, depth?: number): Promise<string> {
+    const file = path.join(dir, 'stats.json')
+    await writeJson(file, value, depth)
+    return readFile(file, 'utf-8')
+  }
+
+  test('writes the same text as JSON.stringify', async () => {
+    const value = {
+      version: '1.0.0',
+      count: 0,
+      flag: false,
+      nothing: null,
+      dropped: undefined,
+      method() {
+        return 1
+      },
+      when: new Date(0),
+      children: [
+        {
+          name: 'lynx',
+          modules: [
+            { id: 1, name: './a.js', nested: { deep: [1, [2, [3]]] } },
+            { id: 2, name: 'ünicode "quoted"\n ', skipped: undefined },
+          ],
+          empty: [],
+          emptyObject: {},
+        },
+      ],
+      sparse: [undefined, () => 1, 'x'],
+    }
+
+    for (const depth of [0, 1, 2, 4, 8]) {
+      expect(await write(value, depth)).toBe(JSON.stringify(value))
+    }
+  })
+
+  test('writes a value larger than one chunk', async () => {
+    const value = {
+      children: [{
+        modules: Array.from({ length: 50_000 }, (_, id) => ({
+          id,
+          name: `./src/module-${id}.js`,
+          size: id,
+        })),
+      }],
+    }
+
+    expect(await write(value)).toBe(JSON.stringify(value))
+  })
+})

--- a/packages/rspeedy/core/test/utils/write-json.test.ts
+++ b/packages/rspeedy/core/test/utils/write-json.test.ts
@@ -20,9 +20,9 @@ describe('writeJson', () => {
     await rm(dir, { recursive: true, force: true })
   })
 
-  async function write(value: unknown, depth?: number): Promise<string> {
+  async function write(value: unknown): Promise<string> {
     const file = path.join(dir, 'stats.json')
-    await writeJson(file, value, depth)
+    await writeJson(file, value)
     return readFile(file, 'utf-8')
   }
 
@@ -42,7 +42,7 @@ describe('writeJson', () => {
           name: 'lynx',
           modules: [
             { id: 1, name: './a.js', nested: { deep: [1, [2, [3]]] } },
-            { id: 2, name: 'ünicode "quoted"\n ', skipped: undefined },
+            { id: 2, name: 'ünicode "quoted"\n ', skipped: undefined },
           ],
           empty: [],
           emptyObject: {},
@@ -51,20 +51,32 @@ describe('writeJson', () => {
       sparse: [undefined, () => 1, 'x'],
     }
 
-    for (const depth of [0, 1, 2, 4, 8]) {
-      expect(await write(value, depth)).toBe(JSON.stringify(value))
-    }
+    expect(await write(value)).toBe(JSON.stringify(value))
   })
 
-  test('writes a value larger than one chunk', async () => {
+  test('passes the property name or index to toJSON', async () => {
     const value = {
-      children: [{
-        modules: Array.from({ length: 50_000 }, (_, id) => ({
-          id,
-          name: `./src/module-${id}.js`,
-          size: id,
-        })),
-      }],
+      named: { toJSON: (key: string) => `named:${key}` },
+      list: [{ toJSON: (key: string) => `index:${key}` }],
+      gone: { toJSON: () => undefined },
+    }
+
+    expect(await write(value)).toBe(JSON.stringify(value))
+  })
+
+  test('writes a deeply nested value larger than one chunk', async () => {
+    const value = {
+      a: {
+        b: {
+          c: {
+            modules: Array.from({ length: 50_000 }, (_, id) => ({
+              id,
+              name: `./src/module-${id}.js`,
+              size: id,
+            })),
+          },
+        },
+      },
     }
 
     expect(await write(value)).toBe(JSON.stringify(value))


### PR DESCRIPTION
With `performance.profile` enabled, a large project still fails after #3239:

```
error   RangeError: Invalid string length
    at JSON.stringify (<anonymous>)
    at .../dist/statsJson.plugin~0.js:22:49
```

Its stats exceed V8's maximum string length (~512 MiB) even without `reasons`. `pluginStatsJson` now streams the JSON to `stats.json` instead of building one string. The file is the same text `JSON.stringify` returns.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed failures when generating `stats.json` for large projects with performance profiling enabled.
  * Statistics are now written incrementally, preventing `RangeError: Invalid string length` errors and improving build reliability.

* **Tests**
  * Expanded coverage for nested JSON data, special values, Unicode content, sparse arrays, large files, and key-aware JSON serialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->