### PR TITLE
fix(react): stop recursing into lazy chunks that import each other

### DIFF
--- a/.changeset/defines-lazy-cycle.md
+++ b/.changeset/defines-lazy-cycle.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react-webpack-plugin": patch
+---
+
+Fix `RangeError: Maximum call stack size exceeded` when lazy chunks import each other.

--- a/packages/webpack/react-webpack-plugin/src/DefinesInjection.ts
+++ b/packages/webpack/react-webpack-plugin/src/DefinesInjection.ts
@@ -119,6 +119,7 @@ export function applyDefinesInjection(
         backgroundRoots: Module[],
         mainThreadRoots: Module[],
         inheritedPresent: { snapshot: string[]; worklet: string[] },
+        ancestors: ReadonlySet<string>,
         request: string,
         inject: (request: string) => Promise<void>,
       ): Promise<void> => {
@@ -165,13 +166,14 @@ export function applyDefinesInjection(
           const mainThreadBoundary = mainThread.asyncBoundaries.get(
             resource,
           );
-          if (!mainThreadBoundary) {
+          if (!mainThreadBoundary || ancestors.has(resource)) {
             continue;
           }
           await processScope(
             [backgroundBoundary],
             [mainThreadBoundary],
             present,
+            new Set([...ancestors, resource]),
             `${resource}.__lynx-react-defines.js`,
             async (boundaryRequest) => {
               definesImports.set(
@@ -193,6 +195,7 @@ export function applyDefinesInjection(
             entryRoots(background),
             entryRoots(mainThread),
             { snapshot: [], worklet: [] },
+            new Set(),
             path.join(
               compiler.context,
               `__lynx-react-defines.${mainThread}.js`,

--- a/packages/webpack/react-webpack-plugin/test/cases/main-thread/merge-defines-lazy-cycle/LazyA.jsx
+++ b/packages/webpack/react-webpack-plugin/test/cases/main-thread/merge-defines-lazy-cycle/LazyA.jsx
@@ -1,0 +1,5 @@
+export function LazyA() {
+  return <view />;
+}
+
+export const loadB = () => import('./LazyB.jsx');

--- a/packages/webpack/react-webpack-plugin/test/cases/main-thread/merge-defines-lazy-cycle/LazyB.jsx
+++ b/packages/webpack/react-webpack-plugin/test/cases/main-thread/merge-defines-lazy-cycle/LazyB.jsx
@@ -1,0 +1,5 @@
+export function LazyB() {
+  return <view />;
+}
+
+export const loadA = () => import('./LazyA.jsx');

--- a/packages/webpack/react-webpack-plugin/test/cases/main-thread/merge-defines-lazy-cycle/index.jsx
+++ b/packages/webpack/react-webpack-plugin/test/cases/main-thread/merge-defines-lazy-cycle/index.jsx
@@ -1,0 +1,11 @@
+/// <reference types="vitest/globals" />
+
+import('./LazyA.jsx');
+
+export function App() {
+  return <view />;
+}
+
+it('builds lazy chunks that import each other', () => {
+  expect(App).toBeTypeOf('function');
+});

--- a/packages/webpack/react-webpack-plugin/test/cases/main-thread/merge-defines-lazy-cycle/rspack.config.js
+++ b/packages/webpack/react-webpack-plugin/test/cases/main-thread/merge-defines-lazy-cycle/rspack.config.js
@@ -1,0 +1,12 @@
+import { createConfig } from '../../../create-react-config.js';
+
+/** @type {import('@rspack/core').Configuration} */
+export default {
+  context: import.meta.dirname,
+  ...createConfig(undefined, {
+    entryPairs: [{
+      mainThread: 'main__main-thread',
+      background: 'main__background',
+    }],
+  }),
+};

--- a/packages/webpack/react-webpack-plugin/test/cases/main-thread/merge-defines-lazy-cycle/test.config.cjs
+++ b/packages/webpack/react-webpack-plugin/test/cases/main-thread/merge-defines-lazy-cycle/test.config.cjs
@@ -1,0 +1,1 @@
+module.exports = { bundlePath: ['main__main-thread.js'] };


### PR DESCRIPTION
`processScope` recursed into every async boundary shared by both layers without checking the scopes it was already in, so lazy chunks that import each other overflowed the stack. Skip boundaries that are already on the current path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed a build error that could cause a stack overflow when mutually dependent lazy-loaded chunks imported each other.

- **Tests**
  - Added coverage to verify successful builds for circular lazy-loading scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->